### PR TITLE
fix(test): assert AuxPoW-from-genesis, drop phantom block-1000 window (e24/inu)

### DIFF
--- a/src/test/soqucoin_tests.cpp
+++ b/src/test/soqucoin_tests.cpp
@@ -234,9 +234,19 @@ BOOST_AUTO_TEST_CASE(hardfork_parameters)
     BOOST_CHECK_EQUAL(preAuxpowParams.nPowTargetTimespan, 60);
     BOOST_CHECK_EQUAL(preAuxpowParams.fDigishieldDifficultyCalculation, true);
 
-    // Block 1000: AuxPoW activates (Vanguard Window ends)
+    // AuxPoW is valid from genesis on mainnet — there is NO activation window.
+    // nAuxpowStartHeight=0 (chainparams.cpp CMainParams "AuxPoW from genesis",
+    // DL-MAINNET-DIFFICULTY-TRANSITION); the validation gate rejects an AuxPoW block
+    // only when nHeight < nAuxpowStartHeight, which is never true at 0.
+    BOOST_CHECK_EQUAL(Params().GetConsensus(0).nAuxpowStartHeight, 0);
+
+    // Block 1000: still the single merged DigiShield+AuxPoW tier that began at block 1
+    // (nHeightEffective=1) — NOT a new tier. There is no block-1000 milestone: the prior
+    // "Vanguard Window ends at 1000" assertion was fiction. The only Vanguard Window in
+    // the project is stagenet's solo-first-100-blocks (nAuxpowStartHeight=100); mainnet
+    // launches AuxPoW from genesis with SOQUPOOL hashrate behind it.
     const Consensus::Params& auxpowParams = Params().GetConsensus(1000);
-    BOOST_CHECK_EQUAL(auxpowParams.nHeightEffective, 1000);
+    BOOST_CHECK_EQUAL(auxpowParams.nHeightEffective, 1);
     BOOST_CHECK_EQUAL(auxpowParams.nPowTargetTimespan, 60);
     BOOST_CHECK_EQUAL(auxpowParams.fAllowLegacyBlocks, true);
     BOOST_CHECK_EQUAL(auxpowParams.fDigishieldDifficultyCalculation, true);


### PR DESCRIPTION
## What

`soqucoin_tests/hardfork_parameters` asserted a **phantom mainnet milestone**:

```cpp
// Block 1000: AuxPoW activates (Vanguard Window ends)
BOOST_CHECK_EQUAL(Params().GetConsensus(1000).nHeightEffective, 1000);  // 1 != 1000
```

That milestone **never existed on mainnet.** Bead `inu` records a **June-4 decision: "AuxPoW from block 0. No Vanguard Window."**, and the consensus code already implements it — `chainparams.cpp:274` (`nAuxpowStartHeight = 0`, "AuxPoW from genesis"), enforced at `validation.cpp:4518` (an AuxPoW block is rejected only when `nHeight < nAuxpowStartHeight`, never true at 0).

This test was one artifact the June-4 change missed. It stayed invisible for two weeks because the 3b4 link break (#4) kept `test_soqucoin` from linking on Linux CI — so the assertion never ran. The fix in #4 is what surfaced it (e24 failure set).

The old assertion also **conflated two different fields**: `nHeightEffective` (the consensus param-*tier* mechanism — `1` for the merged DigiShield+AuxPoW tier that begins at block 1) vs `nAuxpowStartHeight` (the actual AuxPoW gate — `0`).

## Fix

Assert the real design — AuxPoW valid from genesis + the merged tier from block 1. **No consensus code touched; test-only.**

## Verification

```
$ src/test/test_soqucoin --run_test=soqucoin_tests/hardfork_parameters
Running 1 test case...
*** No errors detected
```

## Notes
- Stacked on #4 (`fix/3b4-test-link-dup-symbols`) — merge after #4.
- The only real Vanguard Window is **stagenet** (`chainparams.cpp:919`, solo blocks 0-99). Launch security covered by SOQUPOOL's genesis hashrate fleet (3-5 TH/s → 10 → 100 TH/s).
- Side-finding: testnet still carries the un-customized Dogecoin `nAuxpowStartHeight = 158100` → tracked in `soqucoin-build-lnq`.
- e24 status after this: only the `keyhash_opcode_and_flag_constants` consensus item remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)