### PR TITLE
fix(test): refresh stale APO 0x42 sighash vector (e24 crossvector)

### DIFF
--- a/src/test/dilithium_keyhash_committed_tests.cpp
+++ b/src/test/dilithium_keyhash_committed_tests.cpp
@@ -430,8 +430,15 @@ BOOST_AUTO_TEST_CASE(committed_sdk_crossvector)
         "20a8fb234f71d54297c08936be4acd1e6d21c5bc0143df1a7e94d251f11717682ab651";
     const std::string EXPECT_SPK =
         "56208a0fa8a6e1cf96081b999ab7323df717ee3d2f57a837428b24405cb5e3ed1be5";
+    // Byte-less CTxOut value (Phase 4 removed nVisibility/nAssetType from output
+    // serialization, which changed hashOutputs and therefore the APO 0x42 sighash).
+    // Confirmed authoritative: the SDK's apoSighash (byte-less serTxOutConsensus, green
+    // against node-dumped vectors + on-chain e2e on v1.3.0) produces this exact digest for
+    // the same tx (version 2, locktime 101, single OP_TRUE output @ 1 COIN). The prior
+    // value b3275466…e8ab55 was the pre-byte-less vector and is stale. Regenerate via the
+    // SDK apoSighash or a live-node SignatureHash dump if the output serialization changes.
     const std::string EXPECT_SH  =
-        "b3275466d41b3e4eefe04653941a45ad5f65a73af35fb23af86c221421e8ab55";
+        "5282e95c98dc98c513076b0a0ab92140d8fceaaa725b9b4510165e52dfc4f0e6";
 
     const std::string gotWs  = HexStr(ws.begin(), ws.end());
     const std::string gotSpk = HexStr(spk.begin(), spk.end());


### PR DESCRIPTION
**Stacked on #4** (base = `fix/3b4-test-link-dup-symbols`) — Linux test CI can only link/run with the 3b4 fix underneath.

Resolves the `committed_sdk_crossvector` failure from bead `e24`. The test's hardcoded `EXPECT_SH` was the **stale pre-byte-less** value (`b32754…`); Phase-4 removed `nVisibility`/`nAssetType` from `CTxOut`, changing `hashOutputs` and thus the APO 0x42 sighash.

**Proven, not blind-greened:** the SDK's `apoSighash` (byte-less, green against node-dumped vectors + on-chain e2e on v1.3.0) produces `5282e95c…` for the exact tx — **byte-identical to the C++ `gotSh`**. C++ == SDK == node. The CI failure log itself reported `gotSh = 5282e95c…`.

Only the sighash assert failed; `EXPECT_WS`/`EXPECT_SPK` passed (script assembly was never in question).

Remaining e24 failures (auxpow-1000 chainparams; keyhash sigop counting = consensus rule change) are consensus-sensitive and tracked separately for Casey's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)