### PR TITLE
ci: add gitleaks secret-gate

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,36 @@
+name: secret-scan
+
+# Blocks secrets from entering the repo. Scans the working tree (--no-git) rather than
+# full history, so it catches new secrets in a PR without flagging the inherited Core
+# test vectors that live in old commits (those paths are also allowlisted in .gitleaks.toml).
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install gitleaks
+        run: |
+          VER=8.18.4
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VER}/gitleaks_${VER}_linux_x64.tar.gz" \
+            | tar -xz gitleaks
+          sudo install gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Scan working tree for secrets
+        run: |
+          gitleaks detect \
+            --no-git \
+            --source . \
+            --config .gitleaks.toml \
+            --redact \
+            --no-banner \
+            --verbose

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -20,8 +20,9 @@ tags = ["soqucoin", "third-party"]
 
 [[rules]]
 id = "soq-rpcpassword"
-description = "soqucoind rpcpassword literal (not a template placeholder)"
-regex = '''(?i)rpcpassword\s*=\s*(?!change_me|__env__|<|\$|password\b)[^\s'"]{8,}'''
+description = "soqucoind rpcpassword literal (placeholders excluded via allowlist.regexes)"
+# RE2 (Go) has no lookahead, so placeholder exclusion lives in allowlist.regexes below.
+regex = '''(?i)rpcpassword\s*=\s*['"]?[^\s'"]{8,}'''
 tags = ["soqucoin", "node"]
 
 [allowlist]
@@ -32,17 +33,28 @@ paths = [
   '''(^|/)src/test/''',
   '''(^|/)src/wallet/test/''',
   '''(^|/)src/qt/test/''',
+  '''(^|/)qa/''',                       # Core's python RPC-test harness (test WIFs/pubkeys)
+  '''(^|/)test_data/''',                # local regtest fixtures
+  '''(^|/)src/qt/locale/.*\.ts$''',     # Qt translations (escaped <PLACEHOLDER> docs)
+  '''(^|/)\.gemini/''',                 # gitignored local-only agent docs (never committed)
   '''(^|/)contrib/''',
   '''(^|/)doc/''',
   '''(^|/)depends/''',
   '''\.example$''',
   '''(^|/)share/''',
+  '''(^|/)scripts/mine_.*genesis.*\.py$''',  # genesis miner embeds the PUBLIC coinbase pubkey
 ]
 regexes = [
-  '''CHANGE_ME''',
+  '''(?i)change_me''',
   '''__ENV__''',
-  '''placeholder''',
+  '''(?i)placeholder''',
+  '''(?i)your_password''',
   '''<[^>]*>''',
+  '''&lt;''',                                  # HTML-escaped placeholder bracket
+  '''\{[A-Za-z_][A-Za-z0-9_.]*\}''',           # f-string / template interpolation, e.g. {RPC_PASS}
+  '''\$\{?[A-Za-z_]''',
+  '''soqucoin\.[a-z]+\.[a-z]''',               # dotted domain-separation labels, not secrets
+  '''(?i)\b(password|yourpassword|secret|example|test|dummy|rpcpass)\b''',
   '''os\.environ''',
   '''process\.env''',
   '''getenv''',

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,49 @@
+title = "Soqucoin secret-gate"
+
+# Inherit gitleaks' default rules (AWS/GCP/Stripe/JWT/SSH/private-keys/etc.)
+[extend]
+useDefault = true
+
+# --- Soqucoin-specific secret shapes (the ones that have actually leaked) ---
+
+[[rules]]
+id = "soq-signer-bearer"
+description = "soq-signer hot-wallet bearer token"
+regex = '''soqsigner-[A-Za-z0-9-]*bearer[A-Za-z0-9-]*'''
+tags = ["soqucoin", "custody"]
+
+[[rules]]
+id = "rpc-provider-key"
+description = "Helius/Alchemy/Infura/QuickNode RPC API key"
+regex = '''(?i)(helius|alchemy|infura|quicknode)[a-z0-9_.-]*["'=: ]+[a-f0-9]{8}-?[a-f0-9]{4}-?[a-f0-9]{4,}'''
+tags = ["soqucoin", "third-party"]
+
+[[rules]]
+id = "soq-rpcpassword"
+description = "soqucoind rpcpassword literal (not a template placeholder)"
+regex = '''(?i)rpcpassword\s*=\s*(?!change_me|__env__|<|\$|password\b)[^\s'"]{8,}'''
+tags = ["soqucoin", "node"]
+
+[allowlist]
+description = "Bitcoin/Dogecoin Core test vectors, docs, and template placeholders (false positives)"
+# Inherited Core code carries hard-coded test keys/WIFs/signatures in its test + doc trees.
+paths = [
+  '''(^|/)test/''',
+  '''(^|/)src/test/''',
+  '''(^|/)src/wallet/test/''',
+  '''(^|/)src/qt/test/''',
+  '''(^|/)contrib/''',
+  '''(^|/)doc/''',
+  '''(^|/)depends/''',
+  '''\.example$''',
+  '''(^|/)share/''',
+]
+regexes = [
+  '''CHANGE_ME''',
+  '''__ENV__''',
+  '''placeholder''',
+  '''<[^>]*>''',
+  '''os\.environ''',
+  '''process\.env''',
+  '''getenv''',
+]


### PR DESCRIPTION
Adds a license-free gitleaks secret-scan (working-tree scan, --no-git) so a secret can never be pushed to the repo. Soqucoin-tuned rules (soq-signer tokens, RPC-provider keys, rpcpassword) + allowlist for the inherited Core test vectors/docs. Reference impl for fan-out to soqtec / *-sdk / soqupool-server / soqucoin-ops. The secret-scan check on this PR is itself the validation that the node tree is clean under the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)