### PR TITLE
ci: install ltc_scrypt for Linux x86_64 functional tests (auxpow.py)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,11 @@ jobs:
             pkg-config bsdmainutils python3 libssl-dev \
             libevent-dev libboost-all-dev libminiupnpc-dev \
             libzmq3-dev libsqlite3-dev libdb++-dev ccache \
-            python3-zmq
+            python3-zmq curl python3-pip python3-setuptools python3-dev
+          # ltc_scrypt (Litecoin scrypt hasher) — required by qa/rpc-tests auxpow.py.
+          # Use the repo's sanctioned installer: pulls ltc-scrypt v1.0.1 from the
+          # Dogecoin upstream (sha256-checked) and pip-installs it. See qa/README.md.
+          ./qa/pull-tester/install-deps.sh
 
       - name: CCache
         uses: actions/cache@v5


### PR DESCRIPTION
## What
With #8 (python3-zmq) merged, `rpc-tests.py` now imports — and the next functional-test dependency surfaced:
```
auxpow.py -> test_framework/scrypt_auxpow.py: ModuleNotFoundError: No module named 'ltc_scrypt'
```
`ltc_scrypt` is Litecoin's scrypt hasher, needed by the auxpow functional test.

## Fix
Run the repo's **own** installer `qa/pull-tester/install-deps.sh` (pulls `ltc-scrypt v1.0.1` from the Dogecoin upstream, sha256-pinned, `pip install`), and add the deps it needs (`curl python3-pip python3-setuptools python3-dev`). `qa/README.md` lists `python3-zmq` + `ltc_scrypt` as the two test deps — so this **completes the documented set**.

## Verification (local, what's verifiable off-CI)
- Download URL resolves; **sha256 matches the pin** in `install-deps.sh` (`OK`).
- Tarball is a standard `setup.py` + `scryptmodule.c` C extension → builds with `build-essential` + `python3-dev` (both installed).
- CI environment only; **no code change.**

## Heads-up (next layer)
This exhausts the *documented* test-dependency gaps (zmq + ltc_scrypt). After this, the 3 functional tests (`auxpow`, `latticefold_basic`, `pat_basic`) actually execute for the first time — the next run either goes green, or surfaces a real **test-logic** issue (different in kind from these dependency fixes).

## Stack
Into PR #4 branch, after #5/#6/#7/#8. Latest known blocker for #4 → green → merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)