### PR TITLE
chore: redact provisional patent serial numbers

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -32,7 +32,7 @@ third-party source code.
 
 | Path | Module | License | Notes |
 |------|--------|---------|-------|
-| `src/crypto/latticebp/` | Lattice-BP++ (confidential tx primitives) | MIT + **patent-pending** | U.S. Provisional No. 63/999,796 + No. 64/023,515; see [`LICENSE`](src/crypto/latticebp/LICENSE) |
+| `src/crypto/latticebp/` | Lattice-BP++ (confidential tx primitives) | MIT + **patent-pending** | Patent pending (provisional serials withheld); see [`LICENSE`](src/crypto/latticebp/LICENSE) |
 | `src/crypto/latticefold/` | LatticeFold+ verifier (Dilithium batch verify) | MIT | Halborn-remediated |
 | `src/crypto/binius/` | Binius binary-field commitments | MIT | Foundation for Sangria |
 | `src/crypto/binius64/` | GF(2^128) field arithmetic | MIT | Halborn-remediated (SOQ-A001..A004) |
@@ -44,5 +44,5 @@ third-party source code.
 - Per-directory `LICENSE` files state the authoritative terms for each module.
 - The CI `license-check` job (`.github/workflows/license-check.yml`) asserts that
   every cryptographic module directory carries a `LICENSE`.
-- The latticebp patent notice references U.S. Provisional Patent Application
-  No. 63/999,796 (2025) and No. 64/023,515 (2026), both filed by Soqucoin Labs Inc.
+- The latticebp patent notice references two pending U.S. provisional patent
+  applications (filed 2025 and 2026) by Soqucoin Labs Inc.; serial numbers are withheld.

--- a/src/crypto/latticebp/LICENSE
+++ b/src/crypto/latticebp/LICENSE
@@ -17,12 +17,11 @@ third-party source code.
 
 PATENT NOTICE — Patent Pending
 ------------------------------
-Lattice-BP++ is the subject of the following pending U.S. provisional patent
-applications by Soqucoin Labs Inc.:
+Lattice-BP++ is the subject of pending U.S. provisional patent applications by
+Soqucoin Labs Inc. (serial numbers withheld pending non-provisional filing):
 
-  - No. 63/999,796 — "Post-Quantum Cryptographic Architecture for Blockchain
-    Networks" (filed 2025)
-  - No. 64/023,515 — "Lattice-BP++ Post-Quantum Privacy" (filed 2026)
+  - "Post-Quantum Cryptographic Architecture for Blockchain Networks" (filed 2025)
+  - "Lattice-BP++ Post-Quantum Privacy" (filed 2026)
 
 The MIT copyright license above governs the copyright in this source code; it
 does not itself grant any rights under those patents. This notice is


### PR DESCRIPTION
Removes specific U.S. provisional serial numbers from ATTRIBUTION.md and src/crypto/latticebp/LICENSE, keeping the patent-pending status and public invention titles. Consistent with the redaction applied to the whitepapers and docs site. Per Casey's call to redact all serials for consistency until non-provisional filing.