### PR TITLE
consensus: gate CDKH/CSFS sigop counting on BIP9 activation flags (beads 05n + b9a)

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1104,9 +1104,11 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
 //     → 1 sigop. Implicit single-key Dilithium verify.
 //
 //   Witness v0, 32-byte program (P2WSH — Dilithium script hash):
-//     → Count OP_CHECKSIG + OP_CHECKSIGVERIFY + OP_CHECKSIGFROMSTACK in
-//       the witness script (last witness stack item). Each = 1 sigop.
+//     → Count sig-verification opcodes in the witness script (last witness
+//       stack item). OP_CHECKSIG/OP_CHECKSIGVERIFY = 1 sigop each;
 //       OP_CHECKMULTISIG = N sigops where N is the key count pushdata.
+//       OP_CHECKSIGFROMSTACK / OP_CHECKDILITHIUMKEYHASH = 1 sigop each,
+//       but ONLY under their activation flags (see below).
 //
 //   Witness v1..v5 (PAT, LatticeFold, Lattice-BP++, USDSOQ authority):
 //     → 1 sigop per input. These programs perform at most one aggregate
@@ -1121,14 +1123,52 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
 //   (OP_HASH160, OP_SHA256, OP_CHECKTEMPLATEVERIFY) carry no sigop weight.
 //   This matches Bitcoin Core's treatment of non-sig opcodes.
 //
-// CSFS (OP_NOP5) and OP_CHECKDILITHIUMKEYHASH (OP_NOP7) contribution:
-//   counted via GetSigOpCount() on the witness script, which detects
-//   OP_CHECKSIGFROMSTACK and OP_CHECKDILITHIUMKEYHASH alongside OP_CHECKSIG.
-//   Each occurrence costs 1 sigop (one Dilithium verification).
+// CSFS (OP_NOP5) and OP_CHECKDILITHIUMKEYHASH (OP_NOP7) contribution (bead 05n):
+//   1 sigop each (one Dilithium verification), counted by the flag-aware
+//   CountWitnessScriptSigOps below — ONLY when SCRIPT_VERIFY_CSFS /
+//   SCRIPT_VERIFY_DILITHIUM_KEYHASH is set, so the cost flips atomically with
+//   the BIP9 activation of the opcodes. Pre-activation they are NOPs and cost
+//   0, identical to the legacy CScript::GetSigOpCount(true) count. The legacy
+//   counter itself takes no flags and deliberately stays uncounting: this
+//   count feeds GetTransactionSigOpCost → MAX_BLOCK_SIGOPS_COST (block
+//   validity), so an unconditional count would split upgraded vs non-upgraded
+//   nodes on the witness-v0 P2WSH path.
 //
 // APO (sighash-level feature): 0 additional sigops.
 //   APO modifies the message being signed, not the number of verifications.
 //   The containing OP_CHECKSIG already contributes its sigop.
+// Flag-aware sigop count for a witness script (bead 05n). Matches
+// CScript::GetSigOpCount(true) exactly when neither activation flag is set;
+// additionally charges 1 sigop per OP_CHECKSIGFROMSTACK[VERIFY] under
+// SCRIPT_VERIFY_CSFS and per OP_CHECKDILITHIUMKEYHASH under
+// SCRIPT_VERIFY_DILITHIUM_KEYHASH.
+static size_t CountWitnessScriptSigOps(const CScript& script, unsigned int flags)
+{
+    size_t n = 0;
+    CScript::const_iterator pc = script.begin();
+    opcodetype lastOpcode = OP_INVALIDOPCODE;
+    while (pc < script.end()) {
+        opcodetype opcode;
+        if (!script.GetOp(pc, opcode))
+            break;
+        if (opcode == OP_CHECKSIG || opcode == OP_CHECKSIGVERIFY) {
+            n++;
+        } else if (opcode == OP_CHECKMULTISIG || opcode == OP_CHECKMULTISIGVERIFY) {
+            if (lastOpcode >= OP_1 && lastOpcode <= OP_16)
+                n += CScript::DecodeOP_N(lastOpcode);
+            else
+                n += MAX_PUBKEYS_PER_MULTISIG;
+        } else if ((flags & SCRIPT_VERIFY_CSFS) && opcode == OP_CHECKSIGFROMSTACK) {
+            // Covers OP_CHECKSIGFROMSTACKVERIFY too (same byte, OP_NOP5).
+            n++;
+        } else if ((flags & SCRIPT_VERIFY_DILITHIUM_KEYHASH) && opcode == OP_CHECKDILITHIUMKEYHASH) {
+            n++;
+        }
+        lastOpcode = opcode;
+    }
+    return n;
+}
+
 size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, unsigned int flags)
 {
     static const size_t SIGOPS_PER_CHECKSIG = 1;
@@ -1153,12 +1193,14 @@ size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey,
                 // P2WSH: count sig-verification opcodes in the witness script
                 // The witness script is always the last stack item.
                 // SECURITY NOTE (SOQ-COV-010): We count OP_CHECKSIG,
-                // OP_CHECKSIGVERIFY, OP_CHECKSIGFROMSTACK, and
-                // OP_CHECKMULTISIG/VERIFY in the redeemScript. CTV (OP_NOP4)
-                // and APO sighash types do NOT contribute additional sigops.
+                // OP_CHECKSIGVERIFY, and OP_CHECKMULTISIG/VERIFY in the
+                // redeemScript, plus OP_CHECKSIGFROMSTACK and
+                // OP_CHECKDILITHIUMKEYHASH under their activation flags
+                // (bead 05n). CTV (OP_NOP4) and APO sighash types do NOT
+                // contribute additional sigops.
                 const std::vector<unsigned char>& scriptBytes = witness->stack.back();
                 CScript witnessScript(scriptBytes.begin(), scriptBytes.end());
-                return witnessScript.GetSigOpCount(true);
+                return CountWitnessScriptSigOps(witnessScript, flags);
             }
             // Witness v0 with unrecognized program size: 0 sigops (invalid but non-fatal here)
             return 0;
@@ -1182,7 +1224,7 @@ size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey,
             if (flags & SCRIPT_VERIFY_P2WSH_DILITHIUM) {
                 const std::vector<unsigned char>& scriptBytes = witness->stack[witness->stack.size() - 2];
                 CScript witnessScript(scriptBytes.begin(), scriptBytes.end());
-                return witnessScript.GetSigOpCount(true);
+                return CountWitnessScriptSigOps(witnessScript, flags);
             }
             // Flag not active: charge 0 (anyone-can-spend, no script executed)
             return 0;

--- a/src/test/dilithium_keyhash_tests.cpp
+++ b/src/test/dilithium_keyhash_tests.cpp
@@ -309,28 +309,73 @@ BOOST_AUTO_TEST_CASE(keyhash_opcode_and_flag_constants)
     BOOST_CHECK_EQUAL(std::string(GetOpName(OP_CHECKDILITHIUMKEYHASH)),
                       std::string("OP_CHECKDILITHIUMKEYHASH"));
 
-    // GetSigOpCount — sigop accounting for OP_CHECKDILITHIUMKEYHASH / OP_CHECKSIGFROMSTACK.
+    // Sigop accounting for OP_CHECKDILITHIUMKEYHASH / OP_CHECKSIGFROMSTACK
+    // (soqucoin-build-05n, gated counting).
     //
-    // DEFERRED (soqucoin-build-05n). Counting these opcodes as sigops is a consensus
-    // rule change: CScript::GetSigOpCount feeds GetTransactionSigOpCost, checked vs
-    // MAX_BLOCK_SIGOPS_COST (block validity). The legacy counter takes no activation
-    // flags, so making it count them UNCONDITIONALLY would value blocks differently on
-    // upgraded vs non-upgraded nodes (witness-v0 P2WSH path) → chain split. The count
-    // must instead flip atomically with the BIP9 activation of the opcodes
-    // (SCRIPT_VERIFY_DILITHIUM_KEYHASH / SCRIPT_VERIFY_CSFS), implemented in the
-    // flag-aware witness path and shipped bundled with mainnet activation
-    // (Halborn Phase 2, not yet scheduled). Mainnet opcodes are not active yet.
-    //
-    // Until that lands, the legacy counter intentionally does NOT count them. We assert
-    // that current (pre-gated) behavior so this stays an active guard: any change to the
-    // count must consciously confront the gating decision above, not slip in ungated.
+    // The legacy CScript::GetSigOpCount takes no activation flags, so it must
+    // NEVER count these opcodes: it feeds GetTransactionSigOpCost, checked vs
+    // MAX_BLOCK_SIGOPS_COST (block validity), and an unconditional count would
+    // value blocks differently on upgraded vs non-upgraded nodes (witness-v0
+    // P2WSH path) → chain split. These asserts are a permanent guard, not a TODO.
     CScript script;
     script << OP_CHECKDILITHIUMKEYHASH;
-    BOOST_CHECK_EQUAL(script.GetSigOpCount(true), 0u);  // TODO(soqucoin-build-05n): -> 1u under gated counting
+    BOOST_CHECK_EQUAL(script.GetSigOpCount(true), 0u);  // permanent: legacy counter is flag-blind
 
     CScript multiSigOp;
     multiSigOp << OP_CHECKSIG << OP_CHECKDILITHIUMKEYHASH << OP_CHECKSIGFROMSTACK;
-    BOOST_CHECK_EQUAL(multiSigOp.GetSigOpCount(true), 1u);  // TODO(soqucoin-build-05n): -> 3u (CHECKSIG+CDKH+CSFS) under gated counting
+    BOOST_CHECK_EQUAL(multiSigOp.GetSigOpCount(true), 1u);  // permanent: only OP_CHECKSIG counted
+
+    // The gated count lives in the witness path (CountWitnessSigOps), which
+    // receives the activation flags and so flips atomically with the BIP9
+    // activation of SCRIPT_VERIFY_DILITHIUM_KEYHASH / SCRIPT_VERIFY_CSFS.
+    // Exercise it through a witness-v0 P2WSH program (script = last stack item).
+    {
+        std::vector<unsigned char> wsBytes(multiSigOp.begin(), multiSigOp.end());
+        CScript scriptSig;
+        CScript scriptPubKey;
+        scriptPubKey << OP_0 << std::vector<unsigned char>(32, 0xcc); // P2WSH
+        CScriptWitness witness;
+        witness.stack.push_back(std::vector<unsigned char>(2420, 0x01)); // dummy sig
+        witness.stack.push_back(wsBytes);
+
+        // Pre-activation: CDKH/CSFS are NOPs, cost 0 — only OP_CHECKSIG counts.
+        BOOST_CHECK_EQUAL(CountWitnessSigOps(scriptSig, scriptPubKey, &witness,
+                                             SCRIPT_VERIFY_WITNESS), 1u);
+        // Each flag adds exactly its own opcode's verification cost.
+        BOOST_CHECK_EQUAL(CountWitnessSigOps(scriptSig, scriptPubKey, &witness,
+                                             SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_CSFS), 2u);
+        BOOST_CHECK_EQUAL(CountWitnessSigOps(scriptSig, scriptPubKey, &witness,
+                                             SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_DILITHIUM_KEYHASH), 2u);
+        // Both active: CHECKSIG + CDKH + CSFS = 3 Dilithium verifications.
+        BOOST_CHECK_EQUAL(CountWitnessSigOps(scriptSig, scriptPubKey, &witness,
+                                             SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_CSFS |
+                                             SCRIPT_VERIFY_DILITHIUM_KEYHASH), 3u);
+    }
+
+    // Same accounting on the witness-v6 (P2WSH-Dilithium) path: the eLTOO
+    // funding script is 2x CDKH, witnessScript = second-to-last stack item.
+    {
+        CScript fundingScript;
+        fundingScript << OP_CHECKDILITHIUMKEYHASH << OP_CHECKDILITHIUMKEYHASH;
+        std::vector<unsigned char> wsBytes(fundingScript.begin(), fundingScript.end());
+        CScript scriptSig;
+        CScript scriptPubKey;
+        scriptPubKey << OP_6 << std::vector<unsigned char>(32, 0xdd); // witness v6
+        CScriptWitness witness;
+        witness.stack.push_back(wsBytes);
+        witness.stack.push_back(std::vector<unsigned char>(1312, 0x02)); // dummy pubkey (last)
+
+        // v6 script execution not active: anyone-can-spend, 0 sigops.
+        BOOST_CHECK_EQUAL(CountWitnessSigOps(scriptSig, scriptPubKey, &witness,
+                                             SCRIPT_VERIFY_WITNESS), 0u);
+        // v6 active but keyhash not: CDKH still a NOP, 0 sigops.
+        BOOST_CHECK_EQUAL(CountWitnessSigOps(scriptSig, scriptPubKey, &witness,
+                                             SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2WSH_DILITHIUM), 0u);
+        // v6 + keyhash active: 2 Dilithium verifications = 2 sigops.
+        BOOST_CHECK_EQUAL(CountWitnessSigOps(scriptSig, scriptPubKey, &witness,
+                                             SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2WSH_DILITHIUM |
+                                             SCRIPT_VERIFY_DILITHIUM_KEYHASH), 2u);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## What

Implements bead `soqucoin-build-05n` (Option B step 2, the design Casey approved 2026-06-19) and fixes `soqucoin-build-b9a`.

`OP_CHECKDILITHIUMKEYHASH` and `OP_CHECKSIGFROMSTACK` each perform one Dilithium verification but currently cost **0 sigops** — a block can pack unbounded PQ verifications without touching the 80,000 sigop-cost budget. This is live on stagenet (opcodes ALWAYS_ACTIVE) and a Halborn-class DoS finding.

## How

- New flag-aware `CountWitnessScriptSigOps` helper in interpreter.cpp, used by `CountWitnessSigOps` on both the witness-v0 P2WSH path and the witness-v6 P2WSH-Dilithium path. Charges 1 sigop per CDKH under `SCRIPT_VERIFY_DILITHIUM_KEYHASH` and per CSFS under `SCRIPT_VERIFY_CSFS` — the cost **flips atomically with the BIP9 activation** of the opcodes (validation.cpp already maps deployments → flags for block validation).
- The flag-blind legacy `CScript::GetSigOpCount` is deliberately untouched: an unconditional count there would value blocks differently on upgraded vs non-upgraded nodes = chain split. The tests now assert that as **permanent** behavior, not a TODO.
- Corrects the `CountWitnessSigOps` comment that falsely claimed `GetSigOpCount` already counted these opcodes (bead b9a).
- Test 8 in dilithium_keyhash_tests now exercises the gated path through the public `CountWitnessSigOps` seam: flags off → old counts; per-flag → each opcode adds its own cost; v6 eLTOO funding script (2×CDKH) → 2 sigops under v6+keyhash flags.

## Consensus impact

- **Mainnet: none.** The deployments are not active (`nStartTime=0`, pending Halborn Phase 2).
- **Stagenet/testnet/regtest: counting activates immediately on upgraded nodes** (flags ALWAYS_ACTIVE). A mixed fleet only diverges if a block's v6/CDKH content approaches the 80,000 budget — impossible organically today, constructible adversarially. **Deploy to the stagenet fleet lockstep** (same runbook pattern as v1.3.0).

## Verification

- `dilithium_keyhash_tests` (8 cases) + `covenant_tests` (51 cases) green.
- Full unit suite green: **565 cases, no errors detected** (macOS/clang).
- Linux/GCC CI on this PR is the cross-platform gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)