### PR TITLE
consensus: finality horizon (max-reorg-depth) anti-deep-reorg rule

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -112,6 +112,7 @@ testScripts = [
     'auxpow.py',
     'latticefold_basic.py',
     'pat_basic.py',
+    'maxreorgdepth.py',
     'getauxblock.py',
     'wallet.py',
     'wallet-accounts.py',

--- a/qa/rpc-tests/maxreorgdepth.py
+++ b/qa/rpc-tests/maxreorgdepth.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Soqucoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test the finality horizon (Consensus::nMaxReorgDepth).
+#
+# A small merge-mined chain cannot out-hash a rental 51% attack (renting a
+# majority of SOQ's scrypt hashrate is ~free because the same hashrate earns
+# LTC+DOGE -- Analysis [A], 2026-06-22). The finality horizon makes deeply
+# buried history irreversible: a node refuses to reorganize more than
+# nMaxReorgDepth blocks deep, while still accepting shallower reorgs.
+#
+# The horizon is a consensus parameter on real networks; regtest exposes the
+# -maxreorgdepth override so this test can use a small value (10) instead of
+# the mainnet 288.
+#
+
+import time
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+REORG_LIMIT = 10  # -maxreorgdepth passed to every node
+
+class MaxReorgDepthTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 4
+
+    def setup_network(self):
+        # Start every node UNCONNECTED so we can build divergent chains, each
+        # with a small finality horizon. We connect specific pairs by hand.
+        self.is_network_split = False
+        self.nodes = []
+        for i in range(self.num_nodes):
+            self.nodes.append(start_node(i, self.options.tmpdir,
+                                         ["-debug", "-maxreorgdepth=%d" % REORG_LIMIT]))
+
+    def run_test(self):
+        # ---- Scenario 1: a reorg DEEPER than the horizon is REJECTED ----
+        # node0 builds a 20-block chain; node1 builds a competing, LONGER
+        # 25-block chain (both fork at genesis). When connected, node0 would
+        # have to disconnect all 20 of its blocks (depth 20 >= 10) to adopt
+        # node1's longer chain, so it must refuse and hold its own chain.
+        print("Scenario 1: deep reorg must be rejected")
+        self.nodes[0].generate(20)
+        self.nodes[1].generate(25)
+        assert_equal(self.nodes[0].getblockcount(), 20)
+        assert_equal(self.nodes[1].getblockcount(), 25)
+        node0_tip = self.nodes[0].getbestblockhash()
+
+        connect_nodes_bi(self.nodes, 0, 1)
+        time.sleep(5)  # allow the (rejected) reorg attempt to be processed
+
+        # node0 must NOT have adopted node1's longer-but-too-deep chain.
+        assert_equal(self.nodes[0].getblockcount(), 20)
+        assert_equal(self.nodes[0].getbestblockhash(), node0_tip)
+        assert_equal(self.nodes[1].getblockcount(), 25)
+        print("  OK: node0 held its 20-block chain; depth-20 reorg (>= %d) rejected" % REORG_LIMIT)
+
+        # ---- Scenario 2: a reorg SHALLOWER than the horizon is ACCEPTED ----
+        # node2 has only a 4-block chain; node3 has a competing 20-block chain.
+        # node2 must disconnect only its 4 blocks (depth 4 < 10) to adopt the
+        # longer chain, which is allowed -- proving the rule is active (not
+        # globally disabled) yet does not break normal reorgs.
+        print("Scenario 2: shallow reorg must be accepted")
+        self.nodes[2].generate(4)
+        self.nodes[3].generate(20)
+        assert_equal(self.nodes[2].getblockcount(), 4)
+
+        connect_nodes_bi(self.nodes, 2, 3)
+        sync_blocks(self.nodes[2:4])
+
+        assert_equal(self.nodes[2].getblockcount(), 20)
+        assert_equal(self.nodes[2].getbestblockhash(), self.nodes[3].getbestblockhash())
+        print("  OK: node2 adopted the longer chain; depth-4 reorg (< %d) accepted" % REORG_LIMIT)
+
+if __name__ == '__main__':
+    MaxReorgDepthTest().main()

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -157,6 +157,12 @@ public:
         consensus.nPowTargetSpacing = 60;                                                                    // 1 minute
         consensus.fDigishieldDifficultyCalculation = false;
         consensus.nCoinbaseMaturity = 30;
+        // Finality horizon (Analysis [A], 2026-06-22): refuse reorgs deeper than
+        // this. 288 blocks ~= 4.8h at 1-min spacing, >>any natural reorg depth.
+        // TEAM-TUNABLE policy value (smaller = faster finality + smaller
+        // double-spend window; must stay well above the deepest natural reorg).
+        // Propagates into digishieldConsensus via the copy below.
+        consensus.nMaxReorgDepth = 288;
         consensus.fSimplifiedRewards = true; // Fixed 500K SOQ/block from genesis (no Dogecoin random rewards)
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowAllowDigishieldMinDifficultyBlocks = false;
@@ -394,6 +400,7 @@ public:
         consensus.nPowTargetTimespan = 4 * 60 * 60; // pre-digishield: 4 hours
         consensus.fDigishieldDifficultyCalculation = false;
         consensus.nCoinbaseMaturity = 30;
+        consensus.nMaxReorgDepth = 288; // Finality horizon (Analysis [A]); see CMainParams. Propagates into digishieldConsensus.
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowAllowDigishieldMinDifficultyBlocks = false;
         consensus.nSubsidyHalvingInterval = 100000;
@@ -682,6 +689,7 @@ public:
         // Soqucoin parameters
         consensus.fSimplifiedRewards = true;
         consensus.nCoinbaseMaturity = 60; // For easier testability in RPC tests
+        consensus.nMaxReorgDepth = 0;      // Disabled on regtest; functional tests opt in via -maxreorgdepth (see UpdateMaxReorgDepth)
 
         digishieldConsensus = consensus;
         digishieldConsensus.nHeightEffective = 10;
@@ -753,6 +761,12 @@ public:
         consensus.vDeployments[d].nStartTime = nStartTime;
         consensus.vDeployments[d].nTimeout = nTimeout;
     }
+
+    void UpdateMaxReorgDepth(int nMaxReorgDepth)
+    {
+        consensus.nMaxReorgDepth = nMaxReorgDepth;
+        digishieldConsensus.nMaxReorgDepth = nMaxReorgDepth;
+    }
 };
 static CRegTestParams regTestParams;
 
@@ -795,6 +809,7 @@ public:
         consensus.nMinerConfirmationWindow = 2016;
         consensus.fSimplifiedRewards = true;
         consensus.nCoinbaseMaturity = 30;
+        consensus.nMaxReorgDepth = 288; // Finality horizon (Analysis [A]); mainnet rehearsal — match CMainParams.
 
         // Dilithium only from genesis
         consensus.dilithiumOnlyHeight = 0;
@@ -1041,4 +1056,9 @@ void SelectParams(const std::string& network)
 void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout)
 {
     regTestParams.UpdateBIP9Parameters(d, nStartTime, nTimeout);
+}
+
+void UpdateRegtestMaxReorgDepth(int nMaxReorgDepth)
+{
+    regTestParams.UpdateMaxReorgDepth(nMaxReorgDepth);
 }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -128,4 +128,10 @@ void SelectParams(const std::string& chain);
  */
 void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout);
 
+/**
+ * Allows overriding the regtest finality horizon (Consensus::nMaxReorgDepth)
+ * for functional tests. Regtest only.
+ */
+void UpdateRegtestMaxReorgDepth(int nMaxReorgDepth);
+
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -75,6 +75,21 @@ struct Params {
     uint32_t nMinerConfirmationWindow;
     BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS];
     uint32_t nCoinbaseMaturity;
+    /**
+     * Finality horizon (anti-deep-reorg). Reject any block that builds on a
+     * fork more than this many blocks below the active tip, i.e. refuse to
+     * reorganize deeper than nMaxReorgDepth. 0 = disabled.
+     *
+     * Rationale (Analysis [A], 2026-06-22): SOQ is a small merge-mined chain
+     * whose committed scrypt hashrate is a rounding error against the rentable
+     * scrypt market, and renting a 51% majority is ~free because the same
+     * hashrate earns LTC+DOGE. PoW weight therefore cannot secure the chain
+     * (the CoiledCoin failure mode). A bounded reorg horizon converts an
+     * unlimited-time cheap attack into a bounded-window one and makes deeply
+     * buried history final regardless of attacker hashrate. Must exceed any
+     * realistic natural reorg depth (a few blocks) by a wide margin.
+     */
+    int nMaxReorgDepth = 0;
     /** Proof of work parameters */
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1164,6 +1164,20 @@ bool AppInitParameterInteraction()
             }
         }
     }
+
+    if (IsArgSet("-maxreorgdepth")) {
+        // Allow overriding the finality horizon (Consensus::nMaxReorgDepth) for
+        // testing. Regtest only — it is a consensus parameter on real networks.
+        if (!chainparams.MineBlocksOnDemand()) {
+            return InitError("-maxreorgdepth may only be overridden on regtest.");
+        }
+        int64_t nDepth;
+        if (!ParseInt64(GetArg("-maxreorgdepth", ""), &nDepth) || nDepth < 0) {
+            return InitError("Invalid -maxreorgdepth (expected a non-negative integer)");
+        }
+        UpdateRegtestMaxReorgDepth((int)nDepth);
+        LogPrintf("Setting regtest finality horizon (nMaxReorgDepth) to %d\n", (int)nDepth);
+    }
     return true;
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4534,6 +4534,28 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
             return state.DoS(100, error("%s: forked chain older than last checkpoint (height %d)", __func__, nHeight), REJECT_CHECKPOINT, "bad-fork-prior-to-checkpoint");
     }
 
+    // Finality horizon (anti-deep-reorg). A small merge-mined chain cannot
+    // out-hash a rental 51% attack (Analysis [A], 2026-06-22) — renting a
+    // majority of SOQ's scrypt hashrate is ~free because the same hashrate
+    // earns LTC+DOGE. So we refuse to reorganize more than nMaxReorgDepth blocks
+    // deep: a block building on a branch that forks below the horizon can never
+    // join the active chain, making sufficiently buried history final
+    // regardless of attacker hashrate. Skipped during initial sync, when the
+    // node must be free to select the most-work chain while bootstrapping.
+    // No peer ban (DoS 0): near the horizon two honest nodes can briefly
+    // disagree, and banning would partition them. 0 = disabled (e.g. regtest).
+    if (consensusParams.nMaxReorgDepth > 0 && pindexPrev != NULL &&
+        chainActive.Tip() != NULL && !IsInitialBlockDownload()) {
+        const CBlockIndex* pforkPrev = chainActive.FindFork(pindexPrev);
+        if (pforkPrev != NULL) {
+            const int nReorgDepth = chainActive.Height() - pforkPrev->nHeight;
+            if (nReorgDepth >= consensusParams.nMaxReorgDepth)
+                return state.DoS(0, error("%s: block builds on a fork %d blocks deep, beyond the %d-block finality horizon",
+                    __func__, nReorgDepth, consensusParams.nMaxReorgDepth),
+                    REJECT_INVALID, "bad-fork-beyond-finality");
+        }
+    }
+
     // Check timestamp against prev
     if (block.GetBlockTime() <= pindexPrev->GetMedianTimePast())
         return state.Invalid(false, REJECT_INVALID, "time-too-old", "block's timestamp is too early");


### PR DESCRIPTION
Adds a finality horizon (max-reorg-depth) consensus rule rejecting deep reorgs beyond a fixed depth.

Standalone consensus change. The Opt3 B1 control-flow-restore PR is stacked on top of this branch and will retarget to main once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)