### PR TITLE
docs: sync exchange finality guidance to the 288-block rule

### DIFF
--- a/doc/guides/EXCHANGE_INTEGRATION_GUIDE.md
+++ b/doc/guides/EXCHANGE_INTEGRATION_GUIDE.md
@@ -219,9 +219,10 @@ soqucoin-cli listtransactions "*" 100 0 true | jq '.[] | select(.category == "re
 |------------------|---------------------------|
 | < 1,000 SOQ | 6 confirmations (~6 min) |
 | 1,000 - 10,000 SOQ | 12 confirmations (~12 min) |
-| > 10,000 SOQ | 24+ confirmations (~24 min) |
+| 10,000 - 100,000 SOQ | 24 confirmations (~24 min) |
+| Large value / final settlement | **288 confirmations (~4.8h — absolute finality)** |
 
-> **Note**: With 1-minute block times and merged mining, 6 confirmations provides strong finality for most transactions.
+> **Note**: Below 288 blocks, confirmations are **probabilistic** — more confirmations lower the reversal risk, but a large hashpower rental can still reorganize recent blocks. At **288 blocks (~4.8h)** finality becomes **absolute**: the network rejects any reorg deeper than 288 blocks (`nMaxReorgDepth`), so a buried transaction cannot be reversed by hashpower. **Do not credit large deposits on a handful of confirmations** — wait for the 288-block finality horizon for high-value settlement. See [Chain Finality](https://soqu.org/docs/protocol/finality/) for the full properties and tradeoffs.
 
 ---
 


### PR DESCRIPTION
The exchange integration guide claimed *6 confirmations provides strong finality* (probabilistic-only). Soqucoin enforces a 288-block (~4.8h) hard finality rule (`nMaxReorgDepth`). Updated the confirmation table (added a 288-conf final-settlement tier) and the note to explain the probabilistic-then-absolute model, linking the new Chain Finality docs page.

Part of the consensus-doc sync ahead of the emission/finality public announcement (bead c61 Phase 2).