### PR TITLE
policy: enforce/relay V6 covenant txs at the mempool (deployment-gated)

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1029,6 +1029,27 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
             scriptVerifyFlags = GetArg("-promiscuousmempoolflags", scriptVerifyFlags);
         }
 
+        // Relay + enforce V6 covenant txs that the NEXT block will enforce. STANDARD omits the V6
+        // covenant opcodes, so without this a B1/eLTOO (or CTV/CSFS/keyhash) tx is non-standard
+        // (won't relay) AND its covenant opcodes are no-ops at the mempool — e.g. OP_CLTV in a v6
+        // script wrongly passes a below-floor eLTOO spend that ConnectBlock rejects. OR-in the V6
+        // covenant flags gated by their BIP9 deployment (per-net), mirroring ConnectBlock: they are
+        // ALWAYS_ACTIVE on stagenet/regtest and nStartTime=0 (never) on mainnet, so this adds NOTHING
+        // on mainnet until activation — keeping mempool policy consistent with consensus.
+        {
+            const CBlockIndex* tipPrev = chainActive.Tip();
+            const Consensus::Params& cons = Params().GetConsensus(0);
+            auto v6active = [&](Consensus::DeploymentPos pos) {
+                return VersionBitsState(tipPrev, cons, pos, versionbitscache) == THRESHOLD_ACTIVE;
+            };
+            if (v6active(Consensus::DEPLOYMENT_CTV))               scriptVerifyFlags |= SCRIPT_VERIFY_CTV;
+            if (v6active(Consensus::DEPLOYMENT_APO))               scriptVerifyFlags |= SCRIPT_VERIFY_APO;
+            if (v6active(Consensus::DEPLOYMENT_CSFS))              scriptVerifyFlags |= SCRIPT_VERIFY_CSFS;
+            if (v6active(Consensus::DEPLOYMENT_P2WSH_DILITHIUM))   scriptVerifyFlags |= SCRIPT_VERIFY_P2WSH_DILITHIUM;
+            if (v6active(Consensus::DEPLOYMENT_DILITHIUM_KEYHASH)) scriptVerifyFlags |= SCRIPT_VERIFY_DILITHIUM_KEYHASH;
+            if (v6active(Consensus::DEPLOYMENT_V6_CONTROLFLOW))    scriptVerifyFlags |= SCRIPT_VERIFY_V6_CONTROLFLOW;
+        }
+
         // Check against previous transactions
         // This is done last to help prevent CPU exhaustion denial-of-service attacks.
         PrecomputedTransactionData txdata(tx);


### PR DESCRIPTION
## Why (the b1-canary "ratchet broken" alarm was a relay-policy gap, not a consensus bug)

`testmempoolaccept`/`AcceptToMemoryPool` verify scripts with `STANDARD_SCRIPT_VERIFY_FLAGS` (validation.cpp:1027), which contains **no V6 covenant flag**. So at the mempool layer the V6 covenant opcodes are no-ops — e.g. `OP_CLTV` in a v6 eLTOO script passes a **below-floor** update that `ConnectBlock` (consensus) correctly rejects. The b1 canary checked `testmempoolaccept` and wrongly read this as "OP_CLTV not enforced." Consensus enforces it fine; **the mempool doesn't relay or enforce V6 covenant txs** — the §0.2-P0 gap. For Lightning, B1 txs must relay.

## What

In `AcceptToMemoryPool`, OR-in the V6 covenant flags **gated by each BIP9 deployment's `VersionBitsState`**, mirroring `ConnectBlock`:
`CTV, APO, CSFS, P2WSH_DILITHIUM, DILITHIUM_KEYHASH, V6_CONTROLFLOW`.

Per-net by construction:
- **stagenet / regtest**: these are `ALWAYS_ACTIVE` → mempool now enforces + relays them, matching consensus.
- **mainnet**: `nStartTime=0` (never active) → the OR adds **nothing** until a deployment activates → zero mainnet behaviour change; mempool stays consistent with consensus.

## Safety

- **Not a consensus rule change** — only mempool relay policy. Block validity is unchanged → **no chain wipe**; just rebuild + redeploy the relaying nodes.
- Only newly *rejects* covenant txs that are **invalid for the next block anyway** (e.g. a below-floor eLTOO spend). Valid covenant txs now relay where they previously didn't.
- Full unit suite: **565 green**.

## Relation to the stagenet canary

This is the proper fix behind the b1-canary's step-3 finding. The **immediate** stagenet unblock is a config change (add bit 26 = `67108864` to the relaying node's `-promiscuousmempoolflags`); this PR makes it correct + default across nodes without per-node config.

> Proposal for review — consensus-adjacent (mempool policy). Do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)