### PR TITLE
ci: install python3-zmq on Linux x86_64 so rpc-tests.py can run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,8 @@ jobs:
             build-essential libtool autotools-dev automake \
             pkg-config bsdmainutils python3 libssl-dev \
             libevent-dev libboost-all-dev libminiupnpc-dev \
-            libzmq3-dev libsqlite3-dev libdb++-dev ccache
+            libzmq3-dev libsqlite3-dev libdb++-dev ccache \
+            python3-zmq
 
       - name: CCache
         uses: actions/cache@v5


### PR DESCRIPTION
## What
`Linux x86_64` failed at the **functional-test** stage:
```
ERROR: "import zmq" failed. Set ENABLE_ZMQ=0 ...
ModuleNotFoundError: No module named 'zmq'
```

This stage (`qa/pull-tester/rpc-tests.py auxpow.py latticefold_basic.py pat_basic.py`) **never ran before** — it was gated behind `make check`, which the e24 fixes just turned green. The build configures `--enable-zmq`, so `rpc-tests.py` does `import zmq` at startup, but the job installed only the C lib `libzmq3-dev`, not the Python binding.

## Fix
Add `python3-zmq` to the apt deps (one line). Consistent with the `--enable-zmq` build; nothing else uses the binding. **CI environment only — no code change.**

## Heads-up (next layer)
This unblocks the *import*. The 3 curated functional tests (`auxpow`, `latticefold_basic`, `pat_basic`) then run for the first time ever — they may surface their own issues (same unmasking pattern as the e24 unit failures). If so, that's a separate triage, not this PR.

## Stack
Into PR #4 branch, alongside #5/#6/#7. Last known blocker for #4 → green → merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)