### PR TITLE
consensus: testnet AuxPoW from genesis — drop stale Dogecoin tier ladder (bead lnq)

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -397,7 +397,6 @@ class CTestNetParams : public CChainParams
 private:
     Consensus::Params digishieldConsensus;
     Consensus::Params auxpowConsensus;
-    Consensus::Params minDifficultyConsensus;
 
 public:
     CTestNetParams()
@@ -511,37 +510,34 @@ public:
         consensus.fStrictChainId = false;  // Allow legacy blocks without embedded chain ID
         consensus.nHeightEffective = 0;
         consensus.fAllowLegacyBlocks = true; // Allow both legacy Scrypt AND AuxPoW blocks
-        consensus.nAuxpowStartHeight = 158100; // Match auxpowConsensus.nHeightEffective
+        consensus.nAuxpowStartHeight = 0;    // AuxPoW from genesis — mirror mainnet (bead lnq)
 
-        // Blocks 145000 - 157499 are Digishield without minimum difficulty on all blocks
+        // DigiShield + AuxPoW from block 1 — mirrors mainnet's merged tier.
+        // (bead soqucoin-build-lnq: the previous 145000/157500/158100 tier
+        // ladder was un-customized Dogecoin testnet history, meaningless on
+        // Soqucoin's own genesis. Testnet3 is retired in favor of stagenet,
+        // so this has no live-network impact; aligned to the mainnet design
+        // for a possible future re-mine.)
         digishieldConsensus = consensus;
-        digishieldConsensus.nHeightEffective = 145000;
+        digishieldConsensus.nHeightEffective = 1;
         digishieldConsensus.nPowTargetTimespan = 60; // post-digishield: 1 minute
         digishieldConsensus.fDigishieldDifficultyCalculation = true;
         digishieldConsensus.fSimplifiedRewards = true;
-        digishieldConsensus.fPowAllowMinDifficultyBlocks = false;
         digishieldConsensus.nCoinbaseMaturity = 240;
-        digishieldConsensus.dilithiumOnlyHeight = 0;
+        // Testnet keeps the min-difficulty testing allowances (terminal state
+        // of the old 157500+ tiers).
+        digishieldConsensus.fPowAllowDigishieldMinDifficultyBlocks = true;
+        digishieldConsensus.fPowAllowMinDifficultyBlocks = true;
 
-        // Blocks 157500 - 158099 are Digishield with minimum difficulty on all blocks
-        minDifficultyConsensus = digishieldConsensus;
-        minDifficultyConsensus.nHeightEffective = 157500;
-        minDifficultyConsensus.fPowAllowDigishieldMinDifficultyBlocks = true;
-        minDifficultyConsensus.fPowAllowMinDifficultyBlocks = true;
-        minDifficultyConsensus.dilithiumOnlyHeight = 0;
-
-        // Enable AuxPoW at 158100
-        auxpowConsensus = minDifficultyConsensus;
-        auxpowConsensus.nHeightEffective = 158100;
-        auxpowConsensus.fPowAllowDigishieldMinDifficultyBlocks = true;
+        // AuxPoW shares the block-1 tier (same as mainnet — BST valid)
+        auxpowConsensus = digishieldConsensus;
+        auxpowConsensus.nHeightEffective = 1;
         auxpowConsensus.fAllowLegacyBlocks = true;
-        auxpowConsensus.dilithiumOnlyHeight = 0;
 
         // Assemble the binary search tree of parameters
-        pConsensusRoot = &digishieldConsensus;
-        digishieldConsensus.pLeft = &consensus;
-        digishieldConsensus.pRight = &minDifficultyConsensus;
-        minDifficultyConsensus.pRight = &auxpowConsensus;
+        // Simple two-node tree: genesis (left) and block 1+ (right)
+        pConsensusRoot = &consensus;
+        consensus.pRight = &auxpowConsensus;
 
         pchMessageStart[0] = 0xfc;
         pchMessageStart[1] = 0xc1;
@@ -559,7 +555,6 @@ public:
         // Testnet3 is being retired in favor of stagenet.
         consensus.hashGenesisBlock = genesis.GetHash();
         digishieldConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
-        minDifficultyConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
         auxpowConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
         // Genesis hash assertion deferred — testnet3 is being retired
 
@@ -569,7 +564,6 @@ public:
             "soqucoin-latticebp-params-v1",
             "N=256,Q=8380417,K=4,range=64");
         digishieldConsensus.latticeBPSeed = consensus.latticeBPSeed;
-        minDifficultyConsensus.latticeBPSeed = consensus.latticeBPSeed;
         auxpowConsensus.latticeBPSeed = consensus.latticeBPSeed;
 
         // Clear all Dogecoin seeds - Soqucoin testnet is isolated

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4542,7 +4542,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
 
     // AuxPoW height enforcement: reject AuxPoW blocks before the activation
     // height. On mainnet, nAuxpowStartHeight=0 (AuxPoW from genesis).
-    // nAuxpowStartHeight: mainnet=0, stagenet=100, testnet=158100, regtest=20.
+    // nAuxpowStartHeight: mainnet=0, stagenet=100, testnet=0, regtest=20.
     // Solo mining via getblocktemplate/submitblock is always available at all heights.
     if (block.IsAuxpow() && nHeight < consensusParams.nAuxpowStartHeight)
         return state.DoS(100, error("%s : auxpow block at height %d rejected, AuxPoW activates at height %d",


### PR DESCRIPTION
## What

Fixes bead `soqucoin-build-lnq`. Testnet3's `nAuxpowStartHeight=158100` and its `145000/157500/158100` consensus-tier ladder were un-customized Dogecoin testnet history — meaningless on Soqucoin's own genesis, the same bug class the mainnet comment already calls out ("Dogecoin's 145000 is meaningless here").

## How

Testnet now mirrors mainnet's structure: **AuxPoW from genesis** (`nAuxpowStartHeight=0`) with a single merged DigiShield+AuxPoW tier at block 1. The min-difficulty testing allowances (the terminal state of the old 157500+ tiers) are preserved in the merged tier so testnet stays test-friendly. The now-unused `minDifficultyConsensus` member is removed, and the stale height list in the validation.cpp comment is updated.

## Consensus impact

**No live network affected.** Testnet3 is retired in favor of stagenet (its post-Phase-4 genesis re-mine is already deferred, chainparams.cpp notes this). Mainnet, stagenet, and regtest are untouched. This aligns testnet's params with the ratified AuxPoW-from-genesis design (bead `inu`, June-4 decision) for any future revival.

## Verification

Full unit suite green: **565 cases, no errors detected** (macOS/clang). Linux/GCC CI on this PR is the cross-platform gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)