### PR TITLE
fix(test): name OP_CHECKDILITHIUMKEYHASH + defer sigop counting (e24, Option B step 1)

### DIFF
--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -136,7 +136,7 @@ const char* GetOpName(opcodetype opcode)
     case OP_NOP4                   : return "OP_CHECKTEMPLATEVERIFY";
     case OP_NOP5                   : return "OP_NOP5";
     case OP_NOP6                   : return "OP_NOP6";
-    case OP_NOP7                   : return "OP_NOP7";
+    case OP_NOP7                   : return "OP_CHECKDILITHIUMKEYHASH";
     case OP_NOP8                   : return "OP_NOP8";
     case OP_NOP9                   : return "OP_NOP9";
     case OP_NOP10                  : return "OP_NOP10";

--- a/src/test/dilithium_keyhash_tests.cpp
+++ b/src/test/dilithium_keyhash_tests.cpp
@@ -309,15 +309,28 @@ BOOST_AUTO_TEST_CASE(keyhash_opcode_and_flag_constants)
     BOOST_CHECK_EQUAL(std::string(GetOpName(OP_CHECKDILITHIUMKEYHASH)),
                       std::string("OP_CHECKDILITHIUMKEYHASH"));
 
-    // GetSigOpCount must count OP_CHECKDILITHIUMKEYHASH as 1 sigop
+    // GetSigOpCount — sigop accounting for OP_CHECKDILITHIUMKEYHASH / OP_CHECKSIGFROMSTACK.
+    //
+    // DEFERRED (soqucoin-build-05n). Counting these opcodes as sigops is a consensus
+    // rule change: CScript::GetSigOpCount feeds GetTransactionSigOpCost, checked vs
+    // MAX_BLOCK_SIGOPS_COST (block validity). The legacy counter takes no activation
+    // flags, so making it count them UNCONDITIONALLY would value blocks differently on
+    // upgraded vs non-upgraded nodes (witness-v0 P2WSH path) → chain split. The count
+    // must instead flip atomically with the BIP9 activation of the opcodes
+    // (SCRIPT_VERIFY_DILITHIUM_KEYHASH / SCRIPT_VERIFY_CSFS), implemented in the
+    // flag-aware witness path and shipped bundled with mainnet activation
+    // (Halborn Phase 2, not yet scheduled). Mainnet opcodes are not active yet.
+    //
+    // Until that lands, the legacy counter intentionally does NOT count them. We assert
+    // that current (pre-gated) behavior so this stays an active guard: any change to the
+    // count must consciously confront the gating decision above, not slip in ungated.
     CScript script;
     script << OP_CHECKDILITHIUMKEYHASH;
-    BOOST_CHECK_EQUAL(script.GetSigOpCount(true), 1u);
+    BOOST_CHECK_EQUAL(script.GetSigOpCount(true), 0u);  // TODO(soqucoin-build-05n): -> 1u under gated counting
 
-    // Verify it counts alongside other sig ops
     CScript multiSigOp;
     multiSigOp << OP_CHECKSIG << OP_CHECKDILITHIUMKEYHASH << OP_CHECKSIGFROMSTACK;
-    BOOST_CHECK_EQUAL(multiSigOp.GetSigOpCount(true), 3u);
+    BOOST_CHECK_EQUAL(multiSigOp.GetSigOpCount(true), 1u);  // TODO(soqucoin-build-05n): -> 3u (CHECKSIG+CDKH+CSFS) under gated counting
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## What

Last open e24 failure: `dilithium_keyhash_tests/keyhash_opcode_and_flag_constants`. The one test case bundled **two concerns with very different risk** — this splits them (Casey-approved **Option B**, step 1).

### (1) GetOpName — cosmetic, done now
`OP_NOP7` is allocated to `OP_CHECKDILITHIUMKEYHASH`. `GetOpName` now returns the real name — exactly the existing precedent for `OP_NOP4` → `"OP_CHECKTEMPLATEVERIFY"`. Not in any validation path; nothing string-depends on `"OP_NOP7"`.

### (2) GetSigOpCount — consensus, **deferred** (`soqucoin-build-05n`)
Counting `OP_CHECKDILITHIUMKEYHASH` / `OP_CHECKSIGFROMSTACK` as sigops feeds `GetTransactionSigOpCost` → `MAX_BLOCK_SIGOPS_COST` = **block validity**. `CScript::GetSigOpCount` is **unconditional** (no activation flag), so making it count them now would value blocks differently on upgraded vs non-upgraded nodes (witness-v0 P2WSH path) → **chain split**.

The count must instead flip **atomically with the BIP9 activation** of the opcodes (flag-aware witness path), shipped bundled with mainnet activation (**Halborn Phase 2, not yet scheduled**). Mainnet opcodes aren't active yet, so there's no schedule pressure to take the risk early.

Until then the two asserts **guard current pre-gated behavior** (`0`/`1`) with `TODO → 1`/`3`, so the counter can't silently change without confronting the gating decision.

## Risk
**No consensus code changed.** Test + one cosmetic `GetOpName` string only.

## Verification
```
keyhash_opcode_and_flag_constants  -> No errors detected
dilithium_keyhash_tests (8 cases)  -> No errors detected
script_tests (12 cases)            -> No errors detected   (GetOpName rename, no regressions)
```

## Tracking
- `soqucoin-build-05n` — the gated sigop-counting implementation (Option B step 2, with activation).
- `soqucoin-build-b9a` — `CountWitnessSigOps` comment wrongly claims these are already counted; live stagenet under-count.

## Stack
Stacked on #4 (`fix/3b4-test-link-dup-symbols`), independent of #6 (different files). With #5 (crossvector, merged) + #6 (auxpow) + this, all 5 e24 CI failures are green/deferred and #4 can go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)