### PR TITLE
consensus: activate v6 control-flow restore via DEPLOYMENT_V6_CONTROLFLOW (bit 13)

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -263,6 +263,12 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_DILITHIUM_KEYHASH].nStartTime = 0;  // NOT ACTIVE: pending Halborn Phase 2 audit
         consensus.vDeployments[Consensus::DEPLOYMENT_DILITHIUM_KEYHASH].nTimeout = 0;    // Not yet scheduled
 
+        // DL-V6-CONTROLFLOW-RESTORE: restore branch/timelock/hashlock opcodes in v6 EvalScript.
+        // BIP9 activation post-audit: set nStartTime, miners signal bit 13.
+        consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].bit = 13;
+        consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nStartTime = 0;  // NOT ACTIVE: pending Halborn Phase 2 audit
+        consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nTimeout = 0;    // Not yet scheduled
+
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000000e993d2aa86cf246a49b"); // 5,050,000
@@ -482,6 +488,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_DILITHIUM_KEYHASH].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_DILITHIUM_KEYHASH].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
+        // DL-V6-CONTROLFLOW-RESTORE — ALWAYS_ACTIVE on testnet for eLTOO/HTLC integration testing
+        consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].bit = 13;
+        consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");
 
@@ -673,6 +684,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_DILITHIUM_KEYHASH].bit = 12;
         consensus.vDeployments[Consensus::DEPLOYMENT_DILITHIUM_KEYHASH].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_DILITHIUM_KEYHASH].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+
+        // DL-V6-CONTROLFLOW-RESTORE — ALWAYS_ACTIVE for regtest (eLTOO/HTLC unit + functional tests)
+        consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].bit = 13;
+        consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");
@@ -899,6 +915,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_DILITHIUM_KEYHASH].bit = 12;
         consensus.vDeployments[Consensus::DEPLOYMENT_DILITHIUM_KEYHASH].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;  // STAGENET ONLY
         consensus.vDeployments[Consensus::DEPLOYMENT_DILITHIUM_KEYHASH].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+
+        // DL-V6-CONTROLFLOW-RESTORE — ALWAYS_ACTIVE on stagenet for the eLTOO/HTLC e2e (ratchet, settlement, HTLC)
+        consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].bit = 13;
+        consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;  // STAGENET ONLY
+        consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
         // USDSOQ Authority Keys - 2-of-3 ML-DSA-44 multisig (FIPS 204)
         // Keys control USDSOQ mint/burn/freeze. Generated 2026-05-27T04:46:27Z

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -30,6 +30,7 @@ enum DeploymentPos {
     DEPLOYMENT_P2WSH_DILITHIUM, // Witness v6: P2WSH with Dilithium (bit 10) — covenant script execution, L2SOQ Lightning
     DEPLOYMENT_UTXO_COST,       // SOQ-ARCH-003: Consensus-enforced minimum UTXO value (bit 11) — Cardano-style utxoCostPerByte
     DEPLOYMENT_DILITHIUM_KEYHASH, // OP_CHECKDILITHIUMKEYHASH (bit 12) — key-committed Dilithium sig verify, eLTOO 2-of-2 multisig
+    DEPLOYMENT_V6_CONTROLFLOW, // DL-V6-CONTROLFLOW-RESTORE (bit 13) — IF/CLTV/CSV/DROP/SHA256/EQUAL in v6 EvalScript (eLTOO ratchet, HTLC)
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in versionbits.cpp
     MAX_VERSION_BITS_DEPLOYMENTS
 };

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2396,6 +2396,14 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         flags |= SCRIPT_VERIFY_DILITHIUM_KEYHASH;
     }
 
+    // DL-V6-CONTROLFLOW-RESTORE: Start enforcing the restored branch/timelock/hashlock opcodes
+    // (OP_IF/ELSE/ENDIF, OP_DROP, OP_CLTV, OP_CSV, OP_SHA256, OP_EQUAL[VERIFY]) in v6 EvalScript —
+    // the eLTOO state ratchet, settlement CSV, and HTLC hashlock/timeout. PQ sigs stay on
+    // CSFS/keyhash. When inactive these opcodes remain no-ops (unchanged behaviour).
+    if (VersionBitsState(pindex->pprev, consensus, Consensus::DEPLOYMENT_V6_CONTROLFLOW, versionbitscache) == THRESHOLD_ACTIVE) {
+        flags |= SCRIPT_VERIFY_V6_CONTROLFLOW;
+    }
+
     // SATOSHI SCRIPT RESTORATION: Always-active on Soqucoin (genesis-active).
     // AND/OR/XOR/MUL/DIV/MOD/SUBSTR/LEFT/RIGHT re-enabled with BCH-style bounds.
     // No BIP9 gate needed — these are genesis-active like OP_CAT.

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -65,6 +65,11 @@ const struct BIP9DeploymentInfo VersionBitsDeploymentInfo[] = {
         // (gbt_vb_name) constructs std::string from null → crash on stagenet (ALWAYS_ACTIVE).
         /*.name =*/"dilithium_keyhash",
         /*.gbt_force =*/true,
+    },
+    {
+        // DL-V6-CONTROLFLOW-RESTORE: must match DEPLOYMENT_V6_CONTROLFLOW (params.h index 13).
+        /*.name =*/"v6_controlflow",
+        /*.gbt_force =*/true,
     }};
 
 // Compile-time guard: the VersionBitsDeploymentInfo array is indexed by the


### PR DESCRIPTION
## What

Phase 0 activation wiring for the B1 EvalScript change already on `main` (#13). That PR added the *handler* for `SCRIPT_VERIFY_V6_CONTROLFLOW` but nothing turns it on. This adds the BIP9 deployment that gates it, so the restored branch/timelock/hashlock opcodes (eLTOO ratchet, settlement CSV, HTLC hashlock/timeout) actually **enforce at block validation**.

Mirrors exactly how the sibling V6 flags (CTV/APO/CSFS/DILITHIUM_KEYHASH) are wired.

## Changes (4 files)

- **`consensus/params.h`** — `DEPLOYMENT_V6_CONTROLFLOW` enum entry. Bit **13** (0–12 and 28 are taken).
- **`versionbits.cpp`** — matching `VersionBitsDeploymentInfo` entry (`"v6_controlflow"`). Required: the compile-time guard fails without it, and a missing slot crashes `getblocktemplate` on stagenet (ALWAYS_ACTIVE).
- **`chainparams.cpp`** — **mainnet `nStartTime=0` (OFF, pending Halborn Phase 2)**; **testnet/regtest/stagenet `ALWAYS_ACTIVE`**.
- **`validation.cpp`** — `flags |= SCRIPT_VERIFY_V6_CONTROLFLOW` on `THRESHOLD_ACTIVE`, right after the `DILITHIUM_KEYHASH` gate.

## Deliberately NOT changed: `policy.h`

`SCRIPT_VERIFY_V6_CONTROLFLOW` is **not** added to `STANDARD_SCRIPT_VERIFY_FLAGS`, mirroring the sibling V6 covenant flags — they're consensus-active but **non-standard for relay** (the known §0.2-P0 gap; see `lightning_script_tests/ctv_nop4_discouraged_without_flag`). Adding it alone wouldn't make B1 txs relay anyway (the `OP_CHECKDILITHIUMKEYHASH` opcode keeps them non-standard). Relay-standardness for the whole V6 covenant set is a **separate policy decision**; the stagenet e2e submits via `-acceptnonstdtxn`, same as other covenant txs today.

## Tests / safety

- **Full unit suite: 564 cases green, no regressions.** versionbits compile-time guard passes.
- **Mainnet behaviour unchanged** — flag stays OFF (`nStartTime=0`), opcodes remain no-ops.
- Activation on stagenet happens at the coordinated **fleet reset** (runbook: `soqucoin-ops/lightning/STAGENET_V6_CONTROLFLOW_ACTIVATION_RUNBOOK.md`).

Branched off current `main` (not a sibling feature branch — avoids the stacked-PR retarget issue from #12/#13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)