### PR TITLE
opt3(B1): bring v6 control-flow-restore consensus change to main (stranded by stacked-PR base)

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -146,11 +146,18 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
     valtype vchPushValue;
     CScriptNum bn(0);
     vector<valtype> altstack;
+    // DL-V6-CONTROLFLOW-RESTORE: OP_IF/NOTIF/ELSE/ENDIF condition stack. Empty unless
+    // SCRIPT_VERIFY_V6_CONTROLFLOW restores real branching; fExec is recomputed from it.
+    std::vector<bool> vfExec;
     set_success(serror);
 
     try {
         while (pc < pend) {
+            // Executing iff no enclosing conditional branch is currently false.
             bool fExec = true;
+            for (size_t i = 0; i < vfExec.size(); ++i) {
+                if (!vfExec[i]) { fExec = false; break; }
+            }
 
             if (!script.GetOp(pc, opcode, vchPushValue))
                 return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
@@ -162,7 +169,40 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
                 //
                 // Execution
                 //
-                if (fExec) {
+                // DL-V6-CONTROLFLOW-RESTORE: conditional opcodes run even inside a
+                // non-taken branch (they manage the vfExec nesting). Gated by the flag;
+                // when clear they fall through to the no-op behaviour below.
+                if ((flags & SCRIPT_VERIFY_V6_CONTROLFLOW) &&
+                    (opcode == OP_IF || opcode == OP_NOTIF || opcode == OP_ELSE || opcode == OP_ENDIF)) {
+                    if (opcode == OP_IF || opcode == OP_NOTIF) {
+                        // <expression> IF/NOTIF [statements] [ELSE [statements]] ENDIF
+                        bool fValue = false;
+                        if (fExec) {
+                            if (stack.size() < 1)
+                                return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
+                            valtype& vch = stacktop(-1);
+                            if (flags & SCRIPT_VERIFY_MINIMALIF) {
+                                if (vch.size() > 1)
+                                    return set_error(serror, SCRIPT_ERR_MINIMALIF);
+                                if (vch.size() == 1 && vch[0] != 1)
+                                    return set_error(serror, SCRIPT_ERR_MINIMALIF);
+                            }
+                            fValue = CastToBool(vch);
+                            if (opcode == OP_NOTIF)
+                                fValue = !fValue;
+                            popstack(stack);
+                        }
+                        vfExec.push_back(fValue);
+                    } else if (opcode == OP_ELSE) {
+                        if (vfExec.empty())
+                            return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
+                        vfExec.back() = !vfExec.back();
+                    } else { // OP_ENDIF
+                        if (vfExec.empty())
+                            return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
+                        vfExec.pop_back();
+                    }
+                } else if (fExec) {
                     if (opcode == OP_RESERVED_BATCHSIG) {
                         // SOQ-I002: OP_RESERVED_BATCHSIG (0xfe) is permanently DEPRECATED.
                         // The old Binius SNARK batch verifier (sangria::VerifyBatch) has been
@@ -800,6 +840,64 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
                                 return set_error(serror, SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS);
                         }
 
+                    } else if ((flags & SCRIPT_VERIFY_V6_CONTROLFLOW) && opcode == OP_DROP) {
+                        // DL-V6-CONTROLFLOW-RESTORE: pop one item (needed after CLTV/CSV).
+                        if (stack.size() < 1)
+                            return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        popstack(stack);
+
+                    } else if ((flags & SCRIPT_VERIFY_V6_CONTROLFLOW) &&
+                               (opcode == OP_EQUAL || opcode == OP_EQUALVERIFY)) {
+                        // DL-V6-CONTROLFLOW-RESTORE: byte-equality (HTLC hashlock).
+                        if (stack.size() < 2)
+                            return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        valtype& vch1 = stacktop(-2);
+                        valtype& vch2 = stacktop(-1);
+                        bool fEqual = (vch1 == vch2);
+                        popstack(stack);
+                        popstack(stack);
+                        stack.push_back(fEqual ? vchTrue : vchFalse);
+                        if (opcode == OP_EQUALVERIFY) {
+                            if (fEqual)
+                                popstack(stack);
+                            else
+                                return set_error(serror, SCRIPT_ERR_EQUALVERIFY);
+                        }
+
+                    } else if ((flags & SCRIPT_VERIFY_V6_CONTROLFLOW) && opcode == OP_SHA256) {
+                        // DL-V6-CONTROLFLOW-RESTORE: SHA256 (HTLC preimage hashlock).
+                        if (stack.size() < 1)
+                            return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        valtype& vch = stacktop(-1);
+                        valtype vchHash(32);
+                        CSHA256().Write(vch.data(), vch.size()).Finalize(vchHash.data());
+                        popstack(stack);
+                        stack.push_back(vchHash);
+
+                    } else if ((flags & SCRIPT_VERIFY_V6_CONTROLFLOW) && opcode == OP_CHECKLOCKTIMEVERIFY) {
+                        // DL-V6-CONTROLFLOW-RESTORE: BIP65 absolute locktime. Arg stays on
+                        // stack (caller DROPs). eLTOO state ratchet + HTLC timeout.
+                        if (stack.size() < 1)
+                            return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        const CScriptNum nLockTime(stacktop(-1), (flags & SCRIPT_VERIFY_MINIMALDATA) != 0, 5);
+                        if (nLockTime < 0)
+                            return set_error(serror, SCRIPT_ERR_NEGATIVE_LOCKTIME);
+                        if (!checker.CheckLockTime(nLockTime))
+                            return set_error(serror, SCRIPT_ERR_UNSATISFIED_LOCKTIME);
+
+                    } else if ((flags & SCRIPT_VERIFY_V6_CONTROLFLOW) && opcode == OP_CHECKSEQUENCEVERIFY) {
+                        // DL-V6-CONTROLFLOW-RESTORE: BIP112 relative locktime. Arg stays on
+                        // stack (caller DROPs). eLTOO settlement-branch CSV delay.
+                        if (stack.size() < 1)
+                            return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+                        const CScriptNum nSequence(stacktop(-1), (flags & SCRIPT_VERIFY_MINIMALDATA) != 0, 5);
+                        if (nSequence < 0)
+                            return set_error(serror, SCRIPT_ERR_NEGATIVE_LOCKTIME);
+                        // If the disable flag is set the operand is a NOP (BIP112 extensibility).
+                        if ((nSequence.getint64() & CTxIn::SEQUENCE_LOCKTIME_DISABLE_FLAG) == 0)
+                            if (!checker.CheckSequence(nSequence))
+                                return set_error(serror, SCRIPT_ERR_UNSATISFIED_LOCKTIME);
+
                     } else if (flags & SCRIPT_VERIFY_SCRIPT_RESTORE) {
                         // =========================================================
                         // SATOSHI SCRIPT RESTORATION (Soqucoin genesis-active)
@@ -976,6 +1074,10 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
                 }
             }
         }
+
+        // DL-V6-CONTROLFLOW-RESTORE: every OP_IF/NOTIF must be closed by an OP_ENDIF.
+        if ((flags & SCRIPT_VERIFY_V6_CONTROLFLOW) && !vfExec.empty())
+            return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
     } catch (...) {
         return set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
     }

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -160,6 +160,14 @@ enum {
     // Enables eLTOO 2-of-2 multisig for L2SOQ Lightning with oversized Dilithium pubkeys.
     SCRIPT_VERIFY_DILITHIUM_KEYHASH = (1U << 25),
 
+    // DL-V6-CONTROLFLOW-RESTORE: execute the bounded standard-opcode set that
+    // trust-minimised Lightning needs but V6's PQ-only EvalScript treats as no-ops:
+    // OP_IF/NOTIF/ELSE/ENDIF, OP_DROP, OP_CHECKLOCKTIMEVERIFY, OP_CHECKSEQUENCEVERIFY,
+    // OP_SHA256, OP_EQUAL/OP_EQUALVERIFY. PQ signatures stay on CSFS/keyhash (the
+    // 520-byte push limit still forbids inline 1312-byte pubkeys → no inline CHECKSIG).
+    // When clear, those opcodes remain no-ops (unchanged behaviour).
+    SCRIPT_VERIFY_V6_CONTROLFLOW = (1U << 26),
+
     // Signature(s) must be empty vector if an CHECK(MULTI)SIG operation failed
     //
     SCRIPT_VERIFY_NULLFAIL = (1U << 14),

--- a/src/test/lightning_script_tests.cpp
+++ b/src/test/lightning_script_tests.cpp
@@ -1648,4 +1648,348 @@ BOOST_AUTO_TEST_CASE(mldsa44_interop_vector_dump)
     BOOST_TEST_MESSAGE("MLDSA44_VECTOR_END");
 }
 
+// ============================================================================
+// V6 eLTOO SUPERSESSION MODEL — does "latest state wins" hold on-chain?
+// ============================================================================
+//
+// Resolves the open question from the P6.3 recon (SOQUSHIELD_OPT3_P6_3_RECON_
+// FINDINGS_2026-06-24.md §5). Two properties were proven SEPARATELY elsewhere
+// but never JOINTLY, and the supersession ratchet was never tested on V6:
+//
+//   PART A (coexistence): APO-derived CSFS message + in-script CTV bind together
+//     in ONE secure update output, and rebinding (APO ignores prevout) is
+//     consensus-compatible.  Expected: honest spend PASS, tampered REJECT,
+//     rebound spend PASS.
+//
+//   PART B (supersession): classic eLTOO ratchets "newer state supersedes older"
+//     via <state+1> OP_CHECKLOCKTIMEVERIFY in the update script.  On V6,
+//     OP_CLTV/OP_CSV are NO-OPs in EvalScript (interpreter.cpp has no CLTV/CSV
+//     opcode handler; they fall through the default case).  So:
+//       B1: an old, fully co-signed update (state 100) REMAINS a valid spend of
+//           the funding output even after the channel advances to state 200 —
+//           nothing on-chain revokes it.  Expected: PASS (= the finding: no
+//           on-chain supersession).
+//       B2: a script that TRIES to gate by state number via OP_CLTV accepts a
+//           tx whose nLockTime is BELOW the committed floor — the ratchet is
+//           silently skipped.  Expected: PASS (= ratchet does not execute).
+//
+// CONCLUSION (documented, not a pass/fail bug): V6's current opcodes support a
+// CTV-committed unilateral close to a FIXED settlement, but NOT a trustless
+// "latest-state-wins" ratchet (eLTOO) or revocation penalty (LN-penalty) — both
+// need in-script branching/comparison that V6 EvalScript treats as no-ops.
+// Trustless multi-update channels therefore require off-chain enforcement
+// (LSP/watchtower co-signing ONLY the latest state) or a new consensus opcode.
+//
+// Run: src/test/test_soqucoin --run_test=lightning_script_tests/eltoo_v6_supersession_model --log_level=message
+BOOST_AUTO_TEST_CASE(eltoo_v6_supersession_model)
+{
+    auto hex = [](const unsigned char* p, size_t n) {
+        static const char* d = "0123456789abcdef";
+        std::string s; s.reserve(n * 2);
+        for (size_t i = 0; i < n; i++) { s += d[p[i] >> 4]; s += d[p[i] & 0xf]; }
+        return s;
+    };
+    auto hexv = [&](const std::vector<unsigned char>& v) { return hex(v.data(), v.size()); };
+
+    // CTV hash (mirrors csfs_ctv_substitution_attack / interpreter.cpp:1718-1843)
+    auto computeCTVHash = [](const CMutableTransaction& tx, unsigned int nIn) -> std::vector<unsigned char> {
+        auto le32 = [](CSHA256& h, uint32_t v){ uint8_t b[4]={(uint8_t)v,(uint8_t)(v>>8),(uint8_t)(v>>16),(uint8_t)(v>>24)}; h.Write(b,4); };
+        auto le64 = [](CSHA256& h, int64_t v){ uint64_t u=(uint64_t)v; uint8_t b[8]={(uint8_t)u,(uint8_t)(u>>8),(uint8_t)(u>>16),(uint8_t)(u>>24),(uint8_t)(u>>32),(uint8_t)(u>>40),(uint8_t)(u>>48),(uint8_t)(u>>56)}; h.Write(b,8); };
+        CSHA256 ss;
+        le32(ss, (uint32_t)tx.nVersion);
+        le32(ss, tx.nLockTime);
+        le32(ss, (uint32_t)tx.vin.size());
+        CSHA256 ssSeq; for (const auto& i : tx.vin) le32(ssSeq, i.nSequence);
+        uint8_t sh[32]; ssSeq.Finalize(sh); ss.Write(sh, 32);
+        le32(ss, (uint32_t)tx.vout.size());
+        CSHA256 ssOut;
+        for (const auto& o : tx.vout) { le64(ssOut, o.nValue); le32(ssOut, (uint32_t)o.scriptPubKey.size()); if (!o.scriptPubKey.empty()) ssOut.Write(o.scriptPubKey.data(), o.scriptPubKey.size()); }
+        uint8_t oh[32]; ssOut.Finalize(oh); ss.Write(oh, 32);
+        le32(ss, nIn);
+        uint8_t r[32]; ss.Finalize(r);
+        return std::vector<unsigned char>(r, r + 32);
+    };
+
+    auto makeV6ScriptPubKey = [](const CScript& witnessScript) -> CScript {
+        uint256 h; CSHA256().Write(witnessScript.data(), witnessScript.size()).Finalize(h.begin());
+        CScript spk; spk << OP_6; spk << std::vector<unsigned char>(h.begin(), h.end());
+        return spk;
+    };
+
+    // CSFS signing convention (P6.3 §3): raw 2420-byte sig over sha256d(msgBytes),
+    // NO appended hashType byte. msgBytes is the 32-byte sighash carried on the stack.
+    auto signCsfs = [](CKey& k, const uint256& sighash) -> std::vector<unsigned char> {
+        std::vector<unsigned char> msgBytes(sighash.begin(), sighash.begin() + 32);
+        uint256 digest = Hash(msgBytes.begin(), msgBytes.end()); // double-SHA256
+        std::vector<unsigned char> sig;
+        BOOST_REQUIRE(k.Sign(digest, sig));
+        BOOST_REQUIRE_EQUAL(sig.size(), 2420u); // raw — no hashType byte
+        return sig;
+    };
+
+    const unsigned int v6Flags = SCRIPT_VERIFY_WITNESS
+                               | SCRIPT_VERIFY_P2WSH_DILITHIUM
+                               | SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY
+                               | SCRIPT_VERIFY_CHECKSEQUENCEVERIFY
+                               | SCRIPT_VERIFY_APO
+                               | SCRIPT_VERIFY_SCRIPT_RESTORE
+                               | SCRIPT_VERIFY_CSFS
+                               | SCRIPT_VERIFY_CTV;
+
+    // ---- Keys (Alice + Bob channel partners) ----
+    CKey alice, bob;
+    alice.MakeNewKey(true);
+    bob.MakeNewKey(true);
+    CPubKey alicePk = alice.GetPubKey();
+    CPubKey bobPk = bob.GetPubKey();
+    BOOST_REQUIRE(alicePk.IsValid());
+    BOOST_REQUIRE(bobPk.IsValid());
+    std::vector<unsigned char> alicePkBytes(alicePk.begin(), alicePk.end());
+    std::vector<unsigned char> bobPkBytes(bobPk.begin(), bobPk.end());
+    std::vector<unsigned char> alicePkPrefixed; alicePkPrefixed.push_back(0x00);
+    alicePkPrefixed.insert(alicePkPrefixed.end(), alicePkBytes.begin(), alicePkBytes.end());
+
+    const CAmount channelAmount = 100 * COIN;
+    CScript emptyScriptSig;
+
+    // Assemble the secure-variant witness for a CSFS+in-script-CTV spend:
+    //   [aliceSig, msg, alicePk, bobSig, msg, bobPk, witnessScript, 0x00||alicePk]
+    auto secureWitness = [&](const std::vector<unsigned char>& aSig, const std::vector<unsigned char>& aMsg,
+                             const std::vector<unsigned char>& bSig, const std::vector<unsigned char>& bMsg,
+                             const CScript& ws) -> CScriptWitness {
+        CScriptWitness w;
+        w.stack.push_back(aSig);
+        w.stack.push_back(aMsg);
+        w.stack.push_back(alicePkBytes);
+        w.stack.push_back(bSig);
+        w.stack.push_back(bMsg);
+        w.stack.push_back(bobPkBytes);
+        w.stack.push_back(std::vector<unsigned char>(ws.begin(), ws.end()));
+        w.stack.push_back(alicePkPrefixed);
+        return w;
+    };
+
+    // ================================================================
+    // PART A — COEXISTENCE: APO-derived CSFS msg + in-script CTV
+    // ================================================================
+    // Update output commits (in-script CTV) to a settlement that splits 60/40.
+    // Both partners authorize via CSFS over the APO-0x42 sighash of that settlement.
+    CScript ctvPlaceholder; // built once we know the settlement template
+    // Build the settlement first so we can compute its CTV hash.
+    CMutableTransaction settleTx;
+    settleTx.nVersion = 2; settleTx.nLockTime = 0;
+    CTxIn sIn; sIn.prevout.hash = uint256S("00"); sIn.prevout.n = 0; sIn.nSequence = CTxIn::SEQUENCE_FINAL;
+    settleTx.vin.push_back(sIn);
+    CTxOut aPay; aPay.nValue = 60 * COIN; aPay.scriptPubKey = CScript() << OP_TRUE;
+    CTxOut bPay; bPay.nValue = 40 * COIN; bPay.scriptPubKey = CScript() << OP_TRUE;
+    settleTx.vout.push_back(aPay); settleTx.vout.push_back(bPay);
+
+    std::vector<unsigned char> settleCtv = computeCTVHash(settleTx, 0);
+
+    // Secure update output: OP_NOP5 OP_NOP5 <settleCtv> OP_CHECKTEMPLATEVERIFY  (b4 b4 20<hash> b3)
+    CScript updateScript;
+    updateScript << OP_NOP5 << OP_NOP5 << settleCtv << OP_CHECKTEMPLATEVERIFY;
+    CScript updateSpk = makeV6ScriptPubKey(updateScript);
+
+    // CSFS message = APO-0x42 sighash of the settlement (the parties' rebinding convention).
+    CTransaction ctxSettle(settleTx);
+    uint256 apo42 = SignatureHash(updateScript, ctxSettle, 0, SIGHASH_ANYPREVOUTANYSCRIPT,
+                                  channelAmount, SIGVERSION_WITNESS_V0, nullptr);
+    std::vector<unsigned char> apoMsg(apo42.begin(), apo42.begin() + 32);
+    std::vector<unsigned char> aSigA = signCsfs(alice, apo42);
+    std::vector<unsigned char> bSigA = signCsfs(bob, apo42);
+
+    // A1: honest settlement spend (outputs match the committed CTV) → PASS
+    {
+        ScriptError se = SCRIPT_ERR_OK;
+        CScriptWitness w = secureWitness(aSigA, apoMsg, bSigA, apoMsg, updateScript);
+        TransactionSignatureChecker ck(&ctxSettle, 0, channelAmount);
+        bool ok = VerifyScript(emptyScriptSig, updateSpk, &w, v6Flags, ck, &se);
+        BOOST_CHECK_MESSAGE(ok, "A1: APO-CSFS + in-script-CTV honest spend PASSES, serror=" << se);
+    }
+
+    // A2: tamper the settlement outputs (Alice grabs 100), keep the committed CTV → CTV REJECTS
+    {
+        CMutableTransaction theft = settleTx;
+        theft.vout.clear();
+        CTxOut steal; steal.nValue = channelAmount; steal.scriptPubKey = CScript() << OP_TRUE;
+        theft.vout.push_back(steal);
+        CTransaction ctxTheft(theft);
+        // Re-sign for the theft tx so CSFS itself can't be the rejecter — isolate CTV as the gate.
+        uint256 theftApo = SignatureHash(updateScript, ctxTheft, 0, SIGHASH_ANYPREVOUTANYSCRIPT,
+                                         channelAmount, SIGVERSION_WITNESS_V0, nullptr);
+        std::vector<unsigned char> theftMsg(theftApo.begin(), theftApo.begin() + 32);
+        std::vector<unsigned char> aSigT = signCsfs(alice, theftApo);
+        std::vector<unsigned char> bSigT = signCsfs(bob, theftApo);
+        ScriptError se = SCRIPT_ERR_OK;
+        CScriptWitness w = secureWitness(aSigT, theftMsg, bSigT, theftMsg, updateScript);
+        TransactionSignatureChecker ck(&ctxTheft, 0, channelAmount);
+        bool ok = VerifyScript(emptyScriptSig, updateSpk, &w, v6Flags, ck, &se);
+        BOOST_CHECK_MESSAGE(!ok, "A2: tampered outputs REJECTED by in-script CTV, serror=" << se);
+    }
+
+    // A3: rebinding — APO-0x42 ignores prevout, so the SAME sigs validate when the input
+    //     is rebound to a different funding outpoint (consensus-compatible off-chain rebinding).
+    {
+        CMutableTransaction rebound = settleTx;
+        rebound.vin[0].prevout.hash = uint256S("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        rebound.vin[0].prevout.n = 7;
+        CTransaction ctxRebound(rebound);
+        // CTV commits to (version,locktime,nIn,sequences,outputs,inputIndex) — NOT the prevout —
+        // so the committed settleCtv is unchanged; and apo42 ignores prevout, so the msg/sigs hold.
+        BOOST_REQUIRE(computeCTVHash(rebound, 0) == settleCtv);
+        ScriptError se = SCRIPT_ERR_OK;
+        CScriptWitness w = secureWitness(aSigA, apoMsg, bSigA, apoMsg, updateScript);
+        TransactionSignatureChecker ck(&ctxRebound, 0, channelAmount);
+        bool ok = VerifyScript(emptyScriptSig, updateSpk, &w, v6Flags, ck, &se);
+        BOOST_CHECK_MESSAGE(ok, "A3: REBINDING — same CSFS sigs validate against a different prevout, serror=" << se);
+    }
+
+    // ================================================================
+    // PART B — SUPERSESSION: is "latest state wins" enforced on-chain?
+    // ================================================================
+    // Funding output: CSFS 2-of-2 (b4 b4 51). Every update spends THIS output via APO.
+    CScript fundingScript; fundingScript << OP_NOP5 << OP_NOP5 << OP_1;
+    CScript fundingSpk = makeV6ScriptPubKey(fundingScript);
+
+    CMutableTransaction fundTx;
+    fundTx.nVersion = 2; fundTx.nLockTime = 0;
+    CTxIn cb; cb.prevout.SetNull(); cb.nSequence = CTxIn::SEQUENCE_FINAL; fundTx.vin.push_back(cb);
+    CTxOut fo; fo.nValue = channelAmount; fo.scriptPubKey = fundingSpk; fundTx.vout.push_back(fo);
+
+    // Build a co-signed update tx for a given state (nLockTime carries the state number,
+    // mirroring classic eLTOO — but on V6 it has no in-script effect).
+    auto buildSignedUpdate = [&](int64_t stateNum, const CAmount aBal, const CAmount bBal,
+                                 std::vector<unsigned char>& outMsg,
+                                 std::vector<unsigned char>& outASig,
+                                 std::vector<unsigned char>& outBSig) -> CMutableTransaction {
+        // The state's settlement template (what this update would close to).
+        CMutableTransaction settle;
+        settle.nVersion = 2; settle.nLockTime = 0;
+        CTxIn si; si.prevout.SetNull(); si.nSequence = CTxIn::SEQUENCE_FINAL; settle.vin.push_back(si);
+        CTxOut oa; oa.nValue = aBal; oa.scriptPubKey = CScript() << OP_TRUE;
+        CTxOut ob; ob.nValue = bBal; ob.scriptPubKey = CScript() << OP_TRUE;
+        settle.vout.push_back(oa); settle.vout.push_back(ob);
+        std::vector<unsigned char> ctv = computeCTVHash(settle, 0);
+
+        CScript uScript; uScript << OP_NOP5 << OP_NOP5 << ctv << OP_CHECKTEMPLATEVERIFY;
+        CScript uSpk = makeV6ScriptPubKey(uScript);
+
+        CMutableTransaction u;
+        u.nVersion = 2; u.nLockTime = stateNum; // state number (no in-script effect on V6)
+        CTxIn ui; ui.prevout.hash = fundTx.GetHash(); ui.prevout.n = 0; ui.nSequence = 0xfffffffe;
+        u.vin.push_back(ui);
+        CTxOut uo; uo.nValue = channelAmount; uo.scriptPubKey = uSpk; u.vout.push_back(uo);
+
+        CTransaction cu(u);
+        uint256 sh = SignatureHash(fundingScript, cu, 0, SIGHASH_ANYPREVOUTANYSCRIPT,
+                                   channelAmount, SIGVERSION_WITNESS_V0, nullptr);
+        outMsg.assign(sh.begin(), sh.begin() + 32);
+        outASig = signCsfs(alice, sh);
+        outBSig = signCsfs(bob, sh);
+        return u;
+    };
+
+    // State 100 (Alice 50 / Bob 50) and state 200 (Alice 10 / Bob 90 — Bob got paid).
+    std::vector<unsigned char> msg100, aSig100, bSig100;
+    CMutableTransaction u100 = buildSignedUpdate(100, 50 * COIN, 50 * COIN, msg100, aSig100, bSig100);
+    std::vector<unsigned char> msg200, aSig200, bSig200;
+    CMutableTransaction u200 = buildSignedUpdate(200, 10 * COIN, 90 * COIN, msg200, aSig200, bSig200);
+
+    // Channel has advanced to state 200. Both partners hold valid co-signs for BOTH states.
+    // B1: the OLD state-100 update is STILL a valid spend of the funding output — nothing
+    //     on-chain revoked it. Alice can broadcast it to undo Bob's payment.
+    bool u100StillValid;
+    {
+        CTransaction cu100(u100);
+        ScriptError se = SCRIPT_ERR_OK;
+        CScriptWitness w = secureWitness(aSig100, msg100, bSig100, msg100, fundingScript);
+        TransactionSignatureChecker ck(&cu100, 0, channelAmount);
+        u100StillValid = VerifyScript(emptyScriptSig, fundingSpk, &w, v6Flags, ck, &se);
+        BOOST_CHECK_MESSAGE(u100StillValid,
+            "B1: stale state-100 update STILL valid after advancing to 200 — NO on-chain "
+            "supersession (the finding), serror=" << se);
+    }
+    // ...and state 200 is equally valid. Both spend the same funding UTXO; consensus has no
+    // preference for the higher state. Whichever confirms first wins → first-broadcast, not
+    // latest-state. This is the crux: V6 cannot ratchet.
+    bool u200Valid;
+    {
+        CTransaction cu200(u200);
+        ScriptError se = SCRIPT_ERR_OK;
+        CScriptWitness w = secureWitness(aSig200, msg200, bSig200, msg200, fundingScript);
+        TransactionSignatureChecker ck(&cu200, 0, channelAmount);
+        u200Valid = VerifyScript(emptyScriptSig, fundingSpk, &w, v6Flags, ck, &se);
+        BOOST_CHECK_MESSAGE(u200Valid, "B1b: state-200 update also valid (both spend funding), serror=" << se);
+    }
+
+    // B2: an in-script state floor is UNCONSTRUCTIBLE on V6, and OP_CLTV provably does not gate.
+    //   The classic ratchet is <state+1> OP_CHECKLOCKTIMEVERIFY OP_DROP <...>. But OP_CLTV does
+    //   not pop its argument (true in Bitcoin too), so it must be followed by OP_DROP — and
+    //   OP_DROP is ALSO a no-op in V6 EvalScript, so the pushed state number is never removed and
+    //   corrupts the subsequent CSFS stack (the 1st CSFS reads the leftover number as a pubkey).
+    //   PROOF that OP_CLTV is never consulted: a "satisfied" spend (nLockTime=201 >= floor) and a
+    //   "violated" spend (nLockTime=101 < floor) of the SAME script fail IDENTICALLY — if CLTV
+    //   gated anything, the satisfied case would pass. Both fail with the same error → the
+    //   locktime is never looked at.
+    CScript ratchetScript;
+    ratchetScript << CScriptNum(201) << OP_CHECKLOCKTIMEVERIFY << OP_DROP
+                  << OP_NOP5 << OP_NOP5 << OP_1;
+    CScript ratchetSpk = makeV6ScriptPubKey(ratchetScript);
+
+    CMutableTransaction rf;
+    rf.nVersion = 2; rf.nLockTime = 0;
+    CTxIn rcb; rcb.prevout.SetNull(); rcb.nSequence = CTxIn::SEQUENCE_FINAL; rf.vin.push_back(rcb);
+    CTxOut rfo; rfo.nValue = channelAmount; rfo.scriptPubKey = ratchetSpk; rf.vout.push_back(rfo);
+
+    auto spendRatchetAt = [&](uint32_t nLockTime, ScriptError& se) -> bool {
+        CMutableTransaction t;
+        t.nVersion = 2; t.nLockTime = nLockTime;
+        CTxIn ti; ti.prevout.hash = rf.GetHash(); ti.prevout.n = 0; ti.nSequence = 0xfffffffe;
+        t.vin.push_back(ti);
+        CTxOut to; to.nValue = channelAmount; to.scriptPubKey = CScript() << OP_TRUE; t.vout.push_back(to);
+        CTransaction ct(t);
+        uint256 sh = SignatureHash(ratchetScript, ct, 0, SIGHASH_ANYPREVOUTANYSCRIPT,
+                                   channelAmount, SIGVERSION_WITNESS_V0, nullptr);
+        std::vector<unsigned char> rmsg(sh.begin(), sh.begin() + 32);
+        std::vector<unsigned char> ra = signCsfs(alice, sh);
+        std::vector<unsigned char> rb = signCsfs(bob, sh);
+        CScriptWitness w = secureWitness(ra, rmsg, rb, rmsg, ratchetScript);
+        TransactionSignatureChecker ck(&ct, 0, channelAmount);
+        return VerifyScript(emptyScriptSig, ratchetSpk, &w, v6Flags, ck, &se);
+    };
+
+    ScriptError seViolated = SCRIPT_ERR_OK, seSatisfied = SCRIPT_ERR_OK;
+    bool okViolated  = spendRatchetAt(101, seViolated);   // below the "floor"
+    bool okSatisfied = spendRatchetAt(201, seSatisfied);  // meets the "floor"
+
+    // Neither spends, and both fail the same way → OP_CLTV gating is absent (not merely skipped):
+    // the script is simply broken by the no-op CLTV/DROP residue, identically regardless of locktime.
+    bool ratchetUnconstructible = (!okViolated && !okSatisfied && seViolated == seSatisfied);
+    BOOST_CHECK_MESSAGE(ratchetUnconstructible,
+        "B2: in-script state floor is unconstructible — satisfied(201) and violated(101) spends "
+        "fail identically (CLTV never consulted). okViolated=" << okViolated
+        << " seViolated=" << seViolated << " okSatisfied=" << okSatisfied << " seSatisfied=" << seSatisfied);
+
+    // ---- Summary ----
+    BOOST_TEST_MESSAGE("SUPERSESSION_MODEL_BEGIN");
+    BOOST_TEST_MESSAGE("update_script_hex=" << hexv(std::vector<unsigned char>(updateScript.begin(), updateScript.end())));
+    BOOST_TEST_MESSAGE("funding_script_hex=" << hexv(std::vector<unsigned char>(fundingScript.begin(), fundingScript.end())));
+    BOOST_TEST_MESSAGE("b1_stale_state_still_valid=" << u100StillValid);
+    BOOST_TEST_MESSAGE("b1b_new_state_valid=" << u200Valid);
+    BOOST_TEST_MESSAGE("b2_cltv_violated_spends=" << okViolated << " (serror=" << seViolated << ")");
+    BOOST_TEST_MESSAGE("b2_cltv_satisfied_spends=" << okSatisfied << " (serror=" << seSatisfied << ")");
+    BOOST_TEST_MESSAGE("b2_ratchet_unconstructible=" << ratchetUnconstructible);
+    BOOST_TEST_MESSAGE("SUPERSESSION_MODEL_END");
+
+    // The decision-forcing result, asserted so it can't silently regress:
+    //  - coexistence + binding WORK (A1/A2/A3 above), but
+    //  - on-chain supersession does NOT (B1: stale state stays valid; B2: no in-script ratchet).
+    BOOST_REQUIRE_MESSAGE(u100StillValid && u200Valid && ratchetUnconstructible,
+        "SUPERSESSION VERDICT: V6 supports CTV-committed fixed-settlement close, but NOT a "
+        "trustless latest-state-wins ratchet — old fully-signed states stay spendable and an "
+        "in-script CLTV/CSV state floor is unconstructible (no-op opcodes). Multi-update channels "
+        "need off-chain (LSP/watchtower) supersession or a new consensus opcode.");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/lightning_script_tests.cpp
+++ b/src/test/lightning_script_tests.cpp
@@ -1992,4 +1992,251 @@ BOOST_AUTO_TEST_CASE(eltoo_v6_supersession_model)
         "need off-chain (LSP/watchtower) supersession or a new consensus opcode.");
 }
 
+// ============================================================================
+// PATH B1 TARGET TESTS — eLTOO ratchet + HTLC once v6 control-flow is restored
+// ============================================================================
+//
+// Spec: design-log/DL-V6-CONTROLFLOW-RESTORE.md. These LOCK the target B1 script
+// forms (assert the opcode skeleton — green today) and encode the behavioural
+// target (PENDING-guarded; auto-activate when SCRIPT_VERIFY_V6_CONTROLFLOW ships).
+//
+// The guard probe: a script <1> OP_DROP OP_1 leaves a 1-element stack iff real
+// OP_DROP executes. Today OP_DROP is a no-op (residue → 2 elements), so the
+// behavioural blocks below are skipped with a PENDING message and CI stays green.
+// When step 2 restores the opcodes, the probe passes and the assertions enforce.
+
+static const unsigned int kV6ControlFlow = (1U << 26); // proposed SCRIPT_VERIFY_V6_CONTROLFLOW
+
+static bool V6ControlFlowActive()
+{
+    CScript probe; probe << CScriptNum(1) << OP_DROP << OP_1;
+    CMutableTransaction tx = MakeSpendTx(0xffffffff, 0, 1);
+    MutableTransactionSignatureChecker checker(&tx, 0, 0);
+    std::vector<std::vector<unsigned char>> st; ScriptError e = SCRIPT_ERR_OK;
+    EvalScript(st, probe, kV6ControlFlow, checker, SIGVERSION_BASE, &e);
+    return st.size() == 1; // real OP_DROP → [OP_1]; no-op OP_DROP → [1, 1]
+}
+
+// Normalised opcode skeleton: every data push (0x01..OP_PUSHDATA4) → -1, opcodes kept.
+static std::vector<int> OpSkeleton(const CScript& s)
+{
+    std::vector<int> out;
+    CScript::const_iterator pc = s.begin();
+    opcodetype op; std::vector<unsigned char> data;
+    while (s.GetOp(pc, op, data)) {
+        if (op >= 0x01 && op <= OP_PUSHDATA4) out.push_back(-1);
+        else out.push_back((int)op);
+    }
+    return out;
+}
+
+static CScript MakeV6Spk(const CScript& ws)
+{
+    uint256 h; CSHA256().Write(ws.data(), ws.size()).Finalize(h.begin());
+    CScript spk; spk << OP_6; spk << std::vector<unsigned char>(h.begin(), h.end());
+    return spk;
+}
+
+// ------------------------------------------------- eLTOO update output (B1 §4.1)
+BOOST_AUTO_TEST_CASE(eltoo_v6_ratchet_target)
+{
+    // Deterministic keyhashes so the form is reproducible.
+    std::vector<unsigned char> khAu(32, 0x11), khBu(32, 0x22), khAs(32, 0x33), khBs(32, 0x44);
+    const int64_t N = 600000, csv = 288;
+
+    // B1 update script: IF <N+1> CLTV DROP <khB> CDKH <khA> CDKH OP_1
+    //                   ELSE <csv> CSV DROP <khB> CDKH <khA> CDKH OP_1 ENDIF
+    CScript ws;
+    ws << OP_IF
+         << CScriptNum(N + 1) << OP_CHECKLOCKTIMEVERIFY << OP_DROP
+         << khBu << OP_CHECKDILITHIUMKEYHASH << khAu << OP_CHECKDILITHIUMKEYHASH << OP_1
+       << OP_ELSE
+         << CScriptNum(csv) << OP_CHECKSEQUENCEVERIFY << OP_DROP
+         << khBs << OP_CHECKDILITHIUMKEYHASH << khAs << OP_CHECKDILITHIUMKEYHASH << OP_1
+       << OP_ENDIF;
+
+    // ---- FORM LOCK (green today): exact opcode skeleton ----
+    std::vector<int> expected = {
+        OP_IF, -1, OP_CHECKLOCKTIMEVERIFY, OP_DROP,
+        -1, OP_CHECKDILITHIUMKEYHASH, -1, OP_CHECKDILITHIUMKEYHASH, OP_1,
+        OP_ELSE, -1, OP_CHECKSEQUENCEVERIFY, OP_DROP,
+        -1, OP_CHECKDILITHIUMKEYHASH, -1, OP_CHECKDILITHIUMKEYHASH, OP_1,
+        OP_ENDIF };
+    BOOST_CHECK_MESSAGE(OpSkeleton(ws) == expected,
+        "eLTOO update script matches the locked B1 form (IF-CLTV-2of2 / ELSE-CSV-2of2)");
+
+    {
+        auto hex = [](const unsigned char* p, size_t n){ static const char* d="0123456789abcdef"; std::string s; for(size_t i=0;i<n;i++){s+=d[p[i]>>4];s+=d[p[i]&0xf];} return s; };
+        BOOST_TEST_MESSAGE("eltoo_update_script_form_hex=" << hex(ws.data(), ws.size()));
+    }
+
+    // ---- BEHAVIOURAL TARGET (PENDING until DL-V6-CONTROLFLOW-RESTORE ships) ----
+    if (!V6ControlFlowActive()) {
+        BOOST_TEST_MESSAGE("PENDING DL-V6-CONTROLFLOW-RESTORE: ratchet behaviour asserted once "
+                           "v6 control-flow opcodes execute (step 2).");
+        return;
+    }
+
+    // Real keys; rebuild the script with committed keyhashes of the real pubkeys.
+    CKey aU, bU; aU.MakeNewKey(true); bU.MakeNewKey(true);
+    CPubKey aUpk = aU.GetPubKey(), bUpk = bU.GetPubKey();
+    std::vector<unsigned char> aUb(aUpk.begin(), aUpk.end()), bUb(bUpk.begin(), bUpk.end());
+    auto kh = [](const std::vector<unsigned char>& pk){ std::vector<unsigned char> h(32); CSHA256().Write(pk.data(), pk.size()).Finalize(h.data()); return h; };
+    std::vector<unsigned char> aTrail; aTrail.push_back(0x00); aTrail.insert(aTrail.end(), aUb.begin(), aUb.end());
+
+    CScript upd;
+    upd << OP_IF
+          << CScriptNum(N + 1) << OP_CHECKLOCKTIMEVERIFY << OP_DROP
+          << kh(bUb) << OP_CHECKDILITHIUMKEYHASH << kh(aUb) << OP_CHECKDILITHIUMKEYHASH << OP_1
+        << OP_ELSE
+          << CScriptNum(csv) << OP_CHECKSEQUENCEVERIFY << OP_DROP
+          << kh(bUb) << OP_CHECKDILITHIUMKEYHASH << kh(aUb) << OP_CHECKDILITHIUMKEYHASH << OP_1
+        << OP_ENDIF;
+    CScript updSpk = MakeV6Spk(upd);
+    const CAmount amt = 100 * COIN;
+
+    // Funding tx carrying the state-N update output.
+    CMutableTransaction fund; fund.nVersion = 2;
+    CTxIn fi; fi.prevout.SetNull(); fi.nSequence = CTxIn::SEQUENCE_FINAL; fund.vin.push_back(fi);
+    CTxOut fo; fo.nValue = amt; fo.scriptPubKey = updSpk; fund.vout.push_back(fo);
+
+    const unsigned int flags = SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2WSH_DILITHIUM
+                             | SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY | SCRIPT_VERIFY_CHECKSEQUENCEVERIFY
+                             | SCRIPT_VERIFY_APO | SCRIPT_VERIFY_DILITHIUM_KEYHASH
+                             | SCRIPT_VERIFY_SCRIPT_RESTORE | kV6ControlFlow;
+
+    // Spend the update branch with a tx at a GIVEN state (nLockTime). APO-0x42 keyhash 2-of-2.
+    auto spendUpdateBranch = [&](uint32_t lockState, ScriptError& se) -> bool {
+        CMutableTransaction t; t.nVersion = 2; t.nLockTime = lockState;
+        CTxIn ti; ti.prevout.hash = fund.GetHash(); ti.prevout.n = 0; ti.nSequence = 0xfffffffe; t.vin.push_back(ti);
+        CTxOut to; to.nValue = amt; to.scriptPubKey = updSpk; t.vout.push_back(to); // re-commit (next state)
+        CTransaction ct(t);
+        uint256 sh = SignatureHash(upd, ct, 0, SIGHASH_ANYPREVOUTANYSCRIPT, amt, SIGVERSION_WITNESS_V0, nullptr);
+        std::vector<unsigned char> sa, sb; aU.Sign(sh, sa); bU.Sign(sh, sb);
+        sa.push_back(SIGHASH_ANYPREVOUTANYSCRIPT); sb.push_back(SIGHASH_ANYPREVOUTANYSCRIPT);
+        CScriptWitness w; // satisfaction: [sigA,pubA,sigB,pubB, selector=true], then ws, trailer
+        w.stack.push_back(sa); w.stack.push_back(aUb);
+        w.stack.push_back(sb); w.stack.push_back(bUb);
+        w.stack.push_back(std::vector<unsigned char>{0x01});
+        w.stack.push_back(std::vector<unsigned char>(upd.begin(), upd.end()));
+        w.stack.push_back(aTrail);
+        CScript empty; TransactionSignatureChecker ck(&ct, 0, amt);
+        return VerifyScript(empty, updSpk, &w, flags, ck, &se);
+    };
+
+    ScriptError seHi = SCRIPT_ERR_OK, seLo = SCRIPT_ERR_OK;
+    bool higherSupersedes = spendUpdateBranch((uint32_t)N + 100, seHi); // state > N → CLTV ok
+    bool lowerBlocked     = spendUpdateBranch((uint32_t)N - 100, seLo); // state < N+1 → CLTV fail
+    BOOST_CHECK_MESSAGE(higherSupersedes, "ratchet: higher-state update SPENDS the state-N output, serror=" << seHi);
+    BOOST_CHECK_MESSAGE(!lowerBlocked, "ratchet: lower-state update is REJECTED by CLTV, serror=" << seLo);
+}
+
+// ------------------------------------------------------------ HTLC output (B1 §4.2)
+BOOST_AUTO_TEST_CASE(htlc_v6_target)
+{
+    std::vector<unsigned char> H(32, 0xab), khPayee(32, 0x55), khPayer(32, 0x66);
+    const int64_t cltv = 500;
+
+    // B1 HTLC: IF OP_SHA256 <H> OP_EQUALVERIFY <khPayee> CDKH OP_1
+    //          ELSE <cltv> CLTV DROP <khPayer> CDKH OP_1 ENDIF
+    CScript ws;
+    ws << OP_IF
+         << OP_SHA256 << H << OP_EQUALVERIFY << khPayee << OP_CHECKDILITHIUMKEYHASH << OP_1
+       << OP_ELSE
+         << CScriptNum(cltv) << OP_CHECKLOCKTIMEVERIFY << OP_DROP << khPayer << OP_CHECKDILITHIUMKEYHASH << OP_1
+       << OP_ENDIF;
+
+    std::vector<int> expected = {
+        OP_IF, OP_SHA256, -1, OP_EQUALVERIFY, -1, OP_CHECKDILITHIUMKEYHASH, OP_1,
+        OP_ELSE, -1, OP_CHECKLOCKTIMEVERIFY, OP_DROP, -1, OP_CHECKDILITHIUMKEYHASH, OP_1,
+        OP_ENDIF };
+    BOOST_CHECK_MESSAGE(OpSkeleton(ws) == expected,
+        "HTLC script matches the locked B1 form (IF-hashlock-payee / ELSE-CLTV-payer)");
+
+    if (!V6ControlFlowActive()) {
+        BOOST_TEST_MESSAGE("PENDING DL-V6-CONTROLFLOW-RESTORE: HTLC success/timeout asserted once "
+                           "v6 control-flow opcodes execute (step 2).");
+        return;
+    }
+
+    // Real keys + a real preimage; rebuild with committed keyhashes.
+    CKey payee, payer; payee.MakeNewKey(true); payer.MakeNewKey(true);
+    std::vector<unsigned char> peeB(payee.GetPubKey().begin(), payee.GetPubKey().end());
+    std::vector<unsigned char> perB(payer.GetPubKey().begin(), payer.GetPubKey().end());
+    auto kh = [](const std::vector<unsigned char>& pk){ std::vector<unsigned char> h(32); CSHA256().Write(pk.data(), pk.size()).Finalize(h.data()); return h; };
+    std::vector<unsigned char> preimage(32, 0x07);
+    std::vector<unsigned char> Hreal(32); CSHA256().Write(preimage.data(), preimage.size()).Finalize(Hreal.data());
+    std::vector<unsigned char> peeTrail; peeTrail.push_back(0x00); peeTrail.insert(peeTrail.end(), peeB.begin(), peeB.end());
+    std::vector<unsigned char> perTrail; perTrail.push_back(0x00); perTrail.insert(perTrail.end(), perB.begin(), perB.end());
+
+    CScript htlc;
+    htlc << OP_IF
+           << OP_SHA256 << Hreal << OP_EQUALVERIFY << kh(peeB) << OP_CHECKDILITHIUMKEYHASH << OP_1
+         << OP_ELSE
+           << CScriptNum(cltv) << OP_CHECKLOCKTIMEVERIFY << OP_DROP << kh(perB) << OP_CHECKDILITHIUMKEYHASH << OP_1
+         << OP_ENDIF;
+    CScript htlcSpk = MakeV6Spk(htlc);
+    const CAmount amt = 49 * COIN;
+
+    CMutableTransaction fund; fund.nVersion = 2;
+    CTxIn fi; fi.prevout.SetNull(); fi.nSequence = CTxIn::SEQUENCE_FINAL; fund.vin.push_back(fi);
+    CTxOut fo; fo.nValue = amt; fo.scriptPubKey = htlcSpk; fund.vout.push_back(fo);
+
+    const unsigned int flags = SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2WSH_DILITHIUM
+                             | SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY | SCRIPT_VERIFY_DILITHIUM_KEYHASH
+                             | SCRIPT_VERIFY_SCRIPT_RESTORE | kV6ControlFlow;
+
+    // SUCCESS: [sigPayee, pubPayee, preimage, true]
+    {
+        CMutableTransaction t; t.nVersion = 2; t.nLockTime = 0;
+        CTxIn ti; ti.prevout.hash = fund.GetHash(); ti.prevout.n = 0; ti.nSequence = 0xfffffffe; t.vin.push_back(ti);
+        CTxOut to; to.nValue = amt; to.scriptPubKey = CScript() << OP_TRUE; t.vout.push_back(to);
+        CTransaction ct(t);
+        uint256 sh = SignatureHash(htlc, ct, 0, SIGHASH_ALL, amt, SIGVERSION_WITNESS_V0, nullptr);
+        std::vector<unsigned char> sig; payee.Sign(sh, sig); sig.push_back(SIGHASH_ALL);
+        CScriptWitness w;
+        w.stack.push_back(sig); w.stack.push_back(peeB); w.stack.push_back(preimage);
+        w.stack.push_back(std::vector<unsigned char>{0x01});
+        w.stack.push_back(std::vector<unsigned char>(htlc.begin(), htlc.end()));
+        w.stack.push_back(peeTrail);
+        CScript empty; ScriptError se = SCRIPT_ERR_OK; TransactionSignatureChecker ck(&ct, 0, amt);
+        BOOST_CHECK_MESSAGE(VerifyScript(empty, htlcSpk, &w, flags, ck, &se),
+            "HTLC success: correct preimage + payee sig claims, serror=" << se);
+
+        // wrong preimage → hashlock fails
+        CScriptWitness wbad = w; wbad.stack[2] = std::vector<unsigned char>(32, 0x08);
+        ScriptError se2 = SCRIPT_ERR_OK;
+        BOOST_CHECK_MESSAGE(!VerifyScript(empty, htlcSpk, &wbad, flags, ck, &se2),
+            "HTLC success: wrong preimage REJECTED, serror=" << se2);
+    }
+
+    // TIMEOUT: [sigPayer, pubPayer, false], claim tx nLockTime >= cltv
+    {
+        CMutableTransaction t; t.nVersion = 2; t.nLockTime = (uint32_t)cltv + 1;
+        CTxIn ti; ti.prevout.hash = fund.GetHash(); ti.prevout.n = 0; ti.nSequence = 0xfffffffe; t.vin.push_back(ti);
+        CTxOut to; to.nValue = amt; to.scriptPubKey = CScript() << OP_TRUE; t.vout.push_back(to);
+        CTransaction ct(t);
+        uint256 sh = SignatureHash(htlc, ct, 0, SIGHASH_ALL, amt, SIGVERSION_WITNESS_V0, nullptr);
+        std::vector<unsigned char> sig; payer.Sign(sh, sig); sig.push_back(SIGHASH_ALL);
+        CScriptWitness w;
+        w.stack.push_back(sig); w.stack.push_back(perB);
+        w.stack.push_back(std::vector<unsigned char>{}); // false selector → ELSE branch
+        w.stack.push_back(std::vector<unsigned char>(htlc.begin(), htlc.end()));
+        w.stack.push_back(perTrail);
+        CScript empty; ScriptError se = SCRIPT_ERR_OK; TransactionSignatureChecker ck(&ct, 0, amt);
+        BOOST_CHECK_MESSAGE(VerifyScript(empty, htlcSpk, &w, flags, ck, &se),
+            "HTLC timeout: payer claims after CLTV, serror=" << se);
+
+        // premature timeout (nLockTime < cltv) → CLTV rejects
+        CMutableTransaction t2 = t; t2.nLockTime = (uint32_t)cltv - 10;
+        CTransaction ct2(t2);
+        uint256 sh2 = SignatureHash(htlc, ct2, 0, SIGHASH_ALL, amt, SIGVERSION_WITNESS_V0, nullptr);
+        std::vector<unsigned char> sig2; payer.Sign(sh2, sig2); sig2.push_back(SIGHASH_ALL);
+        CScriptWitness w2 = w; w2.stack[0] = sig2;
+        ScriptError se2 = SCRIPT_ERR_OK; TransactionSignatureChecker ck2(&ct2, 0, amt);
+        BOOST_CHECK_MESSAGE(!VerifyScript(empty, htlcSpk, &w2, flags, ck2, &se2),
+            "HTLC timeout: premature claim REJECTED by CLTV, serror=" << se2);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/lightning_script_tests.cpp
+++ b/src/test/lightning_script_tests.cpp
@@ -2242,4 +2242,45 @@ BOOST_AUTO_TEST_CASE(htlc_v6_target)
     }
 }
 
+// ------------------------------------------- B1 script byte vectors (for the SDKs)
+// Emits the canonical B1 eLTOO update + HTLC script hex for deterministic keyhash inputs,
+// so the TS/Dart SDKs can byte-match (the keyhash = SHA256(pubkey) step is pinned by P4).
+// Run: test_soqucoin --run_test=lightning_script_tests/b1_script_vectors --log_level=message
+BOOST_AUTO_TEST_CASE(b1_script_vectors)
+{
+    auto hexs = [](const CScript& s){ static const char* d="0123456789abcdef"; std::string o; for(size_t i=0;i<s.size();i++){o+=d[s[i]>>4];o+=d[s[i]&0xf];} return o; };
+
+    // eLTOO update: distinct update vs settlement keyhashes to exercise the full form.
+    std::vector<unsigned char> khAu(32,0x11), khBu(32,0x22), khAs(32,0x33), khBs(32,0x44);
+    const int64_t N = 600000, csv = 288;
+    CScript eltoo;
+    eltoo << OP_IF
+            << CScriptNum(N + 1) << OP_CHECKLOCKTIMEVERIFY << OP_DROP
+            << khBu << OP_CHECKDILITHIUMKEYHASH << khAu << OP_CHECKDILITHIUMKEYHASH << OP_1
+          << OP_ELSE
+            << CScriptNum(csv) << OP_CHECKSEQUENCEVERIFY << OP_DROP
+            << khBs << OP_CHECKDILITHIUMKEYHASH << khAs << OP_CHECKDILITHIUMKEYHASH << OP_1
+          << OP_ENDIF;
+
+    // HTLC: hashlock H, payee/payer keyhashes, absolute cltv.
+    std::vector<unsigned char> H(32,0xab), khPayee(32,0x55), khPayer(32,0x66);
+    const int64_t cltv = 500;
+    CScript htlc;
+    htlc << OP_IF
+           << OP_SHA256 << H << OP_EQUALVERIFY << khPayee << OP_CHECKDILITHIUMKEYHASH << OP_1
+         << OP_ELSE
+           << CScriptNum(cltv) << OP_CHECKLOCKTIMEVERIFY << OP_DROP << khPayer << OP_CHECKDILITHIUMKEYHASH << OP_1
+         << OP_ENDIF;
+
+    BOOST_TEST_MESSAGE("B1_VECTORS_BEGIN");
+    BOOST_TEST_MESSAGE("eltoo_stateNum=" << N);
+    BOOST_TEST_MESSAGE("eltoo_csv=" << csv);
+    BOOST_TEST_MESSAGE("eltoo_khAu=11..(x32) khBu=22 khAs=33 khBs=44");
+    BOOST_TEST_MESSAGE("eltoo_update_script_hex=" << hexs(eltoo));
+    BOOST_TEST_MESSAGE("htlc_cltv=" << cltv);
+    BOOST_TEST_MESSAGE("htlc_H=ab..(x32) khPayee=55 khPayer=66");
+    BOOST_TEST_MESSAGE("htlc_script_hex=" << hexs(htlc));
+    BOOST_TEST_MESSAGE("B1_VECTORS_END");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/lightning_script_tests.cpp
+++ b/src/test/lightning_script_tests.cpp
@@ -2005,7 +2005,7 @@ BOOST_AUTO_TEST_CASE(eltoo_v6_supersession_model)
 // behavioural blocks below are skipped with a PENDING message and CI stays green.
 // When step 2 restores the opcodes, the probe passes and the assertions enforce.
 
-static const unsigned int kV6ControlFlow = (1U << 26); // proposed SCRIPT_VERIFY_V6_CONTROLFLOW
+static const unsigned int kV6ControlFlow = SCRIPT_VERIFY_V6_CONTROLFLOW; // DL-V6-CONTROLFLOW-RESTORE
 
 static bool V6ControlFlowActive()
 {
@@ -2161,8 +2161,11 @@ BOOST_AUTO_TEST_CASE(htlc_v6_target)
 
     // Real keys + a real preimage; rebuild with committed keyhashes.
     CKey payee, payer; payee.MakeNewKey(true); payer.MakeNewKey(true);
-    std::vector<unsigned char> peeB(payee.GetPubKey().begin(), payee.GetPubKey().end());
-    std::vector<unsigned char> perB(payer.GetPubKey().begin(), payer.GetPubKey().end());
+    // Bind CPubKey to locals before begin()/end() — separate GetPubKey() temporaries
+    // would yield iterators into distinct destroyed objects (the CPubKey-temporary bug).
+    CPubKey payeePk = payee.GetPubKey(), payerPk = payer.GetPubKey();
+    std::vector<unsigned char> peeB(payeePk.begin(), payeePk.end());
+    std::vector<unsigned char> perB(payerPk.begin(), payerPk.end());
     auto kh = [](const std::vector<unsigned char>& pk){ std::vector<unsigned char> h(32); CSHA256().Write(pk.data(), pk.size()).Finalize(h.data()); return h; };
     std::vector<unsigned char> preimage(32, 0x07);
     std::vector<unsigned char> Hreal(32); CSHA256().Write(preimage.data(), preimage.size()).Finalize(Hreal.data());


### PR DESCRIPTION
## What happened

PR #12 (B1 control-flow-restore) was stacked with base `feat/max-reorg-depth-finality`. When merged, it landed on that branch — but PR #11 had already merged the finality branch to `main` *before* B1 was added, so the B1 commits never reached `main`. The SDK PRs merged fine.

## This PR

Brings the stranded B1 delta to `main`. The finality branch now equals `main` + B1, so this is exactly the 4 B1 commits (+ the #12 merge):

- `cd24d1cc2` eltoo_v6_supersession_model (proves the gap)
- `b63283236` B1 spec + positive node tests
- `68bdbe1c2` **restore branch/timelock/hashlock opcodes in v6 EvalScript** (the consensus change, behind `SCRIPT_VERIFY_V6_CONTROLFLOW`; flag-off = no-ops unchanged)
- `71310c2e0` b1_script_vectors (SDK byte-match ground truth)

Full unit suite was 563 green, no regressions. Re-verifies the same consensus change reviewed in #12; this is purely the corrective re-target to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)