### PR TITLE
consensus: flag-day soft-fork activation (Option D) + strict chain-id (lw7) — beads p96/lw7

### DIFF
--- a/qa/rpc-tests/auxpow.py
+++ b/qa/rpc-tests/auxpow.py
@@ -70,12 +70,11 @@ class AuxPOWTest (BitcoinTestFramework):
         # 7. mine an auxpow block with high pow, expect: fail
         assert scrypt_auxpow.mineScryptAux(self.nodes[0], "00", False) is False
 
-        # NOTE: Dogecoin's original step "mine an auxpow whose parent chain is us,
-        # expect: fail" does NOT apply to Soqucoin. The self-chain-id guard in
-        # auxpow.cpp ("Aux POW parent has our chain ID") is gated on fStrictChainId,
-        # which is false on every network by design (allow legacy non-auxpow blocks).
-        # So such a block is accepted, not rejected. Removed to keep the node-0
-        # reward count below exact (steps 2 and 6 only). See soqucoin-build-lw7.
+        # 8. mine an auxpow block whose PARENT chain is us, expect: fail
+        # (lw7: fStrictChainId=true on regtest since 2026-07-02 — an auxpow parent
+        # carrying our own chain id 0x5351 is self-merge-mining PoW reuse and must be
+        # rejected by the parent-side guard in auxpow.cpp. "5153" = 0x5351 LE.)
+        assert scrypt_auxpow.mineScryptAux(self.nodes[0], "5153", True) is False
 
         # 9. mine enough blocks to mature all node 0 rewards
         self.nodes[1].generate(self.MATURITY_HEIGHT)

--- a/qa/rpc-tests/test_framework/scrypt_auxpow.py
+++ b/qa/rpc-tests/test_framework/scrypt_auxpow.py
@@ -40,8 +40,12 @@ def computeAuxpowWithChainId (block, target, chainid, ok):
   txHash = doubleHashHex (tx)
 
   # Construct the parent block header.  It need not be valid, just good
-  # enough for auxpow purposes.
-  header = "0100" + chainid + "00"
+  # enough for auxpow purposes.  The chain id may be one byte ("62") or, for
+  # Soqucoin's two-byte 0x5351, two bytes little-endian ("5153").
+  if len (chainid) == 4:
+    header = "0100" + chainid
+  else:
+    header = "0100" + chainid + "00"
   header += "00" * 32
   header += reverseHex (txHash)
   header += "00" * 4

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -303,7 +303,12 @@ public:
 
         // AuxPoW parameters
         consensus.nAuxpowChainId = 0x5351;   // "SQ" = Soqucoin (unique ID, avoids Dogecoin collision)
-        consensus.fStrictChainId = false;    // Allow legacy blocks without embedded chain ID
+        // lw7: reject AuxPoW blocks that don't carry our chain id (and, via the
+        // parent-side check, parents that DO) — blocks cross-chain / self-merge-mining
+        // PoW reuse. Safe on mainnet: the chain is fresh and the miner (SetBaseVersion)
+        // stamps chain id 0x5351 on every block from genesis. The check is scoped to
+        // AuxPoW blocks (soqucoin.cpp), so solo blocks are unaffected.
+        consensus.fStrictChainId = true;
         consensus.fAllowLegacyBlocks = true; // Allow both legacy Scrypt AND AuxPoW blocks
         consensus.nAuxpowStartHeight = 0;    // AuxPoW from genesis — merge mining available from block 0
         consensus.nHeightEffective = 0;
@@ -537,7 +542,7 @@ public:
 
         // AuxPoW parameters
         consensus.nAuxpowChainId = 0x5351; // "SQ" = Soqucoin (unique ID, avoids Dogecoin collision)
-        consensus.fStrictChainId = false;  // Allow legacy blocks without embedded chain ID
+        consensus.fStrictChainId = true;   // lw7 — testnet3 is retired; mirror mainnet
         consensus.nHeightEffective = 0;
         consensus.fAllowLegacyBlocks = true; // Allow both legacy Scrypt AND AuxPoW blocks
         consensus.nAuxpowStartHeight = 0;    // AuxPoW from genesis — mirror mainnet (bead lnq)
@@ -743,7 +748,7 @@ public:
 
         // AuxPow parameters
         consensus.nAuxpowChainId = 0x5351;   // "SQ" = Soqucoin (unique ID, avoids Dogecoin collision)
-        consensus.fStrictChainId = false;    // Allow legacy blocks without embedded chain ID
+        consensus.fStrictChainId = true;     // lw7 — regtest is ephemeral; mirror mainnet
         consensus.fAllowLegacyBlocks = true; // Allow both legacy Scrypt AND AuxPoW blocks
         consensus.nAuxpowStartHeight = 20;   // Regtest: match auxpowConsensus.nHeightEffective
 
@@ -1011,6 +1016,13 @@ public:
 
         // AuxPoW parameters - same as mainnet
         consensus.nAuxpowChainId = 0x5351; // "SQ" = Soqucoin
+        // lw7: DELIBERATELY still false on stagenet. The LIVE stagenet's historical
+        // AuxPoW blocks were mined as version 0x00000104 — AuxPoW flag set but chain
+        // id 0x0 (the pre-lw7 miner didn't stamp it). Flipping strict here would make
+        // every one of those blocks invalid (IsAuxpow && GetChainId 0 != 0x5351) and
+        // reject the entire live chain. Flip this to true ONLY at the next coordinated
+        // stagenet RESET, once a fresh chain is mined with the chain-id-stamping miner
+        // AND the pool's merged-mining commitment is verified to use chain id 0x5351.
         consensus.fStrictChainId = false;
         consensus.nHeightEffective = 0;
         consensus.fAllowLegacyBlocks = true;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -273,6 +273,24 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nStartTime = 0;  // NOT ACTIVE: pending Halborn Phase 2 audit
         consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nTimeout = 0;    // Not yet scheduled
 
+        // p96 / Option D — MAINNET flag-day activation heights.
+        // These post-launch soft-forks activate by scheduled HEIGHT (not BIP9 miner
+        // signaling: Soqucoin is merge-mined with no signaling constituency; see
+        // DL-P96-BLOCK-VERSION-ACTIVATION.md). All ship NOT_SCHEDULED (dormant) — a
+        // coordinated release sets a real height for each as its Halborn Phase 2
+        // scope clears. The nStartTime/nTimeout above are retained but NOT consulted
+        // for these deployments. (CHECKPATAGG/LATTICEFOLD stay always-active on BIP9;
+        // CSV/SegWit stay on the historical BIP9 windows.)
+        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEBP].nActivationHeight        = Consensus::BIP9Deployment::NOT_SCHEDULED;
+        consensus.vDeployments[Consensus::DEPLOYMENT_USDSOQ].nActivationHeight           = Consensus::BIP9Deployment::NOT_SCHEDULED;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CTV].nActivationHeight              = Consensus::BIP9Deployment::NOT_SCHEDULED;
+        consensus.vDeployments[Consensus::DEPLOYMENT_APO].nActivationHeight              = Consensus::BIP9Deployment::NOT_SCHEDULED;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSFS].nActivationHeight             = Consensus::BIP9Deployment::NOT_SCHEDULED;
+        consensus.vDeployments[Consensus::DEPLOYMENT_P2WSH_DILITHIUM].nActivationHeight  = Consensus::BIP9Deployment::NOT_SCHEDULED;
+        consensus.vDeployments[Consensus::DEPLOYMENT_UTXO_COST].nActivationHeight        = Consensus::BIP9Deployment::NOT_SCHEDULED;
+        consensus.vDeployments[Consensus::DEPLOYMENT_DILITHIUM_KEYHASH].nActivationHeight = Consensus::BIP9Deployment::NOT_SCHEDULED;
+        consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nActivationHeight   = Consensus::BIP9Deployment::NOT_SCHEDULED;
+
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000000e993d2aa86cf246a49b"); // 5,050,000
@@ -497,6 +515,18 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
+        // p96 / Option D: height-gated activation, height 0 = active from genesis
+        // (equivalent to the ALWAYS_ACTIVE test behavior above). See CMainParams.
+        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEBP].nActivationHeight        = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_USDSOQ].nActivationHeight           = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CTV].nActivationHeight              = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_APO].nActivationHeight              = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSFS].nActivationHeight             = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_P2WSH_DILITHIUM].nActivationHeight  = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_UTXO_COST].nActivationHeight        = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_DILITHIUM_KEYHASH].nActivationHeight = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nActivationHeight   = 0;
+
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");
 
@@ -692,6 +722,18 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].bit = 13;
         consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+
+        // p96 / Option D: height-gated activation, height 0 = active from genesis
+        // (equivalent to the ALWAYS_ACTIVE test behavior above). See CMainParams.
+        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEBP].nActivationHeight        = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_USDSOQ].nActivationHeight           = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CTV].nActivationHeight              = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_APO].nActivationHeight              = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSFS].nActivationHeight             = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_P2WSH_DILITHIUM].nActivationHeight  = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_UTXO_COST].nActivationHeight        = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_DILITHIUM_KEYHASH].nActivationHeight = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nActivationHeight   = 0;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");
@@ -927,6 +969,19 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].bit = 13;
         consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;  // STAGENET ONLY
         consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+
+        // p96 / Option D: height-gated activation, height 0 = active from genesis
+        // (equivalent to the ALWAYS_ACTIVE test behavior above — the live stagenet's
+        // historical blocks validate identically). See CMainParams.
+        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEBP].nActivationHeight        = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_USDSOQ].nActivationHeight           = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CTV].nActivationHeight              = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_APO].nActivationHeight              = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSFS].nActivationHeight             = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_P2WSH_DILITHIUM].nActivationHeight  = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_UTXO_COST].nActivationHeight        = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_DILITHIUM_KEYHASH].nActivationHeight = 0;
+        consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nActivationHeight   = 0;
 
         // USDSOQ Authority Keys - 2-of-3 ML-DSA-44 multisig (FIPS 204)
         // Keys control USDSOQ mint/burn/freeze. Generated 2026-05-27T04:46:27Z

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -45,9 +45,28 @@ struct BIP9Deployment {
     int64_t nStartTime;
     /** Timeout/expiry MedianTime for the deployment attempt. */
     int64_t nTimeout;
+    /**
+     * Flag-day (height-gated) activation — bead soqucoin-build-p96, "Option D".
+     * Soqucoin is merge-mined and has no BIP9 signaling constituency (a chain-id
+     * in the block-version high bits also physically precludes the BIP9 top-bits
+     * pattern), so post-launch soft-forks activate at a scheduled height set in a
+     * coordinated release rather than by miner version-bit signaling.
+     *
+     * When != NO_HEIGHT_ACTIVATION, this deployment is ACTIVE for a block iff that
+     * block's height >= nActivationHeight, and the BIP9 nStartTime/nTimeout fields
+     * are NOT consulted for activation. Set to NOT_SCHEDULED to ship a feature
+     * dormant (mainnet), 0 to activate from genesis (test networks). When left at
+     * NO_HEIGHT_ACTIVATION the deployment uses the BIP9 state machine as before
+     * (retained for the ALWAYS_ACTIVE and historical CSV/SegWit deployments).
+     */
+    int nActivationHeight = NO_HEIGHT_ACTIVATION;
 
     static constexpr int64_t NO_TIMEOUT = std::numeric_limits<int64_t>::max();
     static constexpr int64_t ALWAYS_ACTIVE = -1;
+    /** Sentinel: not height-gated — fall back to the BIP9 state machine. */
+    static constexpr int NO_HEIGHT_ACTIVATION = -1;
+    /** A height no chain will reach — feature is height-gated but not yet scheduled. */
+    static constexpr int NOT_SCHEDULED = std::numeric_limits<int>::max();
 };
 
 /**
@@ -162,6 +181,21 @@ struct Params {
      *  MUST match between soqucoind and soq-privacy-signer for proof verification. */
     std::array<uint8_t, 32> latticeBPSeed = {};
 };
+
+/**
+ * Height-gated ("flag-day") soft-fork activation predicate — bead p96, Option D.
+ * Returns whether the height-gated deployment `pos` is active for a block at
+ * `nHeight`. Intended only for deployments configured with an nActivationHeight;
+ * deployments left on the BIP9 state machine (NO_HEIGHT_ACTIVATION) always return
+ * false here and must be queried via VersionBitsState instead. Total and
+ * crash-free by construction (no per-block asserts).
+ */
+inline bool DeploymentActiveAtHeight(int nHeight, const Params& params, DeploymentPos pos)
+{
+    const int h = params.vDeployments[pos].nActivationHeight;
+    return h != BIP9Deployment::NO_HEIGHT_ACTIVATION && nHeight >= h;
+}
+
 } // namespace Consensus
 
 #endif // BITCOIN_CONSENSUS_PARAMS_H

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -153,10 +153,15 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     const Consensus::Params& consensus = chainparams.GetConsensus(nHeight);
     const int32_t nChainId = consensus.nAuxpowChainId;
-    // FIXME: Active version bits after the always-auxpow fork!
-    // const int32_t nVersion = ComputeBlockVersion(pindexPrev, consensus);
+    // p96 / Option D + lw7: soft-forks activate by HEIGHT, not BIP9 version-bit
+    // signaling (Soqucoin is merge-mined; see DL-P96-BLOCK-VERSION-ACTIVATION.md),
+    // so ComputeBlockVersion is intentionally NOT used. We emit the Dogecoin block
+    // version layout — base version in the low bits, our AuxPoW chain id in the high
+    // bits (SetBaseVersion) — so every block (solo and the AuxPoW child template
+    // getauxblock builds on) carries chain id 0x5351. This is what lets fStrictChainId
+    // reject cross-chain / self-merge-mining reuse (bead lw7).
     const int32_t nVersion = VERSIONBITS_LAST_OLD_BLOCK_VERSION;
-    pblock->nVersion = nVersion;
+    pblock->SetBaseVersion(nVersion, nChainId);
     // -regtest only: allow overriding block.nVersion with
     // -blockversion=N to test forking scenarios
     if (chainparams.MineBlocksOnDemand())

--- a/src/rpc/usdsoq.cpp
+++ b/src/rpc/usdsoq.cpp
@@ -64,21 +64,20 @@ static UniValue getusdsoqstatus(const JSONRPCRequest& request)
 
     UniValue result(UniValue::VOBJ);
 
-    // Deployment status
+    // Deployment status (p96 / Option D: height-gated flag-day activation)
     const Consensus::Params& consensus = Params().GetConsensus(chainActive.Height());
-    ThresholdState state = VersionBitsState(chainActive.Tip(),
-        consensus, Consensus::DEPLOYMENT_USDSOQ, versionbitscache);
+    const bool fActive = Consensus::DeploymentActiveAtHeight(chainActive.Height(),
+        consensus, Consensus::DEPLOYMENT_USDSOQ);
+    const int nActHeight = consensus.vDeployments[Consensus::DEPLOYMENT_USDSOQ].nActivationHeight;
 
     string statusStr;
-    switch (state) {
-        case THRESHOLD_DEFINED:   statusStr = "defined"; break;
-        case THRESHOLD_STARTED:   statusStr = "started"; break;
-        case THRESHOLD_LOCKED_IN: statusStr = "locked_in"; break;
-        case THRESHOLD_ACTIVE:    statusStr = "active"; break;
-        case THRESHOLD_FAILED:    statusStr = "failed"; break;
-        default:                  statusStr = "unknown"; break;
-    }
+    if (fActive) statusStr = "active";
+    else if (nActHeight == Consensus::BIP9Deployment::NO_HEIGHT_ACTIVATION) statusStr = "disabled";
+    else if (nActHeight == Consensus::BIP9Deployment::NOT_SCHEDULED) statusStr = "not_scheduled";
+    else statusStr = "scheduled";  // a concrete future activation height is set
     result.pushKV("deployment_status", statusStr);
+    result.pushKV("activation_height",
+        nActHeight == Consensus::BIP9Deployment::NOT_SCHEDULED ? -1 : nActHeight);
     result.pushKV("bit", 6);
     result.pushKV("witness_version", 5);
 
@@ -92,7 +91,7 @@ static UniValue getusdsoqstatus(const JSONRPCRequest& request)
 
     // Supply counters
     UniValue supply(UniValue::VOBJ);
-    if (state == THRESHOLD_ACTIVE) {
+    if (fActive) {
         // SOQ-AUD2-002 D1: Read from global supply counter (persisted to/from LevelDB)
         supply.pushKV("total_minted", ValueFromAmount(g_usdsoq_supply.TotalMinted()));
         supply.pushKV("total_burned", ValueFromAmount(g_usdsoq_supply.TotalBurned()));
@@ -140,10 +139,10 @@ static UniValue getusdsoqauthority(const JSONRPCRequest& request)
     // Authority key set is injected during BIP9 activation.
     // Before activation, report uninitialized state.
     const Consensus::Params& consensus = Params().GetConsensus(chainActive.Height());
-    ThresholdState state = VersionBitsState(chainActive.Tip(),
-        consensus, Consensus::DEPLOYMENT_USDSOQ, versionbitscache);
+    const bool fUsdsoqActive = Consensus::DeploymentActiveAtHeight(chainActive.Height(),
+        consensus, Consensus::DEPLOYMENT_USDSOQ);
 
-    if (state != THRESHOLD_ACTIVE) {
+    if (!fUsdsoqActive) {
         result.pushKV("initialized", false);
         result.pushKV("threshold", 0);
         result.pushKV("key_count", 0);
@@ -214,10 +213,10 @@ static UniValue verifyusdsoqauthority(const JSONRPCRequest& request)
 
     // Check deployment status
     const Consensus::Params& consensus = Params().GetConsensus(chainActive.Height());
-    ThresholdState state = VersionBitsState(chainActive.Tip(),
-        consensus, Consensus::DEPLOYMENT_USDSOQ, versionbitscache);
+    const bool fUsdsoqActive = Consensus::DeploymentActiveAtHeight(chainActive.Height(),
+        consensus, Consensus::DEPLOYMENT_USDSOQ);
 
-    if (state != THRESHOLD_ACTIVE) {
+    if (!fUsdsoqActive) {
         throw JSONRPCError(RPC_MISC_ERROR,
             "USDSOQ deployment is not active. Cannot verify authority signatures.");
     }
@@ -295,10 +294,10 @@ static UniValue usdsoqmint(const JSONRPCRequest& request)
     LOCK(cs_main);
 
     const Consensus::Params& consensus = Params().GetConsensus(chainActive.Height());
-    ThresholdState state = VersionBitsState(chainActive.Tip(),
-        consensus, Consensus::DEPLOYMENT_USDSOQ, versionbitscache);
+    const bool fUsdsoqActive = Consensus::DeploymentActiveAtHeight(chainActive.Height(),
+        consensus, Consensus::DEPLOYMENT_USDSOQ);
 
-    if (state != THRESHOLD_ACTIVE) {
+    if (!fUsdsoqActive) {
         throw JSONRPCError(RPC_MISC_ERROR,
             "USDSOQ deployment is not active. Mint operations are not available.");
     }
@@ -377,10 +376,10 @@ static UniValue usdsoqburn(const JSONRPCRequest& request)
     LOCK(cs_main);
 
     const Consensus::Params& consensus = Params().GetConsensus(chainActive.Height());
-    ThresholdState state = VersionBitsState(chainActive.Tip(),
-        consensus, Consensus::DEPLOYMENT_USDSOQ, versionbitscache);
+    const bool fUsdsoqActive = Consensus::DeploymentActiveAtHeight(chainActive.Height(),
+        consensus, Consensus::DEPLOYMENT_USDSOQ);
 
-    if (state != THRESHOLD_ACTIVE) {
+    if (!fUsdsoqActive) {
         throw JSONRPCError(RPC_MISC_ERROR,
             "USDSOQ deployment is not active. Burn operations are not available.");
     }
@@ -471,10 +470,10 @@ static UniValue usdsoqfreeze(const JSONRPCRequest& request)
     LOCK(cs_main);
 
     const Consensus::Params& consensus = Params().GetConsensus(chainActive.Height());
-    ThresholdState state = VersionBitsState(chainActive.Tip(),
-        consensus, Consensus::DEPLOYMENT_USDSOQ, versionbitscache);
+    const bool fUsdsoqActive = Consensus::DeploymentActiveAtHeight(chainActive.Height(),
+        consensus, Consensus::DEPLOYMENT_USDSOQ);
 
-    if (state != THRESHOLD_ACTIVE) {
+    if (!fUsdsoqActive) {
         throw JSONRPCError(RPC_MISC_ERROR,
             "USDSOQ deployment is not active. Freeze operations are not available.");
     }
@@ -527,9 +526,9 @@ static UniValue usdsoqunfreeze(const JSONRPCRequest& request)
     LOCK(cs_main);
 
     const Consensus::Params& consensus = Params().GetConsensus(chainActive.Height());
-    ThresholdState state = VersionBitsState(chainActive.Tip(),
-        consensus, Consensus::DEPLOYMENT_USDSOQ, versionbitscache);
-    if (state != THRESHOLD_ACTIVE) {
+    const bool fUsdsoqActive = Consensus::DeploymentActiveAtHeight(chainActive.Height(),
+        consensus, Consensus::DEPLOYMENT_USDSOQ);
+    if (!fUsdsoqActive) {
         throw JSONRPCError(RPC_MISC_ERROR,
             "USDSOQ deployment is not active. Unfreeze operations are not available.");
     }
@@ -583,10 +582,10 @@ static UniValue usdsoqrotatekeys(const JSONRPCRequest& request)
     LOCK(cs_main);
 
     const Consensus::Params& consensus = Params().GetConsensus(chainActive.Height());
-    ThresholdState state = VersionBitsState(chainActive.Tip(),
-        consensus, Consensus::DEPLOYMENT_USDSOQ, versionbitscache);
+    const bool fUsdsoqActive = Consensus::DeploymentActiveAtHeight(chainActive.Height(),
+        consensus, Consensus::DEPLOYMENT_USDSOQ);
 
-    if (state != THRESHOLD_ACTIVE) {
+    if (!fUsdsoqActive) {
         throw JSONRPCError(RPC_MISC_ERROR,
             "USDSOQ deployment is not active. Key rotation is not available.");
     }
@@ -813,9 +812,9 @@ static UniValue usdsoqsigntx(const JSONRPCRequest& request)
 
     // Check deployment
     const Consensus::Params& consensus = Params().GetConsensus(chainActive.Height());
-    ThresholdState deployState = VersionBitsState(chainActive.Tip(),
-        consensus, Consensus::DEPLOYMENT_USDSOQ, versionbitscache);
-    if (deployState != THRESHOLD_ACTIVE)
+    const bool fUsdsoqActive = Consensus::DeploymentActiveAtHeight(chainActive.Height(),
+        consensus, Consensus::DEPLOYMENT_USDSOQ);
+    if (!fUsdsoqActive)
         throw JSONRPCError(RPC_MISC_ERROR,
             "USDSOQ deployment is not active.");
 

--- a/src/soqucoin.cpp
+++ b/src/soqucoin.cpp
@@ -88,11 +88,16 @@ unsigned int CalculateSoqucoinNextWorkRequired(const CBlockIndex* pindexLast, in
 
 bool CheckAuxPowProofOfWork(const CBlockHeader& block, const Consensus::Params& params)
 {
-    /* Except for legacy blocks with full version 1, ensure that
-       the chain ID is correct.  Legacy blocks are not allowed since
-       the merge-mining start, which is checked in AcceptBlockHeader
-       where the height is known.  */
-    if (!block.IsLegacy() && params.fStrictChainId && block.GetChainId() != params.nAuxpowChainId)
+    /* Ensure AuxPoW (merge-mined) blocks carry our chain ID (bead lw7). The chain
+       id only has meaning for merge-mining — it selects the merkle index committed
+       in the parent chain's coinbase — so the strict check is scoped to AuxPoW
+       blocks (block.IsAuxpow()), not all non-legacy blocks. Solo/direct-PoW blocks
+       have no parent proof; their version high bits are unconstrained. This is
+       stricter-where-it-matters and, unlike Dogecoin's !IsLegacy() form, does not
+       require every solo block (or in-process test block) to carry the chain id.
+       The complementary parent-side check (auxpow.cpp: parent must NOT carry our
+       chain id) blocks self-merge-mining PoW reuse. */
+    if (block.IsAuxpow() && params.fStrictChainId && block.GetChainId() != params.nAuxpowChainId)
         return error("%s : block does not have our chain ID"
                      " (got %d, expected %d, full nVersion %d)",
                      __func__, block.GetChainId(),

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -376,29 +376,33 @@ BOOST_AUTO_TEST_CASE(auxpow_pow)
     mineBlock(block, true);
     BOOST_CHECK(CheckAuxPowProofOfWork(block, params));
 
-    // Soqucoin block version 2 can be both AuxPoW and regular, so test 3
+    // lw7: the strict chain-id check is scoped to AuxPoW blocks (IsAuxpow()), not
+    // all non-legacy blocks as in Dogecoin. A NON-auxpow block's version high bits
+    // are unconstrained — chain id only has meaning for merge mining (it selects the
+    // parent-coinbase merkle index). So a version-3 block, and a block whose version
+    // carries a MISMATCHED chain id, are accepted regardless of fStrictChainId as
+    // long as the AuxPoW flag is clear. (regtest runs fStrictChainId=true.)
 
-    block.nVersion = 3;
-    mineBlock(block, true);
-    if (params.fStrictChainId) {
-        BOOST_CHECK(!CheckAuxPowProofOfWork(block, params));
-    } else {
-        // Version 3 blocks are allowed when fStrictChainId is false
-        BOOST_CHECK(CheckAuxPowProofOfWork(block, params));
-    }
-
-    block.SetBaseVersion(2, params.nAuxpowChainId);
+    block.nVersion = 3;                                   // non-auxpow, chain id 0
     mineBlock(block, true);
     BOOST_CHECK(CheckAuxPowProofOfWork(block, params));
 
-    block.SetChainId(params.nAuxpowChainId + 1);
+    block.SetBaseVersion(2, params.nAuxpowChainId);       // non-auxpow, correct chain id
     mineBlock(block, true);
-    if (params.fStrictChainId) {
-        BOOST_CHECK(!CheckAuxPowProofOfWork(block, params));
-    } else {
-        // Mismatched chain ID allowed when fStrictChainId is false
-        BOOST_CHECK(CheckAuxPowProofOfWork(block, params));
-    }
+    BOOST_CHECK(CheckAuxPowProofOfWork(block, params));
+
+    block.SetChainId(params.nAuxpowChainId + 1);          // non-auxpow, MISMATCHED chain id
+    mineBlock(block, true);
+    BOOST_CHECK(CheckAuxPowProofOfWork(block, params));    // accepted: not AuxPoW → not checked
+
+    /* An AuxPoW-flagged block with a MISMATCHED chain id is rejected under strict
+       chain id — the lw7 security gate fires before the "missing auxpow data" check.
+       (The full parent-carries-our-chain-id rejection is covered by auxpow.py.) */
+    block.SetChainId(params.nAuxpowChainId + 1);
+    block.SetAuxpowFlag(true);
+    mineBlock(block, true);
+    BOOST_CHECK(!CheckAuxPowProofOfWork(block, params));
+    block.SetAuxpowFlag(false);
 
     /* Check the case when the block does not have auxpow (this is true
      right now).  */

--- a/src/test/genesis_chainparams_tests.cpp
+++ b/src/test/genesis_chainparams_tests.cpp
@@ -241,4 +241,80 @@ BOOST_AUTO_TEST_CASE(subsidy_halving_schedule)
     BOOST_CHECK_EQUAL(GetSoqucoinBlockSubsidy(100 * consensus.nSubsidyHalvingInterval, consensus, dummyHash), 2500 * COIN);
 }
 
+// ============================================================================
+// p96 / Option D — flag-day (height-gated) soft-fork activation
+// ============================================================================
+
+// The height-gated deployments that moved off BIP9 signaling (bits 5-13).
+static const Consensus::DeploymentPos P96_FLAGDAY_DEPLOYMENTS[] = {
+    Consensus::DEPLOYMENT_LATTICEBP,
+    Consensus::DEPLOYMENT_USDSOQ,
+    Consensus::DEPLOYMENT_CTV,
+    Consensus::DEPLOYMENT_APO,
+    Consensus::DEPLOYMENT_CSFS,
+    Consensus::DEPLOYMENT_P2WSH_DILITHIUM,
+    Consensus::DEPLOYMENT_UTXO_COST,
+    Consensus::DEPLOYMENT_DILITHIUM_KEYHASH,
+    Consensus::DEPLOYMENT_V6_CONTROLFLOW,
+};
+
+BOOST_AUTO_TEST_CASE(p96_deployment_active_predicate)
+{
+    Consensus::Params p;  // vDeployments default-constructed (nActivationHeight = NO_HEIGHT_ACTIVATION)
+    const Consensus::DeploymentPos pos = Consensus::DEPLOYMENT_USDSOQ;
+
+    // NO_HEIGHT_ACTIVATION (not height-gated) → never active via this predicate,
+    // even at absurd heights. Such deployments must be queried via BIP9 instead.
+    p.vDeployments[pos].nActivationHeight = Consensus::BIP9Deployment::NO_HEIGHT_ACTIVATION;
+    BOOST_CHECK(!Consensus::DeploymentActiveAtHeight(0, p, pos));
+    BOOST_CHECK(!Consensus::DeploymentActiveAtHeight(1000000, p, pos));
+
+    // NOT_SCHEDULED → dormant at every reachable height (ships-off on mainnet).
+    p.vDeployments[pos].nActivationHeight = Consensus::BIP9Deployment::NOT_SCHEDULED;
+    BOOST_CHECK(!Consensus::DeploymentActiveAtHeight(0, p, pos));
+    BOOST_CHECK(!Consensus::DeploymentActiveAtHeight(1000000000, p, pos));
+
+    // A concrete future height H: inactive below H, active at/above H (flag day).
+    p.vDeployments[pos].nActivationHeight = 500000;
+    BOOST_CHECK(!Consensus::DeploymentActiveAtHeight(499999, p, pos));
+    BOOST_CHECK(Consensus::DeploymentActiveAtHeight(500000, p, pos));   // first enforcing block
+    BOOST_CHECK(Consensus::DeploymentActiveAtHeight(500001, p, pos));
+
+    // Height 0 → active from genesis (the test-network configuration).
+    p.vDeployments[pos].nActivationHeight = 0;
+    BOOST_CHECK(Consensus::DeploymentActiveAtHeight(0, p, pos));
+    BOOST_CHECK(Consensus::DeploymentActiveAtHeight(1, p, pos));
+}
+
+BOOST_AUTO_TEST_CASE(p96_mainnet_ships_dormant)
+{
+    // Every flag-day soft-fork must be dormant on mainnet at genesis and stay
+    // dormant until a coordinated release sets a real height. Prevents an
+    // accidental genesis-active PQ/covenant/economic rule on mainnet.
+    SelectParams(CBaseChainParams::MAIN);
+    const Consensus::Params& consensus = Params().GetConsensus(0);
+    for (const auto pos : P96_FLAGDAY_DEPLOYMENTS) {
+        BOOST_CHECK_EQUAL(consensus.vDeployments[pos].nActivationHeight,
+                          Consensus::BIP9Deployment::NOT_SCHEDULED);
+        BOOST_CHECK(!Consensus::DeploymentActiveAtHeight(0, consensus, pos));
+        BOOST_CHECK(!Consensus::DeploymentActiveAtHeight(1000000, consensus, pos));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(p96_testnets_active_from_genesis)
+{
+    // Regtest and stagenet must keep the flag-day features active from genesis
+    // (height 0), preserving the prior ALWAYS_ACTIVE test behavior — and the
+    // live stagenet's historical blocks must validate identically.
+    for (const std::string& net : {CBaseChainParams::REGTEST, CBaseChainParams::STAGENET}) {
+        SelectParams(net);
+        const Consensus::Params& consensus = Params().GetConsensus(0);
+        for (const auto pos : P96_FLAGDAY_DEPLOYMENTS) {
+            BOOST_CHECK_EQUAL(consensus.vDeployments[pos].nActivationHeight, 0);
+            BOOST_CHECK(Consensus::DeploymentActiveAtHeight(0, consensus, pos));
+        }
+    }
+    SelectParams(CBaseChainParams::MAIN);  // restore default for later tests
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1033,14 +1033,15 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
         // covenant opcodes, so without this a B1/eLTOO (or CTV/CSFS/keyhash) tx is non-standard
         // (won't relay) AND its covenant opcodes are no-ops at the mempool — e.g. OP_CLTV in a v6
         // script wrongly passes a below-floor eLTOO spend that ConnectBlock rejects. OR-in the V6
-        // covenant flags gated by their BIP9 deployment (per-net), mirroring ConnectBlock: they are
-        // ALWAYS_ACTIVE on stagenet/regtest and nStartTime=0 (never) on mainnet, so this adds NOTHING
-        // on mainnet until activation — keeping mempool policy consistent with consensus.
+        // covenant flags gated by their height-activation (p96/Option D), mirroring ConnectBlock:
+        // they are height-0 on stagenet/regtest and NOT_SCHEDULED (never) on mainnet, so this adds
+        // NOTHING on mainnet until activation — keeping mempool policy consistent with consensus.
+        // Evaluated for the NEXT block (tip height + 1), which is what these txs would land in.
         {
-            const CBlockIndex* tipPrev = chainActive.Tip();
-            const Consensus::Params& cons = Params().GetConsensus(0);
+            const int nNextHeight = chainActive.Height() + 1;
+            const Consensus::Params& cons = Params().GetConsensus(nNextHeight);
             auto v6active = [&](Consensus::DeploymentPos pos) {
-                return VersionBitsState(tipPrev, cons, pos, versionbitscache) == THRESHOLD_ACTIVE;
+                return Consensus::DeploymentActiveAtHeight(nNextHeight, cons, pos);
             };
             if (v6active(Consensus::DEPLOYMENT_CTV))               scriptVerifyFlags |= SCRIPT_VERIFY_CTV;
             if (v6active(Consensus::DEPLOYMENT_APO))               scriptVerifyFlags |= SCRIPT_VERIFY_APO;
@@ -2351,12 +2352,19 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // outputs are no longer anyone-can-spend — range proofs are verified.
     // When NOT active, confidential outputs (nVisibility != 0x00) are rejected
     // in the per-TX output validation loop below.
-    if (VersionBitsState(pindex->pprev, consensus, Consensus::DEPLOYMENT_LATTICEBP, versionbitscache) == THRESHOLD_ACTIVE) {
+    //
+    // p96 / Option D: the post-launch soft-forks below activate by scheduled
+    // HEIGHT (DeploymentActiveAtHeight), not BIP9 miner signaling — Soqucoin is
+    // merge-mined with no signaling constituency. Test nets set the height to 0
+    // (active from genesis); mainnet ships them NOT_SCHEDULED (dormant) until a
+    // coordinated release sets a real height. CHECKPATAGG/LATTICEFOLD (always-
+    // active) and CSV/SegWit (historical) remain on the BIP9 state machine above.
+    if (Consensus::DeploymentActiveAtHeight(pindex->nHeight, consensus, Consensus::DEPLOYMENT_LATTICEBP)) {
         flags |= SCRIPT_VERIFY_LATTICEBP;
     }
 
     // SOQ-AUD2-002: Start enforcing USDSOQ stablecoin authority opcodes
-    if (VersionBitsState(pindex->pprev, consensus, Consensus::DEPLOYMENT_USDSOQ, versionbitscache) == THRESHOLD_ACTIVE) {
+    if (Consensus::DeploymentActiveAtHeight(pindex->nHeight, consensus, Consensus::DEPLOYMENT_USDSOQ)) {
         flags |= SCRIPT_VERIFY_USDSOQ;
 
         // SOQ-AUD2-002 D4: Lazy-initialize authority from Consensus::Params.
@@ -2383,7 +2391,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     }
 
     // BIP 119: Start enforcing OP_CHECKTEMPLATEVERIFY (vault/covenant opcodes)
-    if (VersionBitsState(pindex->pprev, consensus, Consensus::DEPLOYMENT_CTV, versionbitscache) == THRESHOLD_ACTIVE) {
+    if (Consensus::DeploymentActiveAtHeight(pindex->nHeight, consensus, Consensus::DEPLOYMENT_CTV)) {
         flags |= SCRIPT_VERIFY_CTV;
     }
 
@@ -2391,13 +2399,13 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // NOTE: This does NOT modify Dilithium signature verification. It adds
     // new sighash types (0x41, 0x42) that produce alternate sighash values.
     // The existing SIGHASH_ALL (0x01) path is completely untouched.
-    if (VersionBitsState(pindex->pprev, consensus, Consensus::DEPLOYMENT_APO, versionbitscache) == THRESHOLD_ACTIVE) {
+    if (Consensus::DeploymentActiveAtHeight(pindex->nHeight, consensus, Consensus::DEPLOYMENT_APO)) {
         flags |= SCRIPT_VERIFY_APO;
     }
 
     // BIP 348: Start enforcing OP_CHECKSIGFROMSTACK (oracle contracts, bridge attestation)
     // Strict ML-DSA-44 only. Message is SHA256'd before Dilithium verify.
-    if (VersionBitsState(pindex->pprev, consensus, Consensus::DEPLOYMENT_CSFS, versionbitscache) == THRESHOLD_ACTIVE) {
+    if (Consensus::DeploymentActiveAtHeight(pindex->nHeight, consensus, Consensus::DEPLOYMENT_CSFS)) {
         flags |= SCRIPT_VERIFY_CSFS;
     }
 
@@ -2405,7 +2413,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // When active, witness v6 programs execute arbitrary scripts via EvalScript,
     // enabling CTV vaults, CSFS oracles, OP_CAT covenants, and L2SOQ Lightning.
     // See DL-P2WSH-DILITHIUM.md for full design.
-    if (VersionBitsState(pindex->pprev, consensus, Consensus::DEPLOYMENT_P2WSH_DILITHIUM, versionbitscache) == THRESHOLD_ACTIVE) {
+    if (Consensus::DeploymentActiveAtHeight(pindex->nHeight, consensus, Consensus::DEPLOYMENT_P2WSH_DILITHIUM)) {
         flags |= SCRIPT_VERIFY_P2WSH_DILITHIUM;
     }
 
@@ -2413,7 +2421,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // When active, OP_NOP7 (0xb6) enforces SHA256(pubkey)==keyhash + Dilithium sig verify.
     // Enables eLTOO 2-of-2 multisig for L2SOQ Lightning with oversized Dilithium pubkeys.
     // See DL-OP-CHECKDILITHIUMKEYHASH.md for design.
-    if (VersionBitsState(pindex->pprev, consensus, Consensus::DEPLOYMENT_DILITHIUM_KEYHASH, versionbitscache) == THRESHOLD_ACTIVE) {
+    if (Consensus::DeploymentActiveAtHeight(pindex->nHeight, consensus, Consensus::DEPLOYMENT_DILITHIUM_KEYHASH)) {
         flags |= SCRIPT_VERIFY_DILITHIUM_KEYHASH;
     }
 
@@ -2421,7 +2429,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // (OP_IF/ELSE/ENDIF, OP_DROP, OP_CLTV, OP_CSV, OP_SHA256, OP_EQUAL[VERIFY]) in v6 EvalScript —
     // the eLTOO state ratchet, settlement CSV, and HTLC hashlock/timeout. PQ sigs stay on
     // CSFS/keyhash. When inactive these opcodes remain no-ops (unchanged behaviour).
-    if (VersionBitsState(pindex->pprev, consensus, Consensus::DEPLOYMENT_V6_CONTROLFLOW, versionbitscache) == THRESHOLD_ACTIVE) {
+    if (Consensus::DeploymentActiveAtHeight(pindex->nHeight, consensus, Consensus::DEPLOYMENT_V6_CONTROLFLOW)) {
         flags |= SCRIPT_VERIFY_V6_CONTROLFLOW;
     }
 
@@ -2434,10 +2442,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // SOQ-ARCH-003: Check if consensus-enforced minimum UTXO value is active (BIP9).
     // When active, every output must hold >= UTXO_COST_PER_BYTE × serialized_output_size.
     // Prevents dust storm attacks that bloat the UTXO set (Cardano-style utxoCostPerByte).
-    // Mainnet: nStartTime=0 (dormant until Phase 2 audit). Stagenet/regtest: ALWAYS_ACTIVE.
+    // Mainnet: NOT_SCHEDULED (dormant until Phase 2 audit). Stagenet/regtest: height 0.
     // See DL-SOQ-FEE-ARCHITECTURE-V3.md.
-    bool fEnforceUtxoCost = (VersionBitsState(pindex->pprev, consensus,
-        Consensus::DEPLOYMENT_UTXO_COST, versionbitscache) == THRESHOLD_ACTIVE);
+    bool fEnforceUtxoCost = Consensus::DeploymentActiveAtHeight(pindex->nHeight, consensus,
+        Consensus::DEPLOYMENT_UTXO_COST);
 
     int64_t nTime2 = GetTimeMicros();
     nTimeForks += nTime2 - nTime1;


### PR DESCRIPTION
Implements the p96 activation architecture (Casey-decided **Option D**) and the ratified **lw7** strict-chain-id flip. Two atomic commits; **no deploy** (fleet + pool coordination gated — see below).

## Why (bead p96)
Every post-launch soft-fork (USDSOQ, CTV, APO, CSFS, P2WSH-Dilithium, UTXO_COST, OP_CHECKDILITHIUMKEYHASH, V6_CONTROLFLOW, LatticeBP) ships **dormant** on mainnet and must be activatable *after* launch as each Halborn Phase 2 scope clears. The only non-hard-fork path is the activation machinery in the genesis binary — which was **disabled**. Research confirmed Dogecoin never solved BIP9-over-AuxPoW (its machinery is dead code); a merge-mined chain has no signaling constituency, and the chain-id in the version high bits physically precludes the BIP9 top-bits pattern (VERSION_AUXPOW even collides with APO on bit 8). Casey chose height-gated (flag-day) activation.

## Commit 1 — flag-day activation (Option D)
- New `BIP9Deployment::nActivationHeight` + `Consensus::DeploymentActiveAtHeight()` predicate (active iff `nHeight >= nActivationHeight`).
- The 9 post-launch deployments move off `VersionBitsState` onto the height predicate in ConnectBlock, the mempool-policy mirror, and the USDSOQ RPCs (one source of truth).
- CHECKPATAGG/LATTICEFOLD (always-active) and CSV/SegWit (historical) stay on BIP9.
- chainparams: mainnet `NOT_SCHEDULED` (dormant); test nets height 0 (identical to prior ALWAYS_ACTIVE — live stagenet history validates the same). Heights set before the per-tier consensus copies.
- 3 new tests (predicate semantics, mainnet-ships-dormant, testnets-active-from-genesis).

## Commit 2 — strict chain-id (lw7)
- Miner emits the Dogecoin version layout via `SetBaseVersion(v, chainId)` so every block (solo + the AuxPoW child template) carries chain id `0x5351` (uses the previously-dead `nChainId`; no BIP9 signaling under Option D).
- Strict self-check scoped to `block.IsAuxpow()` (chain id only matters for merge mining) — stricter-where-it-matters, and doesn't force chain id onto solo/test blocks.
- `fStrictChainId=true` on mainnet/regtest/testnet. **Stagenet deliberately stays false** — its live AuxPoW history is version `0x00000104` (chain id 0x0); flipping would invalidate the whole chain. Flip only at the next stagenet reset.
- auxpow.py restores Dogecoin's step 8 (parent-carries-our-chain-id → rejected); scrypt_auxpow gains 2-byte chain-id support.

## Verification
- Full unit suite green (**154 cases**), incl. usdsoq/covenant/freeze/keyhash (converted flags on regtest) + auxpow_tests updated to the IsAuxpow() semantic.
- Functional **auxpow.py / latticefold_basic.py / pat_basic.py pass on regtest with strict=true** — proves the miner→getauxblock→CAuxPow→self-check path end-to-end.
- Empirically confirmed the stagenet brick risk (live blocks are chain-id 0x0) before deciding to defer it.

## Deploy gates (NOT in this PR)
1. **soqupool-server** must be verified to build its merged-mining merkle commitment against chain id `0x5351` before any fleet deploy (the miner now stamps it on the child template).
2. **Stagenet strict flip** waits for its next coordinated reset (fresh chain + pool verified).
3. Mainnet activation heights get set per-feature in future releases as Phase 2 scopes clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)