### PR TITLE
docs: sync 288-block finality to consensus spec + correct stale emission comments

### DIFF
--- a/doc/specifications/CONSENSUS_COST_SPEC.md
+++ b/doc/specifications/CONSENSUS_COST_SPEC.md
@@ -1,7 +1,7 @@
 # Soqucoin Protocol Parameters & Consensus Cost Specification
 
 > **Version**: 4.1 | **Status**: Pre-Mainnet
-> **Last Updated**: May 25, 2026
+> **Last Updated**: July 2, 2026
 > **Specification Tag**: Mainnet Candidate v1.0.0-rc4
 > **Prepared For**: Halborn Security Audit (Hossam Mohamed, Alexis Fabre)
 
@@ -428,6 +428,7 @@ Standard Bitcoin witness limits were designed for ECDSA (~72 byte signatures). D
 | **Initial Block Reward** | 100,000 SOQ | Modified (Soqucoin) |
 | **Terminal Reward** | 2,500 SOQ (after block 1,000,000) | Modified (Soqucoin) |
 | **Coinbase Maturity** | 30 blocks | Modified (Soqucoin) |
+| **Finality Horizon** | 288 blocks (~4.8h), via `nMaxReorgDepth` | Novel (Soqucoin) |
 | **AuxPoW Chain ID** | 0x5351 (21329 decimal) | Novel (Soqucoin) |
 
 > ¹ Calculation: 250,000 blocks × 60 seconds = 15,000,000 seconds ≈ 173.6 days at target. Actual time varies with hashrate.
@@ -634,7 +635,7 @@ All values are defined in the Soqucoin Core source code at the following paths:
 
 ### Known Limitations
 
-- **Long-range reorg under low AuxPoW participation**: Mitigated by monitoring, checkpoints (if needed)
+- **Long-range reorg under low AuxPoW participation**: Bounded by a hard finality rule. Nodes refuse any reorg deeper than `nMaxReorgDepth` = 288 blocks (~4.8h at 1-min spacing), well above any natural reorg depth. Supplemented by monitoring.
 - **Novel cryptography risk**: LatticeFold is research-grade; staged activation provides buffer
 - **Fee economics pre-market**: Policy parameters are placeholders pending real market data
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -167,7 +167,7 @@ public:
         // double-spend window; must stay well above the deepest natural reorg).
         // Propagates into digishieldConsensus via the copy below.
         consensus.nMaxReorgDepth = 288;
-        consensus.fSimplifiedRewards = true; // Fixed 500K SOQ/block from genesis (no Dogecoin random rewards)
+        consensus.fSimplifiedRewards = true; // Deterministic subsidy: 100,000 SOQ initial, 47B/250k-halving schedule (no Dogecoin random rewards); see GetSoqucoinBlockSubsidy
         consensus.fPowAllowMinDifficultyBlocks = false;
         consensus.fPowAllowDigishieldMinDifficultyBlocks = false;
         consensus.fPowNoRetargeting = false;
@@ -994,7 +994,7 @@ public:
         // Stagenet Genesis Block - April 2026 (v3 — Phase 4 byte-less CTxOut re-mine)
         // Unique genesis isolates Stagenet from all other networks
         // Timestamp: 1745769600 = 2026-04-27 12:00:00 UTC
-        // Reward: 500,000 SOQ (matches mainnet emission schedule)
+        // Reward: 500,000 SOQ (stagenet test value; mainnet initial subsidy is 100,000 SOQ)
         // Nonce re-mined 2026-06-16 after Phase 4 CTxOut byte removal (DL-GENESIS-REMINE.md)
         // Scrypt PoW: 0000023c1d9d18db4abcb57b77efda4968cc3ee0e273870889d7381757c211cc
         genesis = CreateGenesisBlockStagenet(1745769600, 1215028, 0x1e0ffff0, 1, 500000 * COIN);


### PR DESCRIPTION
Documentation sync for the 288-block finality rule (`nMaxReorgDepth = 288`, already live in code) plus correction of stale emission comments found during an ecosystem-wide emission-figure sweep.

## Changes

**`doc/specifications/CONSENSUS_COST_SPEC.md`**
- Added a **Finality Horizon** row to the chain-parameters table: `288 blocks (~4.8h), via nMaxReorgDepth`.
- Replaced the stale long-range-reorg limitation ("Mitigated by monitoring, checkpoints if needed") with the hard finality rule the code actually enforces.
- Bumped Last Updated to July 2, 2026.
- (Earlier commit on this branch: synced the exchange-integration finality guidance to the 288-block rule.)

**`src/chainparams.cpp`** (comment-only, no consensus behavior change)
- Mainnet: the subsidy comment claimed "500K SOQ/block from genesis" (a stagenet value). Corrected to the real 100,000 SOQ / 47B halving schedule.
- Stagenet: the comment claimed 500,000 SOQ "matches mainnet emission schedule" — false (mainnet is 100,000). Clarified as the stagenet test value.

## Not changed (deliberately)
- The consensus spec's emission/tokenomics section (100,000 launch, 250,000-block halving, 2,500 tail, 46.875B head, no premine) was already correct.
- `CHANGELOG.md` and `RELEASE_NOTES_v1.0.0-rc1.md` retain their 500K text as **version-pinned history** — the initial release predated the June 47B change, so those are historically accurate and were not rewritten.

Verified: no residual wrong emission strings in the edited files; `go`/build unaffected (doc + comment-only).