### PR TITLE
docs: update source-tree docs to 47B emission schedule (c61 Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,9 +289,9 @@ This project follows [Bitcoin Core contribution guidelines](CONTRIBUTING.md):
 | **Ticker** | SOQ |
 | **Algorithm** | Scrypt |
 | **Block Time** | 1 minute |
-| **Initial Block Reward** | 500,000 SOQ |
-| **Halving Interval** | 100,000 blocks (~69 days) |
-| **Terminal Emission** | 10,000 SOQ perpetual (after block 600,000) |
+| **Initial Block Reward** | 100,000 SOQ |
+| **Halving Interval** | 250,000 blocks (~174 days) |
+| **Terminal Emission** | 2,500 SOQ perpetual (after block 1,000,000) |
 | **Supply Model** | Inflationary with declining rate |
 | **Premine** | 0 SOQ |
 

--- a/doc/GOVERNANCE.md
+++ b/doc/GOVERNANCE.md
@@ -116,10 +116,11 @@ Soqucoin follows Dogecoin's emission model with minor adjustments:
 
 | Height | Reward | Notes |
 |--------|--------|-------|
-| 0 - 99,999 | 500,000 SOQ | Genesis phase |
-| 100,000 - 199,999 | 250,000 SOQ | First halving |
-| 200,000 - 299,999 | 125,000 SOQ | Second halving |
-| 300,000+ | 10,000 SOQ | Perpetual tail emission |
+| 1 – 250,000 | 100,000 SOQ | Genesis phase |
+| 250,001 – 500,000 | 50,000 SOQ | First halving |
+| 500,001 – 750,000 | 25,000 SOQ | Second halving |
+| 750,001 – 1,000,000 | 12,500 SOQ | Third halving |
+| 1,000,001+ | 2,500 SOQ | Perpetual tail emission |
 
 ### Tail Emission Rationale
 
@@ -128,7 +129,7 @@ Like Dogecoin, Soqucoin uses **perpetual tail emission** (no supply cap) to:
 - Replace lost coins over time
 - Maintain transaction fee competitiveness
 
-**Annual Inflation:** ~5.26B SOQ (~3% decreasing annually)
+**Annual Inflation:** ~1.31B SOQ/year at tail (declining; ~2.7% at head completion)
 
 ---
 
@@ -202,7 +203,7 @@ See [INCIDENT_RESPONSE_PLAN.md](INCIDENT_RESPONSE_PLAN.md) for:
 | Consensus | SHA-256 (merged-mined) | Scrypt (AuxPoW capable) |
 | Signatures | ECDSA | **Dilithium (PQ-safe)** |
 | Block Time | 1 minute | 1 minute |
-| Tail Emission | 10,000 DOGE/block | 10,000 SOQ/block |
+| Tail Emission | 10,000 DOGE/block | 2,500 SOQ/block |
 | Governance | BIP9 soft forks | BIP9 soft forks |
 
 **Key Differentiator:** Soqucoin is the **first quantum-resistant Scrypt chain**.

--- a/doc/api-reference.md
+++ b/doc/api-reference.md
@@ -107,7 +107,7 @@ Creates a new block template for merged mining.
   "hash": "abc123...",
   "chainid": 21329,
   "previousblockhash": "def456...",
-  "coinbasevalue": 50000000000000,
+  "coinbasevalue": 10000000000000,
   "bits": "1e0fffff",
   "height": 1213,
   "_target": "00000fffff..."

--- a/doc/guides/FAQ.md
+++ b/doc/guides/FAQ.md
@@ -4,9 +4,9 @@
 
 Soqucoin uses a **perpetual emission model** (similar to Dogecoin) to ensure long-term miner incentives for network security:
 
-- **Initial block reward**: 500,000 SOQ
-- **Halvings**: Every 100,000 blocks (~70 days)
-- **Terminal emission**: 10,000 SOQ perpetual after block 600,000
+- **Initial block reward**: 100,000 SOQ
+- **Halvings**: Every 250,000 blocks (~174 days)
+- **Terminal emission**: 2,500 SOQ perpetual after block 1,000,000
 
 This inflationary model ensures miners always have incentive to secure the post-quantum network.
 
@@ -14,19 +14,17 @@ This inflationary model ensures miners always have incentive to secure the post-
 
 | Block Range | Block Reward | Timeline (~1 min blocks) |
 |-------------|-------------|--------------------------|
-| 0 – 99,999 | 500,000 SOQ | First ~70 days |
-| 100,000 – 199,999 | 250,000 SOQ | ~70 days |
-| 200,000 – 299,999 | 125,000 SOQ | ~70 days |
-| 300,000 – 399,999 | 62,500 SOQ | ~70 days |
-| 400,000 – 499,999 | 31,250 SOQ | ~70 days |
-| 500,000 – 599,999 | 15,625 SOQ | ~70 days |
-| **600,000+** | **10,000 SOQ (perpetual)** | **Forever** |
+| 1 – 250,000 | 100,000 SOQ | First ~174 days |
+| 250,001 – 500,000 | 50,000 SOQ | ~174 days |
+| 500,001 – 750,000 | 25,000 SOQ | ~174 days |
+| 750,001 – 1,000,000 | 12,500 SOQ | ~174 days |
+| **1,000,001+** | **2,500 SOQ (perpetual)** | **Forever** |
 
 **Key characteristics:**
-- **No hard cap** – perpetual emission after block 600,000
-- **100,000 block halving interval** (~70 days at 1-min blocks)
-- **~11.4 months** to reach terminal emission
-- **Terminal emission**: 10,000 SOQ/block = ~5.25B SOQ/year
+- **No hard cap** – perpetual emission after block 1,000,000
+- **250,000 block halving interval** (~174 days at 1-min blocks)
+- **~1.9 years** to reach terminal emission
+- **Terminal emission**: 2,500 SOQ/block = ~1.31B SOQ/year
 
 ## Where is the emission schedule defined?
 
@@ -61,13 +59,11 @@ Soqucoin uses the **Scrypt** proof-of-work algorithm with:
 
 | Block Range | Reward (SOQ) |
 |-------------|-------------:|
-| 0 – 99,999 | 500,000 |
-| 100,000 – 199,999 | 250,000 |
-| 200,000 – 299,999 | 125,000 |
-| 300,000 – 399,999 | 62,500 |
-| 400,000 – 499,999 | 31,250 |
-| 500,000 – 599,999 | 15,625 |
-| 600,000+ | 10,000 (perpetual) |
+| 1 – 250,000 | 100,000 |
+| 250,001 – 500,000 | 50,000 |
+| 500,001 – 750,000 | 25,000 |
+| 750,001 – 1,000,000 | 12,500 |
+| 1,000,001+ | 2,500 (perpetual) |
 
 ## Is there a mining pool?
 

--- a/doc/guides/mining-guide.md
+++ b/doc/guides/mining-guide.md
@@ -108,7 +108,7 @@ var SoqucoinNetwork = &AuxChain{
         User:       "soqurpc",
         Password:   "your_secure_password",
     },
-    BlockReward:    500000,     // Initial block reward
+    BlockReward:    100000,     // Initial block reward
     ConfirmBlocks:  100,        // Coinbase maturity
 }
 ```
@@ -135,13 +135,11 @@ soqucoin-cli getauxblock "blockhash" "auxpow_data"
 
 | Block Range | Reward (SOQ) | Notes |
 |-------------|--------------|-------|
-| 0 - 99,999 | 500,000 | Initial phase |
-| 100,000 - 199,999 | 250,000 | First halving |
-| 200,000 - 299,999 | 125,000 | Second halving |
-| 300,000 - 399,999 | 62,500 | Third halving |
-| 400,000 - 499,999 | 31,250 | Fourth halving |
-| 500,000 - 599,999 | 15,625 | Fifth halving |
-| 600,000+ | 10,000 | Terminal perpetual |
+| 1 - 250,000 | 100,000 | Initial phase |
+| 250,001 - 500,000 | 50,000 | First halving |
+| 500,001 - 750,000 | 25,000 | Second halving |
+| 750,001 - 1,000,000 | 12,500 | Third halving |
+| 1,000,001+ | 2,500 | Terminal perpetual |
 
 ### Block Time
 

--- a/doc/pool-integration.md
+++ b/doc/pool-integration.md
@@ -135,7 +135,7 @@ soqucoin-cli createauxblock ssq1p23ssp9dsfcxzn33msmfzsk723rg24h9j8lrdn4qtaezcztj
 #   "hash": "...",
 #   "chainid": 98,
 #   "previousblockhash": "...",
-#   "coinbasevalue": 50000000000000,
+#   "coinbasevalue": 10000000000000,
 #   "bits": "...",
 #   "height": 126,
 #   "_target": "..."
@@ -152,13 +152,11 @@ soqucoin-cli submitauxblock <hash> <serialized_auxpow>
 
 | Block Range | Subsidy (SOQ) | Phase |
 |-------------|---------------|-------|
-| 0 – 99,999 | 500,000 | Emission 1 |
-| 100,000 – 199,999 | 250,000 | Halving 1 |
-| 200,000 – 299,999 | 125,000 | Halving 2 |
-| 300,000 – 399,999 | 62,500 | Halving 3 |
-| 400,000 – 499,999 | 31,250 | Halving 4 |
-| 500,000 – 599,999 | 15,625 | Halving 5 |
-| 600,000+ | 10,000 | Perpetual tail emission |
+| 1 – 250,000 | 100,000 | Emission 1 |
+| 250,001 – 500,000 | 50,000 | Halving 1 |
+| 500,001 – 750,000 | 25,000 | Halving 2 |
+| 750,001 – 1,000,000 | 12,500 | Halving 3 |
+| 1,000,001+ | 2,500 | Perpetual tail emission |
 
 **Notes:**
 - Reward is 100% to miner (no dev tax, no foundation cut)

--- a/doc/specifications/CONSENSUS_COST_SPEC.md
+++ b/doc/specifications/CONSENSUS_COST_SPEC.md
@@ -194,7 +194,7 @@ This section explains **why** each modified parameter differs from Dogecoin's ba
 
 | Dogecoin | Soqucoin | Rationale |
 |----------|----------|-----------|
-| Blocks 0-100k: Random 0-1,000,000 DOGE | Blocks 0-100k: Fixed 500,000 SOQ | **Predictability** |
+| Blocks 0-100k: Random 0-1,000,000 DOGE | Blocks 1-250k: Fixed 100,000 SOQ | **Predictability** |
 
 Dogecoin's random block rewards were a "fun" feature reflecting its meme origins. For a serious post-quantum chain:
 - Miners and investors require **predictable economic models**
@@ -205,12 +205,12 @@ Dogecoin's random block rewards were a "fun" feature reflecting its meme origins
 
 | Dogecoin | Soqucoin | Rationale |
 |----------|----------|-----------|
-| 10,000 DOGE perpetual (after block 600k) | 10,000 SOQ perpetual (after block 600k) | **Miner incentive sustainability** |
+| 10,000 DOGE perpetual (after block 600k) | 2,500 SOQ perpetual (after block 1,000,000) | **Miner incentive sustainability** |
 
-Both chains converge to **identical terminal emission**: 10,000 tokens/block indefinitely. This is intentional:
+Both chains adopt **perpetual tail emission**, but Soqucoin uses a smaller 2,500 SOQ/block tail (vs Dogecoin's 10,000 DOGE/block) and begins it later, after block 1,000,000. This is intentional:
 - Perpetual inflation ensures ongoing miner incentives
 - Prevents "fee-only" security model concerns
-- Aligns with Dogecoin's proven long-term approach
+- Aligns with Dogecoin's proven long-term approach while keeping tail inflation lower
 
 ### 2.3 Fee Structure: Placeholder for Mainnet Economics
 
@@ -424,13 +424,13 @@ Standard Bitcoin witness limits were designed for ECDSA (~72 byte signatures). D
 |-----------|-------|--------|
 | **Block Time Target** | 60 seconds | Inherited (Dogecoin) |
 | **Difficulty Adjustment** | Every block (DigiShield) | Inherited (Dogecoin) |
-| **Halving Interval** | 100,000 blocks (~69 days)¹ | Modified (Soqucoin) |
-| **Initial Block Reward** | 500,000 SOQ | Modified (Soqucoin) |
-| **Terminal Reward** | 10,000 SOQ (after block 600,000) | Modified (Soqucoin) |
+| **Halving Interval** | 250,000 blocks (~174 days)¹ | Modified (Soqucoin) |
+| **Initial Block Reward** | 100,000 SOQ | Modified (Soqucoin) |
+| **Terminal Reward** | 2,500 SOQ (after block 1,000,000) | Modified (Soqucoin) |
 | **Coinbase Maturity** | 30 blocks | Modified (Soqucoin) |
 | **AuxPoW Chain ID** | 0x5351 (21329 decimal) | Novel (Soqucoin) |
 
-> ¹ Calculation: 100,000 blocks × 60 seconds = 6,000,000 seconds ≈ 69.4 days at target. Actual time varies with hashrate.
+> ¹ Calculation: 250,000 blocks × 60 seconds = 15,000,000 seconds ≈ 173.6 days at target. Actual time varies with hashrate.
 
 ---
 
@@ -646,13 +646,11 @@ All values are defined in the Soqucoin Core source code at the following paths:
 
 | Block Range | Reward per Block | Cumulative Supply |
 |-------------|------------------|-------------------|
-| 0 - 100,000 | 500,000 SOQ | 50 billion SOQ |
-| 100,001 - 200,000 | 250,000 SOQ | 75 billion SOQ |
-| 200,001 - 300,000 | 125,000 SOQ | 87.5 billion SOQ |
-| 300,001 - 400,000 | 62,500 SOQ | 93.75 billion SOQ |
-| 400,001 - 500,000 | 31,250 SOQ | 96.875 billion SOQ |
-| 500,001 - 600,000 | 15,625 SOQ | 98.4375 billion SOQ |
-| 600,001+ | 10,000 SOQ | Perpetual inflation |
+| 1 - 250,000 | 100,000 SOQ | 25 billion SOQ |
+| 250,001 - 500,000 | 50,000 SOQ | 37.5 billion SOQ |
+| 500,001 - 750,000 | 25,000 SOQ | 43.75 billion SOQ |
+| 750,001 - 1,000,000 | 12,500 SOQ | 46.875 billion SOQ |
+| 1,000,001+ | 2,500 SOQ | Perpetual inflation (~1.31B SOQ/year) |
 
 ### Allocations
 

--- a/doc/stagenet-mining-guide.md
+++ b/doc/stagenet-mining-guide.md
@@ -3,7 +3,7 @@
 > **Network**: Stagenet (pre-mainnet testing environment)  
 > **Algorithm**: Scrypt (Litecoin/Dogecoin compatible — AuxPoW merge-mining ready)  
 > **Block time**: ~60 seconds  
-> **Initial reward**: 500,000 SOQ/block (halving every 100,000 blocks)  
+> **Initial reward**: 100,000 SOQ/block (halving every 250,000 blocks)  
 > **Pool**: `stratum+tcp://64.23.197.144:3333`  
 > **Explorer**: Coming soon
 
@@ -211,8 +211,8 @@ Payouts are processed every 10 minutes via PPLNS. Minimum payout: 1 SOQ.
 | PoW Algorithm | Scrypt |
 | AuxPoW | Enabled (merge-mining ready) |
 | Block Time | ~60 seconds |
-| Initial Subsidy | 500,000 SOQ |
-| Halving Interval | 100,000 blocks |
+| Initial Subsidy | 100,000 SOQ |
+| Halving Interval | 250,000 blocks |
 | Consensus Features | Dilithium signatures, USDSOQ opcodes, Lattice-BP++ privacy (BIP9-gated) |
 
 ### Seed Nodes


### PR DESCRIPTION
Propagates the locked **47B Moderate emission** (consensus PR #18) into the repo's published documentation. Docs-only — no code changes.

**New schedule reflected everywhere:** 100,000 SOQ launch · 250,000-block halvings (~174 days) · 4 epochs (100K→50K→25K→12.5K) · perpetual 2,500 SOQ tail from block 1,000,001 · ~46.875B head over ~1.9 years · no hard cap.

**Updated (8 files):**
- `README.md` — tokenomics table
- `doc/GOVERNANCE.md` — emission table (was malformed), annual-inflation figure, Dogecoin tail comparison
- `doc/stagenet-mining-guide.md` — header + params table
- `doc/pool-integration.md` — coinbasevalue example + schedule table
- `doc/api-reference.md` — coinbasevalue example
- `doc/specifications/CONSENSUS_COST_SPEC.md` — §2.1/§2.2/§7 + appendix table (incl. the now-corrected note that SOQ's 2,500 tail no longer equals Dogecoin's 10,000)
- `doc/guides/FAQ.md` — emission bullets + two schedule tables
- `doc/guides/mining-guide.md` — config example + schedule table

**Deliberately left intact:**
- `RELEASE_NOTES_v1.0.0-rc1.md` — historical record of that release; not rewritten.
- False positives verified and skipped: benchmark counts, wallet test-vector satoshi values, PBKDF2 iteration counts, exchange confirmation thresholds, solo-miner `pool_difficulty`.

**Verification:** residual grep clean across all 8 files; new tables spot-checked (correct cumulative 25/37.5/43.75/46.875B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)