### PR TITLE
USDSOQ: six-bug consensus/policy fix arc + stagenet enforcement recalibration (carries p96 flag-day)

### DIFF
--- a/doc/design/DL-USDSOQ-MEMPOOL-CRASH-FIX.md
+++ b/doc/design/DL-USDSOQ-MEMPOOL-CRASH-FIX.md
@@ -1,0 +1,95 @@
+# DL-USDSOQ-MEMPOOL-CRASH-FIX
+
+**Bug class:** remotely-triggerable node crash (DoS) + missing mempool policy
+**Found:** 2026-07-03, live stagenet drill (first-ever USDSOQ *spend* through the mempool)
+**Severity:** high — any peer can abort() a node with one crafted USDSOQ tx; also blocks all USDSOQ sends
+**Scope:** stagenet today (USDSOQ ALWAYS_ACTIVE); mainnet once USDSOQ activates — must ship before that
+
+## Symptom
+
+A SoquShield USDSOQ send failed with `RpcException(-502)`. Root cause on the node:
+
+```
+txmempool.cpp:35: CTxMemPoolEntry::CTxMemPoolEntry(...):
+  Assertion `inChainInputValue <= nValueIn' failed.
+```
+
+The daemon `abort()`ed; systemd restarted it 30s later. The -502 was the node
+dying mid-request. No funds moved (the tx never entered the mempool).
+
+## Why it happens
+
+In the `CTxMemPoolEntry` constructor:
+
+```cpp
+CAmount nValueIn = tx->GetValueOut() + nFee;   // GetValueOut() sums ALL assets; nFee is SOQ-only
+assert(inChainInputValue <= nValueIn);
+```
+
+- `inChainInputValue` (coins.cpp `GetPriority`) sums the **raw** value of confirmed
+  inputs — **including** the full USDSOQ nValue.
+- `nFee` (validation.cpp ATMP) is the **SOQ-only** fee (`nSOQIn − nSOQOut`), by
+  design (USDSOQ value must not count as fee).
+
+For a fully-confirmed-input tx the delta is exactly:
+
+```
+inChainInputValue − nValueIn = USDSOQ_in − USDSOQ_out
+```
+
+So the assert fires **iff USDSOQ is not conserved** (a deficit spend). A valid
+conserving send gives 0 (holds); an authority mint gives USDSOQ_out ≥ USDSOQ_in,
+i.e. a negative delta (holds) — which is why the mint never crashed and only a
+*spend* exposed this.
+
+The consensus rule that rejects non-conserving USDSOQ (`bad-txns-usdsoq-not-conserved`
+in `Consensus::CheckTxInputs`) DOES run in the mempool path — but via `CheckInputs`
+at validation.cpp ~1057, **~200 lines after** the `CTxMemPoolEntry` is constructed
+(~834). The crashing assert fires first. Unit tests never caught it because they
+drive `ConnectBlock`, not `AcceptToMemoryPool`, and no USDSOQ UTXO had ever been
+spent on-chain before this drill.
+
+## Fix (two layers)
+
+**1. Correctness — reject early (validation.cpp, AcceptToMemoryPool).**
+Run the USDSOQ per-asset conservation check *before* constructing the
+`CTxMemPoolEntry`, mirroring the ConnectBlock rule (authority/OP_5 txs exempt).
+A non-conserving USDSOQ tx is now rejected cleanly with
+`bad-txns-usdsoq-not-conserved` — mempool policy matches block-validation
+consensus, and the bad tx never reaches the entry constructor.
+
+**2. Never-crash hardening (txmempool.cpp).**
+A node must never `abort()` on a peer's transaction. `inChainInputValue` only
+feeds the priority heuristic, so the fatal `assert` is replaced with a clamp:
+if `inChainInputValue > nValueIn`, log and clamp to `nValueIn`. This removes the
+crash primitive entirely, independent of any single validation ordering.
+
+Together: layer 1 makes the node *behave correctly* (clean reject); layer 2
+guarantees it *cannot crash* here even if some future path builds an imbalanced
+entry.
+
+## Tests
+
+- `mempool_tests.cpp::MempoolEntryNoCrashOnUsdsoqImbalance` — constructs an entry
+  with `inChainInputValue ≫ GetValueOut()+fee`; asserts no abort + value clamped.
+  (Before the fix this test kills the test binary.)
+- Regression: `usdsoq_tests`, `usdsoq_authority_tests`,
+  `usdsoq_v7_conservation_harness_tests`, `freeze_registry_tests` all still green.
+
+## Deploy note
+
+This is a node consensus-path change. It must be built and rolled to the whole
+node fleet in lockstep (Services + Broadcast + Mining/pool + any ElectrumX-backing
+node) — a Casey-gated operation. The fix is backward-compatible: it only adds a
+rejection for txs that are already consensus-invalid, and removes an abort; it
+does not change what blocks are valid.
+
+## Related app-side bug (separate arc — Bug 1)
+
+The proximate trigger was SoquShield's tx_builder computing USDSOQ `change =
+totalInput − amount − SOQ_fee`, i.e. deducting the SOQ fee out of the USDSOQ
+value and emitting no SOQ input/output — producing the non-conserving tx. Fixed
+separately by porting the signer's two-asset-set construction (USDSOQ inputs
+fund USDSOQ recipient+change exactly; separate SOQ inputs pay the fee). This node
+fix stands on its own: the node must reject such txs cleanly regardless of who
+sends them.

--- a/doc/design/DL-USDSOQ-MEMPOOL-FIX-DEPLOY-RUNBOOK.md
+++ b/doc/design/DL-USDSOQ-MEMPOOL-FIX-DEPLOY-RUNBOOK.md
@@ -119,3 +119,77 @@ Rebuild SoquShield from `soqucoin-ops` branch `feat/usdsoq-balance-v7-index`
 (carries the USDSOQ send asset-isolation + v7-input-scriptPubKey fixes, the
 balance/UTXO API v7 queries, and the privacy de-claw). The node fix + the app
 fix are BOTH required for the send to complete.
+
+---
+
+## 2026-07-04 ADDENDUM — the deploy was INCOMPLETE: the 3 Hetzner pool daemons were missed
+
+**Incident (2026-07-04 16:41 UTC).** The drill's burn step (`d10c651d…566c`,
+100 USDSOQ, authority burn = non-conserving by design) was broadcast from the
+signer. It was ATMP-accepted and template-included on Broadcast (the BUG-20/21
+policy behavior working as designed), then relayed over P2P to the SOQUPOOL
+Hetzner daemons — which were still on `v1.4.0.0-8264181ef-dirty` (the v1.4.0
+release merge, PRE-dating ALL five fixes). All three hit the exact Bug-2 assert:
+
+```
+soqucoind: txmempool.cpp:35: CTxMemPoolEntry: Assertion `inChainInputValue <= nValueIn' failed.
+```
+
+systemd auto-restarted all three within ~40s (NRestarts=1, no loop); pool
+mining continued (blocks 7567/7568 found after). No payout impact. The burn tx
+now sits ONLY in the fixed DO nodes' mempools — the pool nodes crashed during
+acceptance, so it never entered their mempools and (having already been
+announced once) will NOT re-relay on its own. **The burn cannot mine until the
+Hetzner daemons run the fixed binary.**
+
+**Second finding — pool-node supply DBs are CORRUPT.** On restart Hillsboro
+logged `Restored supply from DB: total_minted=24800000000000` (248,000 USDSOQ;
+true value: 1,000). The old build PERSISTED the BUG-18 dry-run leak (the
+`!fJustCheck` persist gate does not exist at `8264181ef`), then re-added +1000
+replaying block 7077. ⚠️ The "restart self-heals" note above applies only to
+builds that HAVE the persist gate — the Hetzner builds do not. The only correct
+repair is a reindex (or fresh resync): the chain is ~7.6k mostly-empty blocks,
+so this is minutes-not-hours despite the usual reindex caution.
+
+**Staged binaries (2026-07-04, built per-box from the branch @ `5e5876763` —
+lib parity guaranteed):** `/opt/pool/bin/soqucoind.usdsoqfix` on each of
+Hillsboro `5.78.192.237`, Nuremberg `116.203.230.200`, Singapore `5.223.50.163`.
+Verify sha256 against the build logs before swapping.
+
+### Per-node completion steps (ROLLING, one box at a time — Casey/coordinated;
+### stop/restart + reindex are DCG-gated)
+
+For each of Hillsboro → Nuremberg → Singapore (2/3 keep mining SOQ while one
+reindexes; LTC/DOGE stratum is unaffected):
+
+1. `sha256sum /opt/pool/bin/soqucoind.usdsoqfix` — matches the build log.
+2. `cp /opt/pool/bin/soqucoind /opt/pool/bin/soqucoind.bak-20260704`
+3. `systemctl stop soqucoind` (pool-server stays up; SOQ jobs stall on this box only)
+4. `cp /opt/pool/bin/soqucoind.usdsoqfix /opt/pool/bin/soqucoind`
+5. One-time reindex to heal the supply DB: add `-reindex` to ExecStart (or run
+   once via a drop-in), `systemctl daemon-reload && systemctl start soqucoind`,
+   wait for tip (watch `getblockcount` — expect minutes), then REMOVE the
+   `-reindex` flag and `daemon-reload` again (do NOT leave it — every future
+   restart would reindex).
+6. Verify: `--version` → `v1.4.0.0-5e5876763`; `getusdsoqstatus` →
+   `total_minted=1000, outstanding=1000` (pre-burn) — the corrupt 249,000 is gone;
+   journal clean of asserts.
+7. Next box.
+
+### After ALL THREE are upgraded — finish the burn drill
+
+The burn will not re-announce by itself. Re-submit it once:
+
+```
+# on Broadcast (64.23.129.28):
+RAW=$(soqucoin-cli getrawtransaction d10c651d86a30ab20a8f537215448e69111289336d5b1425af625a54a197566c 0)
+# on any upgraded pool box:
+soqucoin-cli sendrawtransaction $RAW
+```
+
+Then confirm it MINES and `getusdsoqstatus` shows
+`total_burned=100, outstanding=900` on every node (BUG-20 live proof).
+
+⚠️ Do NOT broadcast ANY further USDSOQ tx (send/burn/mint) until all three
+Hetzner daemons run `5e5876763` — any non-conserving authority tx re-crashes
+the unfixed miners (this is exactly what happened at 16:41 UTC).

--- a/doc/design/DL-USDSOQ-MEMPOOL-FIX-DEPLOY-RUNBOOK.md
+++ b/doc/design/DL-USDSOQ-MEMPOOL-FIX-DEPLOY-RUNBOOK.md
@@ -1,0 +1,68 @@
+# USDSOQ Mempool Crash Fix — Fleet Deploy Runbook (Buddy handoff)
+
+**Fix branch:** `consensus/usdsoq-mempool-crash-fix` (repo `soqucoin/soqucoin`), tip `9270bd79b`
+**Spec:** `doc/design/DL-USDSOQ-MEMPOOL-CRASH-FIX.md`
+**Staged binary:** Services VPS `143.110.229.69:/usr/local/bin/soqucoind.usdsoqfix`
+- version `v1.4.0.0-9270bd79b`, sha256 `625ecd239b9c1f09cf03114d4b4ad9de607dc92b3ba05bf1d6782087a6d7fc7f`
+- Linux x86-64 ELF, built on the Services VPS from the fix branch.
+
+## What this fixes
+
+A non-conserving USDSOQ spend crashed the node (`CTxMemPoolEntry` assert →
+abort). Remotely-triggerable DoS + the reason USDSOQ sends fail. Two layers:
+mempool acceptance now rejects non-conserving USDSOQ txs cleanly, and the entry
+constructor clamps instead of asserting. **Backward-compatible** — it only adds
+a reject for txs that were already consensus-invalid and removes an abort; block
+validity is unchanged. Verified: `mempool_tests` + USDSOQ/freeze suites green.
+NOT yet live-proven (this deploy is the proof).
+
+## ⚠️ Binary-parity caveat
+
+The staged binary links against the Services VPS system libs (boost 1.83.0,
+db_cxx-5.3, libevent 2.1, libzmq5). **Only copy it to another node if that node
+has the same lib versions** — check with `ldd` on the first target. If versions
+differ, build per-VPS from the branch instead (the safe, canonical path):
+
+```
+cd /opt && git clone -b consensus/usdsoq-mempool-crash-fix \
+  https://github.com/soqucoin/soqucoin.git soqucoin-usdsoqfix && \
+cd soqucoin-usdsoqfix && ./autogen.sh && ./configure --without-gui --disable-bench && \
+make -j$(nproc)   # real binary at src/.libs/soqucoind
+```
+
+## Fleet — must deploy in LOCKSTEP (all chain-backing nodes)
+
+USDSOQ is ALWAYS_ACTIVE on stagenet; a mixed fleet (some patched, some not)
+means unpatched nodes still crash on the same tx. Deploy to ALL:
+- Services `143.110.229.69` (stagenet node behind ElectrumX + the balance API)
+- Broadcast `64.23.129.28` (soqucoind-broadcast — the node the signer + app hit via staging-rpc)
+- Any pool / Mining node still backing the chain
+- Monitoring node if it runs one
+Confirm the full node set from the fleet topology before starting.
+
+## Per-node steps (systemctl stop/restart is DCG-gated — Casey/coordinated)
+
+1. Verify sha of the binary you're installing.
+2. Back up the current binary (`cp /usr/local/bin/soqucoind{,.bak-YYYYMMDD}`).
+3. Install the new binary in place.
+4. `systemctl restart soqucoind-<role>` (per node role).
+5. Verify: `soqucoind ... --version` == `v1.4.0.0-9270bd79b`; node reaches the
+   current tip and stays up (`getblockcount`, no assertion in the journal).
+
+## Post-deploy verification (the live proof)
+
+1. **Clean-reject, no crash:** submit a deliberately non-conserving USDSOQ tx
+   (or just retry the app send below) and confirm the node returns
+   `bad-txns-usdsoq-not-conserved` and STAYS UP (no `Assertion ... failed` in the
+   journal, no systemd restart).
+2. **Real send works** (needs the app fix too — repo `soqucoin-ops`, branch
+   `feat/usdsoq-balance-v7-index`, rebuild the sim): SoquShield → Send → USDSOQ →
+   100 to self → approve → broadcasts. Then verify on-chain the v7→v7 transfer
+   conserved (supply unchanged) and both scripthashes re-indexed.
+
+## App side (same handoff)
+
+Rebuild SoquShield from `soqucoin-ops` branch `feat/usdsoq-balance-v7-index`
+(carries the USDSOQ send asset-isolation + v7-input-scriptPubKey fixes, the
+balance/UTXO API v7 queries, and the privacy de-claw). The node fix + the app
+fix are BOTH required for the send to complete.

--- a/doc/design/DL-USDSOQ-MEMPOOL-FIX-DEPLOY-RUNBOOK.md
+++ b/doc/design/DL-USDSOQ-MEMPOOL-FIX-DEPLOY-RUNBOOK.md
@@ -154,7 +154,9 @@ so this is minutes-not-hours despite the usual reindex caution.
 **Staged binaries (2026-07-04, built per-box from the branch @ `5e5876763` —
 lib parity guaranteed):** `/opt/pool/bin/soqucoind.usdsoqfix` on each of
 Hillsboro `5.78.192.237`, Nuremberg `116.203.230.200`, Singapore `5.223.50.163`.
-Verify sha256 against the build logs before swapping.
+All three are byte-identical: version `v1.4.0.0-5e58767`, sha256
+`2442b590a9bdbea8be8e0146d4ba3ba94e654c13d429ab58d9420e0c21981b15`.
+(The version string abbreviates the commit to 7 chars — same `5e5876763`.)
 
 ### Per-node completion steps (ROLLING, one box at a time — Casey/coordinated;
 ### stop/restart + reindex are DCG-gated)

--- a/doc/design/DL-USDSOQ-MEMPOOL-FIX-DEPLOY-RUNBOOK.md
+++ b/doc/design/DL-USDSOQ-MEMPOOL-FIX-DEPLOY-RUNBOOK.md
@@ -195,3 +195,66 @@ Then confirm it MINES and `getusdsoqstatus` shows
 ⚠️ Do NOT broadcast ANY further USDSOQ tx (send/burn/mint) until all three
 Hetzner daemons run `5e5876763` — any non-conserving authority tx re-crashes
 the unfixed miners (this is exactly what happened at 16:41 UTC).
+
+---
+
+## 2026-07-04 DEPLOY #3 — enforcement-height recalibration + BUG-22 (commit `92522497e`)
+
+Status when this section was written: burn PROVEN (block 7595, supply 900),
+full 8-instance fleet on `5e5876763`.
+
+**What this deploy carries (two commits on top of `5e5876763`):**
+
+1. **`c7f870cd9` — stagenet `nUSDSOQAuthorityEnforcementHeight` 37201 → 7700**
+   (Casey-ratified 2026-07-04). The stale pre-reset value exempted authority-sig
+   verification AND silently no-opped freeze/unfreeze registry application until
+   ~block 37201. All existing authority txs (mint 6501, send 7077, burn 7595)
+   stay below 7700, so historical validation is unchanged; full enforcement
+   (mainnet-shape) engages at 7700. Mainnet untouched (height 0).
+2. **`92522497e` — BUG-22: ATMP rejects spends of frozen USDSOQ outpoints.**
+   Same divergence class as BUG-21: a frozen-coin spend is script-valid, so
+   without this the first freeze drill's "try to spend the frozen coin" step
+   would have relayed a template-poisoning tx → empty blocks (chain-halting
+   DoS). Regression-tested; found by inspection before any freeze existed.
+   Also fixes the unit-test fixture to wire the `pcoinsdbview` global like
+   production (it was silently NULL in every unit test). Full suite 575/575.
+
+**⏰ DEADLINE: all 8 instances must be restarted on `92522497e` BEFORE block
+7700.** (Tip was 7611 when staged; ~16-20 blocks/h → several hours of margin.)
+If 7700 is somehow crossed first: no immediate risk (only WE create authority
+txs — do NOT fire any freeze/mint/burn until the fleet is uniform), finish the
+rollout, then proceed.
+
+**No reindex this time** — both changes affect only future blocks/mempool
+policy. Plain rolling binary swap + restart, same order and steps as the
+Hetzner completion above (skip step 5's reindex). Staged 2026-07-04:
+- Hetzner (per-box builds, byte-identical x3): `/opt/pool/bin/soqucoind.usdsoqfix`
+  version `v1.4.0.0-9252249`, sha256
+  `cb5e26ec5357296dbcb88c43fd7c718a9ebafc4344f1c5850c42cdfb48f05017`
+- Services (for the DO fleet, copy with lib parity as before):
+  `/usr/local/bin/soqucoind.usdsoqfix` version `v1.4.0.0-92522497e`, sha256
+  `31da956b21287e87765557132d2e05f6d93f09bca3a86fdce5ad674674113998`
+Verify `--version` per node and that `getusdsoqstatus` still shows
+minted 1000 / burned 100 / outstanding 900 after restart.
+
+### FREEZE drill (after fleet uniform on `92522497e` AND tip ≥ 7700)
+
+0. Casey guarded swap of the signer: `/usr/local/bin/soq-signer.freezefix`
+   (sha `a885a6af…`, freeze/unfreeze endpoints) → `/usr/local/bin/soq-signer`,
+   restart `soq-signer`. Also requires `SOQ_SIGNER_AUTHORITY_KEY_FILE` (already
+   set for mint/burn).
+1. Freeze the wallet's 900-USDSOQ UTXO:
+   `POST /api/v1/freeze-usdsoq` with the outpoint
+   `03dd0a3abf5c048732ae5df5cc3fb274df35701798e66e8412afaa292e737eef:1`.
+2. Wait for the freeze tx to MINE; check the node journal for
+   `USDSOQ: FREEZE applied — outpoint …` (this log line only appears ≥ 7700).
+3. Attempt to spend the frozen coin from the app (or a signer send-usdsoq) —
+   expect a CLEAN reject `bad-txns-spend-frozen-usdsoq` at broadcast (BUG-22),
+   chain keeps mining non-empty.
+4. `POST /api/v1/unfreeze-usdsoq` same outpoint → mine → journal
+   `UNFREEZE applied` → repeat the spend → it must now relay and mine.
+5. Supply must remain 900 throughout (freeze/unfreeze are supply-neutral).
+
+⚠️ Ordering note (bead `kp5`): always let a FREEZE confirm before letting
+wallets attempt spends of that outpoint. A spend that enters mempools before
+the freeze confirms is not evicted until the poisoned node restarts.

--- a/doc/design/DL-USDSOQ-MEMPOOL-FIX-DEPLOY-RUNBOOK.md
+++ b/doc/design/DL-USDSOQ-MEMPOOL-FIX-DEPLOY-RUNBOOK.md
@@ -1,13 +1,13 @@
 # USDSOQ Mempool Crash Fix — Fleet Deploy Runbook (Buddy handoff)
 
-**Fix branch:** `consensus/usdsoq-mempool-crash-fix` (repo `soqucoin/soqucoin`), tip `a982ee25b`
+**Fix branch:** `consensus/usdsoq-mempool-crash-fix` (repo `soqucoin/soqucoin`), tip `5e5876763`
 **Spec:** `doc/design/DL-USDSOQ-MEMPOOL-CRASH-FIX.md`
-**Staged binary (REBUILT — now contains Bug 2 + BUG-18 + BUG-19 + BUG-20):** Services VPS `143.110.229.69:/usr/local/bin/soqucoind.usdsoqfix`
-- version `v1.4.0.0-a982ee25b`, sha256 `095b67c25e558c2c41d067ecbb2838a03c577a455f664257ed8d04cff35597c9`
+**Staged binary (REBUILT — Bug 2 + BUG-18 + BUG-19 + BUG-20 + mempool-flag mirror):** Services VPS `143.110.229.69:/usr/local/bin/soqucoind.usdsoqfix`
+- version `v1.4.0.0-5e5876763`, sha256 `e5049bd89003ed883b2c04a3e0935ff86f75276bedf6e6fa2ed8093c28b2e2c1`
 - Linux x86-64 ELF, built on the Services VPS from the fix branch.
-- ⚠️ Supersedes the earlier `e61e727c…` (Bug2+BUG-18) and `625ecd23…` (Bug2-only) binaries. Deploy THIS one.
+- ⚠️ Supersedes `095b67c2…`, `e61e727c…`, `625ecd23…`. Deploy THIS one.
 
-## What this fixes (FOUR bugs, all in this binary)
+## What this fixes (FIVE bugs, all in this binary)
 
 **Bug 2 — node crash on USDSOQ spend.** A non-conserving USDSOQ spend crashed
 the node (`CTxMemPoolEntry` assert → abort) — remotely-triggerable DoS.
@@ -38,7 +38,20 @@ block undo (same source `DisconnectBlock` uses), gated on `isAuthorityTx`. Suppl
 accounting is now correct for mint (+outputs), pure burn (−inputs), and
 burn-with-change (outputs−inputs = net burned).
 
-All four are **backward-compatible** (block validity rules unchanged for any
+**BUG-21 — mempool accepted txs that block validation rejects (the real empty-block
+cause; found live 2026-07-04).** `AcceptToMemoryPool` omitted `SCRIPT_VERIFY_PAT`,
+`LATTICEFOLD`, `LATTICEBP` and `USDSOQ` — flags `ConnectBlock` enforces — so a v7
+USDSOQ input was verified leniently (anyone-can-spend) at accept time. A mis-signed
+v7 send (app signed the v7 input against the v1 scriptCode → NULLFAIL) therefore
+relayed fine but could never be mined, stalling every block template → empty blocks
+(live tx `daf9fd85`). Now the mempool mirrors ConnectBlock's flags (same activation),
+so such a tx is rejected up front. **Deploy side effect (good): on restart, the
+`mempool.dat` reload re-runs ATMP with the new flags, so the stuck mis-signed
+`daf9fd85` is REJECTED on reload and auto-evicted — no manual mempool clearing
+needed.** (The paired app-signing fix is soqucoin-ops `feat/usdsoq-balance-v7-index`
+— the app now signs v7 inputs against OP_7; both are needed for a real send to work.)
+
+All four consensus bugs are **backward-compatible** (block validity rules unchanged for any
 already-valid block) and verified by unit tests — `mempool_tests`, the v7
 conservation harness (7 cases: the SOQ→v7 rejection, v7→v7 conservation, the
 BUG-18 dry-run-no-leak regression, the BUG-19 `v7_send_connects_with_prior_minted_supply`
@@ -78,7 +91,7 @@ Confirm the full node set from the fleet topology before starting.
 2. Back up the current binary (`cp /usr/local/bin/soqucoind{,.bak-YYYYMMDD}`).
 3. Install the new binary in place.
 4. `systemctl restart soqucoind-<role>` (per node role).
-5. Verify: `soqucoind ... --version` == `v1.4.0.0-a982ee25b`; node reaches the
+5. Verify: `soqucoind ... --version` == `v1.4.0.0-5e5876763`; node reaches the
    current tip and stays up (`getblockcount`, no assertion in the journal).
 
 ## Post-deploy verification (the live proof)
@@ -94,7 +107,8 @@ Confirm the full node set from the fleet topology before starting.
    `getusdsoqsupply`/the balance API shows `outstanding` UNCHANGED across the
    send (a transfer is supply-neutral). Empty blocks around the send = BUG-19 not
    deployed. ⚠️ Do NOT re-broadcast until ALL chain-backing nodes run
-   `a982ee25b` — a mixed fleet with an old node re-inflates the supply.
+   `5e5876763` — a mixed fleet with an old node re-inflates the supply or
+   re-accepts the mis-signed tx.
 3. **Burn drops supply (BUG-20 proof):** run the drill's burn step and confirm
    `outstanding` DECREASES by the burned amount (before this binary a burn
    confirmed but supply stayed flat).

--- a/doc/design/DL-USDSOQ-MEMPOOL-FIX-DEPLOY-RUNBOOK.md
+++ b/doc/design/DL-USDSOQ-MEMPOOL-FIX-DEPLOY-RUNBOOK.md
@@ -1,20 +1,33 @@
 # USDSOQ Mempool Crash Fix — Fleet Deploy Runbook (Buddy handoff)
 
-**Fix branch:** `consensus/usdsoq-mempool-crash-fix` (repo `soqucoin/soqucoin`), tip `9270bd79b`
+**Fix branch:** `consensus/usdsoq-mempool-crash-fix` (repo `soqucoin/soqucoin`), tip `e860a6409`
 **Spec:** `doc/design/DL-USDSOQ-MEMPOOL-CRASH-FIX.md`
-**Staged binary:** Services VPS `143.110.229.69:/usr/local/bin/soqucoind.usdsoqfix`
-- version `v1.4.0.0-9270bd79b`, sha256 `625ecd239b9c1f09cf03114d4b4ad9de607dc92b3ba05bf1d6782087a6d7fc7f`
+**Staged binary (REBUILT — now contains Bug 2 + BUG-18):** Services VPS `143.110.229.69:/usr/local/bin/soqucoind.usdsoqfix`
+- version `v1.4.0.0-e860a6409`, sha256 `e61e727ccac0bfaf6ab739f6ad6708fd138f537c4082e6c4a2cac066a2f3d6cd`
 - Linux x86-64 ELF, built on the Services VPS from the fix branch.
+- ⚠️ Supersedes the earlier `625ecd23…` binary (that one had only Bug 2). Deploy THIS one.
 
-## What this fixes
+## What this fixes (TWO critical bugs, both in this binary)
 
-A non-conserving USDSOQ spend crashed the node (`CTxMemPoolEntry` assert →
-abort). Remotely-triggerable DoS + the reason USDSOQ sends fail. Two layers:
-mempool acceptance now rejects non-conserving USDSOQ txs cleanly, and the entry
-constructor clamps instead of asserting. **Backward-compatible** — it only adds
-a reject for txs that were already consensus-invalid and removes an abort; block
-validity is unchanged. Verified: `mempool_tests` + USDSOQ/freeze suites green.
-NOT yet live-proven (this deploy is the proof).
+**Bug 2 — node crash on USDSOQ spend.** A non-conserving USDSOQ spend crashed
+the node (`CTxMemPoolEntry` assert → abort) — remotely-triggerable DoS.
+Mempool acceptance now rejects non-conserving USDSOQ txs cleanly and the entry
+constructor clamps instead of asserting.
+
+**BUG-18 — USDSOQ supply-accumulator leak in dry-run validation (found live).**
+`ConnectBlock` mutated the global supply counter even during `fJustCheck` dry-runs
+(`TestBlockValidity`, run on every `getblocktemplate` poll) with no rollback, so
+the counter inflated ~1000→137000 after ~140 polls; `TestBlockValidity` then
+failed and the pool mined ~570 empty (coinbase-only) blocks, blocking ALL USDSOQ
+confirmation. Now the delta is validated on a copy and committed only on a real
+connect (`!fJustCheck`).
+
+Both are **backward-compatible** (block validity unchanged) and verified by unit
+tests (`mempool_tests`, the v7 conservation harness incl. the dry-run-no-leak
+regression, plus the USDSOQ/freeze suites — all green). NOT yet live-proven;
+this deploy is the proof. NOTE: running nodes may hold an inflated in-memory
+supply — a restart reloads the correct value from LevelDB (the persist was
+always `!fJustCheck`-gated), so the redeploy self-heals it.
 
 ## ⚠️ Binary-parity caveat
 
@@ -46,7 +59,7 @@ Confirm the full node set from the fleet topology before starting.
 2. Back up the current binary (`cp /usr/local/bin/soqucoind{,.bak-YYYYMMDD}`).
 3. Install the new binary in place.
 4. `systemctl restart soqucoind-<role>` (per node role).
-5. Verify: `soqucoind ... --version` == `v1.4.0.0-9270bd79b`; node reaches the
+5. Verify: `soqucoind ... --version` == `v1.4.0.0-e860a6409`; node reaches the
    current tip and stays up (`getblockcount`, no assertion in the journal).
 
 ## Post-deploy verification (the live proof)

--- a/doc/design/DL-USDSOQ-MEMPOOL-FIX-DEPLOY-RUNBOOK.md
+++ b/doc/design/DL-USDSOQ-MEMPOOL-FIX-DEPLOY-RUNBOOK.md
@@ -1,13 +1,13 @@
 # USDSOQ Mempool Crash Fix — Fleet Deploy Runbook (Buddy handoff)
 
-**Fix branch:** `consensus/usdsoq-mempool-crash-fix` (repo `soqucoin/soqucoin`), tip `e860a6409`
+**Fix branch:** `consensus/usdsoq-mempool-crash-fix` (repo `soqucoin/soqucoin`), tip `a982ee25b`
 **Spec:** `doc/design/DL-USDSOQ-MEMPOOL-CRASH-FIX.md`
-**Staged binary (REBUILT — now contains Bug 2 + BUG-18):** Services VPS `143.110.229.69:/usr/local/bin/soqucoind.usdsoqfix`
-- version `v1.4.0.0-e860a6409`, sha256 `e61e727ccac0bfaf6ab739f6ad6708fd138f537c4082e6c4a2cac066a2f3d6cd`
+**Staged binary (REBUILT — now contains Bug 2 + BUG-18 + BUG-19 + BUG-20):** Services VPS `143.110.229.69:/usr/local/bin/soqucoind.usdsoqfix`
+- version `v1.4.0.0-a982ee25b`, sha256 `095b67c25e558c2c41d067ecbb2838a03c577a455f664257ed8d04cff35597c9`
 - Linux x86-64 ELF, built on the Services VPS from the fix branch.
-- ⚠️ Supersedes the earlier `625ecd23…` binary (that one had only Bug 2). Deploy THIS one.
+- ⚠️ Supersedes the earlier `e61e727c…` (Bug2+BUG-18) and `625ecd23…` (Bug2-only) binaries. Deploy THIS one.
 
-## What this fixes (TWO critical bugs, both in this binary)
+## What this fixes (FOUR bugs, all in this binary)
 
 **Bug 2 — node crash on USDSOQ spend.** A non-conserving USDSOQ spend crashed
 the node (`CTxMemPoolEntry` assert → abort) — remotely-triggerable DoS.
@@ -22,12 +22,31 @@ failed and the pool mined ~570 empty (coinbase-only) blocks, blocking ALL USDSOQ
 confirmation. Now the delta is validated on a copy and committed only on a real
 connect (`!fJustCheck`).
 
-Both are **backward-compatible** (block validity unchanged) and verified by unit
-tests (`mempool_tests`, the v7 conservation harness incl. the dry-run-no-leak
-regression, plus the USDSOQ/freeze suites — all green). NOT yet live-proven;
-this deploy is the proof. NOTE: running nodes may hold an inflated in-memory
-supply — a restart reloads the correct value from LevelDB (the persist was
-always `!fJustCheck`-gated), so the redeploy self-heals it.
+**BUG-19 — plain USDSOQ transfers inflated the supply (found live; this was the
+remaining empty-block cause after BUG-18).** `ConnectBlock` counted EVERY
+transparent v7 output as "minted", so an ordinary v7→v7 send added its amount to
+the supply every time (the burn side couldn't offset it — see BUG-20). The
+inflated supply then failed the block template carrying the send. Fix: supply is
+moved only by AUTHORITY txs (OP_5 marker); a transfer is now supply-neutral.
+Mirrored in `DisconnectBlock` so reorgs only reverse authority-tx deltas.
+
+**BUG-20 — authority burns didn't decrement the supply (latent; would have
+surfaced at the burn step).** The burned-input counter read the coins view after
+`UpdateCoins` had already spent the inputs, so it was silently always 0 — a burn
+tx confirmed but the supply never dropped. Fix: read the spent prevouts from the
+block undo (same source `DisconnectBlock` uses), gated on `isAuthorityTx`. Supply
+accounting is now correct for mint (+outputs), pure burn (−inputs), and
+burn-with-change (outputs−inputs = net burned).
+
+All four are **backward-compatible** (block validity rules unchanged for any
+already-valid block) and verified by unit tests — `mempool_tests`, the v7
+conservation harness (7 cases: the SOQ→v7 rejection, v7→v7 conservation, the
+BUG-18 dry-run-no-leak regression, the BUG-19 `v7_send_connects_with_prior_minted_supply`
+regression, and the BUG-20 `v7_authority_burn_decrements_supply` regression),
+plus the usdsoq/authority/v7-holding/freeze/covenant/ctxout suites — all green.
+BUG-19/20 are NOT yet live-proven; this deploy + the send/burn drill steps are
+the proof. NOTE: a restart reloads the correct supply from LevelDB (persist was
+always `!fJustCheck`-gated), so the redeploy self-heals any inflated in-memory value.
 
 ## ⚠️ Binary-parity caveat
 
@@ -59,7 +78,7 @@ Confirm the full node set from the fleet topology before starting.
 2. Back up the current binary (`cp /usr/local/bin/soqucoind{,.bak-YYYYMMDD}`).
 3. Install the new binary in place.
 4. `systemctl restart soqucoind-<role>` (per node role).
-5. Verify: `soqucoind ... --version` == `v1.4.0.0-e860a6409`; node reaches the
+5. Verify: `soqucoind ... --version` == `v1.4.0.0-a982ee25b`; node reaches the
    current tip and stays up (`getblockcount`, no assertion in the journal).
 
 ## Post-deploy verification (the live proof)
@@ -68,10 +87,17 @@ Confirm the full node set from the fleet topology before starting.
    (or just retry the app send below) and confirm the node returns
    `bad-txns-usdsoq-not-conserved` and STAYS UP (no `Assertion ... failed` in the
    journal, no systemd restart).
-2. **Real send works** (needs the app fix too — repo `soqucoin-ops`, branch
-   `feat/usdsoq-balance-v7-index`, rebuild the sim): SoquShield → Send → USDSOQ →
-   100 to self → approve → broadcasts. Then verify on-chain the v7→v7 transfer
-   conserved (supply unchanged) and both scripthashes re-indexed.
+2. **Send now CONFIRMS (BUG-19 proof):** the earlier send `daf9fd85` was
+   mempool-flushed, so re-broadcast a fresh v7→v7 send (SoquShield → Send →
+   USDSOQ → 100 to self → approve, with the app fix below; or via the signer).
+   Then confirm it gets MINED into a real block (not just accepted) and that
+   `getusdsoqsupply`/the balance API shows `outstanding` UNCHANGED across the
+   send (a transfer is supply-neutral). Empty blocks around the send = BUG-19 not
+   deployed. ⚠️ Do NOT re-broadcast until ALL chain-backing nodes run
+   `a982ee25b` — a mixed fleet with an old node re-inflates the supply.
+3. **Burn drops supply (BUG-20 proof):** run the drill's burn step and confirm
+   `outstanding` DECREASES by the burned amount (before this binary a burn
+   confirmed but supply stayed flat).
 
 ## App side (same handoff)
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -999,12 +999,16 @@ public:
         consensus.usdsoqAuthorityThreshold = 2;  // 2-of-3 multisig
 
         // SOQ-I005-STAGENET: Authority signature enforcement height.
-        // Blocks 0–37200 contain pre-authority USDSOQ test mints (created via
-        // CLI `usdsoqmint` RPC before ConnectBlock authority validation existed).
-        // These TXs are structurally valid but lack authority witness signatures.
-        // Authority signature verification is required from block 37201 onward.
+        // RECALIBRATED 2026-07-04 (Casey-ratified) for the reset stagenet chain:
+        // the old 37201 was calibrated for the pre-reset chain's CLI test mints
+        // and, on the reset chain, ALSO silently no-opped freeze/unfreeze
+        // registry application in ConnectBlock until ~block 37201.
+        // Blocks 0–7699 hold the signer-built drill txs (mint 6501, send 7077,
+        // burn 7595) and stay exempt, so historical validation is unchanged.
+        // From 7700 onward: full M-of-N authority signature verification AND
+        // freeze-registry application are enforced (mainnet-shape behavior).
         // See SECURITY_ISSUE_REGISTRY.md SOQ-I005-STAGENET.
-        consensus.nUSDSOQAuthorityEnforcementHeight = 37201;
+        consensus.nUSDSOQAuthorityEnforcementHeight = 7700;
 
         // SOQ-I007-STAGENET: UTXO cost minimum enforcement height.
         // Blocks 0–37200 may contain outputs below UTXO_COST_PER_BYTE minimum

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -152,14 +152,16 @@ struct Params {
     /** SOQ-I005-STAGENET: USDSOQ authority signature enforcement height.
      *  Before this height, USDSOQ authority TXs (bootstrap or chain) are
      *  accepted WITHOUT authority signature verification. This exempts
-     *  pre-authority test mints on stagenet (blocks 0–37200).
+     *  pre-enforcement authority txs on stagenet.
      *
      *  MAINNET: Set to 0 — authority signatures enforced from BIP9 activation.
      *  No unsigned USDSOQ TX can exist before BIP9 activates USDSOQ, so the
      *  enforcement height is irrelevant (there are no blocks to exempt).
      *
-     *  STAGENET: Set to 37201 — blocks 0-37200 exempt (pre-authority test mints).
-     *  Authority signature verification required from block 37201 onward.
+     *  STAGENET: Set to 7700 (recalibrated 2026-07-04 for the reset chain;
+     *  was 37201 for the pre-reset chain). Blocks 0-7699 exempt (drill txs).
+     *  Authority signature verification AND freeze-registry application are
+     *  required from block 7700 onward.
      *
      *  See SECURITY_ISSUE_REGISTRY.md SOQ-I005-STAGENET for full rationale. */
     int32_t nUSDSOQAuthorityEnforcementHeight = 0;

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -585,4 +585,34 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     SetMockTime(0);
 }
 
+// SOQ-USDSOQ-MEMPOOL-CRASH: a non-conserving USDSOQ spend produced
+// inChainInputValue > (GetValueOut() + fee). The old CTxMemPoolEntry ctor
+// assert()ed on that and abort()ed the daemon — a remotely-triggerable crash.
+// The ctor now clamps instead of aborting. This test constructs that exact
+// condition and verifies (a) no abort and (b) inChainInputValue is clamped to
+// GetValueOut()+fee. Before the fix this test would kill the test binary.
+BOOST_AUTO_TEST_CASE(MempoolEntryNoCrashOnUsdsoqImbalance)
+{
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vin[0].scriptSig = CScript() << OP_11;
+    tx.vout.resize(1);
+    tx.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx.vout[0].nValue = 100000LL; // GetValueOut() == 100000
+
+    const CAmount fee = 0;
+    // inChainInputValue far exceeds GetValueOut()+fee — the crash condition
+    // (mirrors a USDSOQ input whose raw value isn't reflected in the SOQ-only fee).
+    const CAmount inflatedInChain = 100000000000LL; // 1000 "USDSOQ"
+    LockPoints lp;
+
+    CTxMemPoolEntry entry(MakeTransactionRef(tx), fee, /*nTime=*/0, /*prio=*/0.0,
+        /*height=*/1, inflatedInChain, /*spendsCoinbase=*/false, /*sigOps=*/1, lp);
+
+    // Reaching here at all means we did NOT abort() (the DoS is fixed).
+    // The value is clamped to GetValueOut()+fee so the priority heuristic stays sane.
+    BOOST_CHECK_EQUAL(entry.GetInChainInputValue(), CTransaction(tx).GetValueOut() + fee);
+    BOOST_CHECK(entry.GetTxSize() > 0);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -77,6 +77,12 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
     mempool.setSanityCheck(1.0);
     pblocktree = new CBlockTreeDB(1 << 20, true);
     pcoinsdbview = new CCoinsViewDB(1 << 23, true);
+    // The member above SHADOWS the validation.cpp global of the same name.
+    // Production (init.cpp) sets the global, and consensus paths in
+    // validation.cpp (freeze-registry lookups, supply/authority persistence)
+    // are guarded on it — leaving it null silently disables those paths in
+    // every unit test. Mirror the production wiring.
+    ::pcoinsdbview = pcoinsdbview;
     pcoinsTip = new CCoinsViewCache(pcoinsdbview);
     InitBlockIndex(chainparams);
     {
@@ -99,6 +105,7 @@ TestingSetup::~TestingSetup()
     threadGroup.join_all();
     UnloadBlockIndex();
     delete pcoinsTip;
+    ::pcoinsdbview = nullptr; // un-alias the global before freeing the member
     delete pcoinsdbview;
     delete pblocktree;
     fs::remove_all(pathTemp);

--- a/src/test/usdsoq_v7_conservation_harness_tests.cpp
+++ b/src/test/usdsoq_v7_conservation_harness_tests.cpp
@@ -65,6 +65,19 @@ static CScript MakeV7Spk(const std::vector<unsigned char>& rawPubkey)
     return spk;
 }
 
+// V5 authority-marker scriptPubKey: OP_5 <32-byte hash>. Its presence in an output
+// makes a tx an AUTHORITY tx (mint/burn/freeze/rotate) — the OP_5 <32> shape is exactly
+// what ConnectBlock scans for. Sig verification only kicks in once g_usdsoq_authority
+// is initialized (it is NOT in this harness), so a marker alone flags authority here.
+static CScript MakeV5Spk(const std::vector<unsigned char>& rawPubkey)
+{
+    uint256 pkHash;
+    CSHA256().Write(rawPubkey.data(), rawPubkey.size()).Finalize(pkHash.begin());
+    CScript spk;
+    spk << OP_5 << std::vector<unsigned char>(pkHash.begin(), pkHash.end());
+    return spk;
+}
+
 // 0x00-prefixed pubkey for the trailing witness item (FIPS 204 Table 3).
 static std::vector<unsigned char> Prefixed(const std::vector<unsigned char>& rawPubkey)
 {
@@ -276,6 +289,29 @@ struct V7ConservationChainSetup : public TestingSetup {
         return tx;
     }
 
+    // AUTHORITY BURN: a v7 USDSOQ input is destroyed (no v7 output), the tx carries an
+    // OP_5 authority marker so it's exempt from value-conservation, and a SOQ fee input
+    // covers the marker + fee. USDSOQ in > USDSOQ out → supply must DROP by the burned
+    // amount. Exercises the BUG-20 path: burned inputs are read from the block undo
+    // (they're already spent in the coins view by the time the supply loop runs).
+    CMutableTransaction BuildV7Burn(const COutPoint& v7op, CAmount v7Val,
+                                    const CTransaction& feeCoinbase)
+    {
+        const CAmount feeVal = feeCoinbase.vout[0].nValue;
+        CMutableTransaction tx; tx.nVersion = 2;
+
+        CTxIn vin0; vin0.prevout = v7op; vin0.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(vin0);
+        CTxIn vin1; vin1.prevout = COutPoint(feeCoinbase.GetHash(), 0); vin1.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(vin1);
+
+        // OP_5 authority marker (funded from the SOQ input) — no v7 output at all.
+        CTxOut mark; mark.nValue = 10000;              mark.scriptPubKey = MakeV5Spk(coinbasePkBytes); tx.vout.push_back(mark);
+        CTxOut chg;  chg.nValue  = feeVal - 20000;     chg.scriptPubKey  = coinbaseSpk;                 tx.vout.push_back(chg);  // SOQ change (fee=10000)
+
+        SignInput(tx, 0, MakeV7Spk(coinbasePkBytes), v7Val);  // v7 USDSOQ input (to be burned)
+        SignInput(tx, 1, coinbaseSpk, feeVal);                // SOQ fee input
+        return tx;
+    }
+
     // v7 USDSOQ input → v1 SOQ output (no USDSOQ out): converting USDSOQ→SOQ, must be rejected.
     CMutableTransaction BuildV7ToSoq(const COutPoint& v7op, CAmount v7Val, const CScript& soqDestSpk)
     {
@@ -438,6 +474,36 @@ BOOST_AUTO_TEST_CASE(dryrun_testblockvalidity_does_not_leak_usdsoq_supply)
     BOOST_CHECK_EQUAL(g_usdsoq_supply.TotalMinted(), mintedBefore);
     BOOST_CHECK_EQUAL(g_usdsoq_supply.TotalBurned(), burnedBefore);
     BOOST_CHECK_EQUAL(g_usdsoq_supply.Outstanding(), outBefore);
+}
+
+// ---------------------------------------------------------------------------
+// BUG-20: an AUTHORITY burn must DECREMENT the supply. Before the fix the
+// burned-input count read the coins view AFTER UpdateCoins had already spent
+// the inputs, so nUSDSOQBurned was always 0 and a burn left the supply
+// unchanged (USDSOQ silently un-destroyable). The fix reads the spent prevouts
+// from the block undo. Seed a prior mint of v7Val, burn the whole v7 coin, and
+// assert outstanding drops to 0.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(v7_authority_burn_decrements_supply)
+{
+    const CAmount v7Val = 5 * COIN;
+    {
+        LOCK(cs_main);
+        g_usdsoq_supply.Reset();
+        BOOST_REQUIRE(g_usdsoq_supply.Mint(v7Val)); // the earlier authority mint
+    }
+    COutPoint v7op = SeedV7Coin(v7Val, 0x00);
+    CMutableTransaction burn = BuildV7Burn(v7op, v7Val, coinbaseTxns[0]);
+    std::vector<CMutableTransaction> txns{burn};
+    CBlock B = CreateAndProcessBlock(txns, coinbaseSpk);
+    BOOST_CHECK_MESSAGE(chainActive.Tip()->GetBlockHash() == B.GetHash(),
+        "an authority burn (v7 in, OP_5 marker, no v7 out) must connect");
+    {
+        LOCK(cs_main);
+        BOOST_CHECK_EQUAL(g_usdsoq_supply.TotalBurned(), v7Val);   // burn was counted
+        BOOST_CHECK_EQUAL(g_usdsoq_supply.Outstanding(), 0);       // supply destroyed
+        g_usdsoq_supply.Reset();
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/usdsoq_v7_conservation_harness_tests.cpp
+++ b/src/test/usdsoq_v7_conservation_harness_tests.cpp
@@ -148,6 +148,41 @@ struct V7ConservationChainSetup : public TestingSetup {
         return block;
     }
 
+    // Like CreateAndProcessBlock but STOPS before ProcessNewBlock — returns a fully
+    // solved (PoW + commitment) block that is NOT connected, so a caller can run
+    // TestBlockValidity(fJustCheck) against it repeatedly. Used to reproduce BUG-18
+    // (getblocktemplate re-runs the dry-run every poll).
+    CBlock BuildSolvedBlock(const std::vector<CMutableTransaction>& txns, const CScript& spk)
+    {
+        const CChainParams& cp = Params();
+        std::unique_ptr<CBlockTemplate> tmpl = BlockAssembler(cp).CreateNewBlock(spk, true);
+        BOOST_REQUIRE(tmpl != nullptr);
+        CBlock& block = tmpl->block;
+        block.vtx.resize(1);
+        {
+            CMutableTransaction coinbaseMut(*block.vtx[0]);
+            coinbaseMut.vout.erase(
+                std::remove_if(coinbaseMut.vout.begin(), coinbaseMut.vout.end(),
+                    [](const CTxOut& o) {
+                        return o.scriptPubKey.size() >= 38 &&
+                               o.scriptPubKey[0] == OP_RETURN && o.scriptPubKey[1] == 0x24 &&
+                               o.scriptPubKey[2] == 0xaa && o.scriptPubKey[3] == 0x21 &&
+                               o.scriptPubKey[4] == 0xa9 && o.scriptPubKey[5] == 0xed;
+                    }),
+                coinbaseMut.vout.end());
+            coinbaseMut.vin[0].scriptWitness.stack.clear();
+            block.vtx[0] = MakeTransactionRef(std::move(coinbaseMut));
+        }
+        for (const CMutableTransaction& tx : txns)
+            block.vtx.push_back(MakeTransactionRef(tx));
+        GenerateCoinbaseCommitment(block, chainActive.Tip(), cp.GetConsensus(0));
+        unsigned int extraNonce = 0;
+        IncrementExtraNonce(&block, chainActive.Tip(), extraNonce);
+        while (!CheckProofOfWork(block.GetPoWHash(), block.nBits, cp.GetConsensus(0)))
+            ++block.nNonce;
+        return block;
+    }
+
     // A NON-authority tx spending a mature coinbase to a single output `destSpk`,
     // signed with the Dilithium v1 witness path. Fee = 10000 sat in SOQ.
     CMutableTransaction BuildSpendTo(const CTransaction& coinbase, const CScript& destSpk)
@@ -339,6 +374,43 @@ BOOST_AUTO_TEST_CASE(v7_input_to_soq_output_rejected)
     BOOST_CHECK_MESSAGE(chainActive.Tip()->GetBlockHash() != B.GetHash(),
         "a v7-USDSOQ-input → SOQ-output tx must be rejected by conservation (can't convert "
         "USDSOQ→SOQ); if it connects, the v7 input isn't classified USDSOQ by version");
+}
+
+// ---------------------------------------------------------------------------
+// BUG-18: a VALIDATION-ONLY dry-run (TestBlockValidity → ConnectBlock fJustCheck)
+// must NOT mutate the global USDSOQ supply accumulator. CreateNewBlock runs this
+// on EVERY getblocktemplate poll; the old code leaked the counter each call, so
+// after ~140 polls the supply inflated and the pool mined empty blocks. Here we
+// build a valid v7→v7-send block and TestBlockValidity it many times, asserting
+// the global supply is byte-for-byte unchanged. Before the fix this fails
+// (total_minted grows by v7Val per call).
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(dryrun_testblockvalidity_does_not_leak_usdsoq_supply)
+{
+    const CAmount v7Val = 5 * COIN;
+    COutPoint v7op = SeedV7Coin(v7Val, 0x00);
+    CScript v7Dest = MakeV7Spk(coinbasePkBytes);
+    CMutableTransaction send = BuildV7ToV7Send(v7op, v7Val, coinbaseTxns[0], v7Dest);
+    CBlock B = BuildSolvedBlock({send}, coinbaseSpk); // solved but NOT connected
+
+    LOCK(cs_main);
+    const CAmount mintedBefore = g_usdsoq_supply.TotalMinted();
+    const CAmount burnedBefore = g_usdsoq_supply.TotalBurned();
+    const CAmount outBefore = g_usdsoq_supply.Outstanding();
+
+    // Simulate 25 getblocktemplate polls (each is a TestBlockValidity dry-run).
+    bool anyValid = false;
+    for (int i = 0; i < 25; ++i) {
+        CValidationState st;
+        if (TestBlockValidity(st, Params(), B, chainActive.Tip(), true, true))
+            anyValid = true;
+    }
+    BOOST_CHECK_MESSAGE(anyValid, "the send block must pass TestBlockValidity at least once "
+        "(else this test isn't exercising the supply-delta path)");
+
+    BOOST_CHECK_EQUAL(g_usdsoq_supply.TotalMinted(), mintedBefore);
+    BOOST_CHECK_EQUAL(g_usdsoq_supply.TotalBurned(), burnedBefore);
+    BOOST_CHECK_EQUAL(g_usdsoq_supply.Outstanding(), outBefore);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/usdsoq_v7_conservation_harness_tests.cpp
+++ b/src/test/usdsoq_v7_conservation_harness_tests.cpp
@@ -289,6 +289,29 @@ struct V7ConservationChainSetup : public TestingSetup {
         return tx;
     }
 
+    // Mirrors the LIVE drill send daf9fd85: one v7 USDSOQ input (full value) SPLIT into
+    // TWO v7 outputs (split0 + (v7Val-split0)) + a SOQ fee input → SOQ change. USDSOQ
+    // in==out exactly across the two outputs; fee paid in SOQ. This is the shape the app
+    // actually produces (send amount + USDSOQ change), which the single-output helper
+    // above does not exercise.
+    CMutableTransaction BuildV7SplitSend(const COutPoint& v7op, CAmount v7Val, CAmount split0,
+                                         const CTransaction& feeCoinbase, const CScript& v7DestSpk)
+    {
+        const CAmount feeVal = feeCoinbase.vout[0].nValue;
+        CMutableTransaction tx; tx.nVersion = 2;
+
+        CTxIn vin0; vin0.prevout = v7op; vin0.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(vin0);
+        CTxIn vin1; vin1.prevout = COutPoint(feeCoinbase.GetHash(), 0); vin1.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(vin1);
+
+        CTxOut o0; o0.nValue = split0;          o0.scriptPubKey = v7DestSpk;  tx.vout.push_back(o0); // USDSOQ send
+        CTxOut o1; o1.nValue = v7Val - split0;  o1.scriptPubKey = v7DestSpk;  tx.vout.push_back(o1); // USDSOQ change (v7)
+        CTxOut o2; o2.nValue = feeVal - 10000;  o2.scriptPubKey = coinbaseSpk; tx.vout.push_back(o2); // SOQ change
+
+        SignInput(tx, 0, MakeV7Spk(coinbasePkBytes), v7Val);
+        SignInput(tx, 1, coinbaseSpk, feeVal);
+        return tx;
+    }
+
     // AUTHORITY BURN: a v7 USDSOQ input is destroyed (no v7 output), the tx carries an
     // OP_5 authority marker so it's exempt from value-conservation, and a SOQ fee input
     // covers the marker + fee. USDSOQ in > USDSOQ out → supply must DROP by the burned
@@ -484,6 +507,30 @@ BOOST_AUTO_TEST_CASE(dryrun_testblockvalidity_does_not_leak_usdsoq_supply)
 // from the block undo. Seed a prior mint of v7Val, burn the whole v7 coin, and
 // assert outstanding drops to 0.
 // ---------------------------------------------------------------------------
+// LIVE REPRO: exact shape of the drill send daf9fd85 — a 1000-unit v7 coin split into
+// 100 + 900 v7 outputs, prior supply minted=1000. Must connect and leave outstanding=1000.
+BOOST_AUTO_TEST_CASE(v7_split_send_connects_with_prior_minted_supply)
+{
+    const CAmount v7Val = 1000 * COIN;
+    {
+        LOCK(cs_main);
+        g_usdsoq_supply.Reset();
+        BOOST_REQUIRE(g_usdsoq_supply.Mint(v7Val));
+    }
+    COutPoint v7op = SeedV7Coin(v7Val, 0x00);
+    CScript v7Dest = MakeV7Spk(coinbasePkBytes);
+    CMutableTransaction send = BuildV7SplitSend(v7op, v7Val, 100 * COIN, coinbaseTxns[0], v7Dest);
+    std::vector<CMutableTransaction> txns{send};
+    CBlock B = CreateAndProcessBlock(txns, coinbaseSpk);
+    BOOST_CHECK_MESSAGE(chainActive.Tip()->GetBlockHash() == B.GetHash(),
+        "a v7→(v7+v7) split send (the app's real shape) must connect with prior supply>0");
+    {
+        LOCK(cs_main);
+        BOOST_CHECK_EQUAL(g_usdsoq_supply.Outstanding(), v7Val);
+        g_usdsoq_supply.Reset();
+    }
+}
+
 BOOST_AUTO_TEST_CASE(v7_authority_burn_decrements_supply)
 {
     const CAmount v7Val = 5 * COIN;

--- a/src/test/usdsoq_v7_conservation_harness_tests.cpp
+++ b/src/test/usdsoq_v7_conservation_harness_tests.cpp
@@ -385,6 +385,33 @@ BOOST_AUTO_TEST_CASE(v7_input_to_soq_output_rejected)
 // the global supply is byte-for-byte unchanged. Before the fix this fails
 // (total_minted grows by v7Val per call).
 // ---------------------------------------------------------------------------
+// BUG-19 repro: match the LIVE state — a prior real mint left outstanding>0 —
+// then validate/connect a plain v7→v7 send. If ConnectBlock's gross-flow supply
+// accounting (transfer outputs counted as minted, inputs as burned) rejects the
+// block, this reproduces the empty-block failure.
+BOOST_AUTO_TEST_CASE(v7_send_connects_with_prior_minted_supply)
+{
+    const CAmount v7Val = 5 * COIN;
+    {
+        LOCK(cs_main);
+        g_usdsoq_supply.Reset();
+        BOOST_REQUIRE(g_usdsoq_supply.Mint(v7Val)); // simulate the earlier authority mint
+    }
+    COutPoint v7op = SeedV7Coin(v7Val, 0x00);
+    CScript v7Dest = MakeV7Spk(coinbasePkBytes);
+    CMutableTransaction send = BuildV7ToV7Send(v7op, v7Val, coinbaseTxns[0], v7Dest);
+    std::vector<CMutableTransaction> txns{send};
+    CBlock B = CreateAndProcessBlock(txns, coinbaseSpk);
+    BOOST_CHECK_MESSAGE(chainActive.Tip()->GetBlockHash() == B.GetHash(),
+        "a v7→v7 send must connect even when prior supply.outstanding>0 — a plain transfer "
+        "must not be rejected by supply accounting (BUG-19)");
+    {
+        LOCK(cs_main);
+        BOOST_CHECK_EQUAL(g_usdsoq_supply.Outstanding(), v7Val); // transfer is supply-neutral
+        g_usdsoq_supply.Reset();
+    }
+}
+
 BOOST_AUTO_TEST_CASE(dryrun_testblockvalidity_does_not_leak_usdsoq_supply)
 {
     const CAmount v7Val = 5 * COIN;

--- a/src/test/usdsoq_v7_conservation_harness_tests.cpp
+++ b/src/test/usdsoq_v7_conservation_harness_tests.cpp
@@ -602,4 +602,51 @@ BOOST_AUTO_TEST_CASE(mempool_rejects_v7_input_signed_with_wrong_scriptcode)
     BOOST_CHECK(!mempool.exists(bad.GetHash()));
 }
 
+// REGRESSION BUG-22 (mempool ≡ consensus, same divergence class as BUG-21): the
+// mempool must REJECT a spend of a registry-frozen USDSOQ outpoint. ConnectBlock
+// enforces the freeze registry (bad-txns-spend-frozen-usdsoq), but a frozen-coin
+// spend is script-VALID (freezing does not alter the holding script), so without
+// the ATMP mirror it relays, sits in the mempool, and fails every block template
+// at TestBlockValidity → coinbase-only blocks (the exact empty-block DoS shape of
+// BUG-18/21). The same tx must be ACCEPTED once the outpoint is unfrozen, proving
+// the rejection is the freeze guard and not an incidental policy failure.
+BOOST_AUTO_TEST_CASE(mempool_rejects_spend_of_frozen_v7_outpoint)
+{
+    const CAmount v7Val = 5 * COIN;
+    COutPoint v7op = SeedV7Coin(v7Val, 0x00);
+    CScript v7Dest = MakeV7Spk(coinbasePkBytes);
+    CMutableTransaction spend = BuildV7ToV7Send(v7op, v7Val, coinbaseTxns[0], v7Dest);
+
+    // Freeze the outpoint in the DB-backed registry (what a mined authority
+    // FREEZE op does via WriteFrozenOutpoint at ConnectBlock).
+    {
+        LOCK(cs_main);
+        BOOST_REQUIRE(pcoinsdbview->WriteFrozenOutpoint(v7op));
+        BOOST_REQUIRE(pcoinsdbview->IsFrozenOutpoint(v7op));
+    }
+
+    CValidationState state;
+    bool missingInputs = false;
+    bool ok = AcceptToMemoryPool(mempool, state, MakeTransactionRef(spend), false,
+                                 &missingInputs, nullptr, false, 0);
+    BOOST_CHECK_MESSAGE(!ok, "mempool must REJECT a spend of a frozen USDSOQ outpoint "
+        "(else it relays and stalls every block template at TestBlockValidity)");
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-txns-spend-frozen-usdsoq");
+    BOOST_CHECK(!mempool.exists(spend.GetHash()));
+
+    // Unfreeze → the SAME tx must now be accepted (isolates the freeze guard).
+    {
+        LOCK(cs_main);
+        BOOST_REQUIRE(pcoinsdbview->EraseFrozenOutpoint(v7op));
+        BOOST_REQUIRE(!pcoinsdbview->IsFrozenOutpoint(v7op));
+    }
+    CValidationState state2;
+    bool missingInputs2 = false;
+    bool ok2 = AcceptToMemoryPool(mempool, state2, MakeTransactionRef(spend), false,
+                                  &missingInputs2, nullptr, false, 0);
+    BOOST_CHECK_MESSAGE(ok2, "the identical tx must be ACCEPTED once unfrozen, got: "
+        + state2.GetRejectReason());
+    BOOST_CHECK(mempool.exists(spend.GetHash()));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/usdsoq_v7_conservation_harness_tests.cpp
+++ b/src/test/usdsoq_v7_conservation_harness_tests.cpp
@@ -31,6 +31,7 @@
 #include "script/interpreter.h"
 #include "script/script.h"
 #include "coins.h"
+#include "txmempool.h"
 #include "txdb.h"
 #include "uint256.h"
 #include "validation.h"
@@ -286,6 +287,25 @@ struct V7ConservationChainSetup : public TestingSetup {
 
         SignInput(tx, 0, MakeV7Spk(coinbasePkBytes), v7Val);  // v7 USDSOQ input
         SignInput(tx, 1, coinbaseSpk, feeVal);                // SOQ fee input
+        return tx;
+    }
+
+    // The daf9fd85 BUG, reproduced: a conserving v7→v7 send whose v7 input is signed
+    // against the v1 scriptCode (OP_1 <program>) instead of the correct v7 scriptCode
+    // (OP_7 <program>). The tx is otherwise valid (conserves, generous SOQ fee), so the
+    // ONLY thing wrong is the v7 signature — which the node catches as NULLFAIL once
+    // SCRIPT_VERIFY_USDSOQ is set. Used to prove the mempool now enforces that flag.
+    CMutableTransaction BuildV7SendMisSigned(const COutPoint& v7op, CAmount v7Val,
+                                             const CTransaction& feeCoinbase, const CScript& v7DestSpk)
+    {
+        const CAmount feeVal = feeCoinbase.vout[0].nValue;
+        CMutableTransaction tx; tx.nVersion = 2;
+        CTxIn vin0; vin0.prevout = v7op; vin0.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(vin0);
+        CTxIn vin1; vin1.prevout = COutPoint(feeCoinbase.GetHash(), 0); vin1.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(vin1);
+        CTxOut o0; o0.nValue = v7Val;            o0.scriptPubKey = v7DestSpk;  tx.vout.push_back(o0); // USDSOQ out (full)
+        CTxOut o1; o1.nValue = feeVal - 100000;  o1.scriptPubKey = coinbaseSpk; tx.vout.push_back(o1); // SOQ change (generous 100k fee)
+        SignInput(tx, 0, MakeV1Spk(coinbasePkBytes), v7Val);  // WRONG: v1 scriptCode for a v7 input (the bug)
+        SignInput(tx, 1, coinbaseSpk, feeVal);                // SOQ fee input (correct)
         return tx;
     }
 
@@ -551,6 +571,35 @@ BOOST_AUTO_TEST_CASE(v7_authority_burn_decrements_supply)
         BOOST_CHECK_EQUAL(g_usdsoq_supply.Outstanding(), 0);       // supply destroyed
         g_usdsoq_supply.Reset();
     }
+}
+
+// REGRESSION (mempool ≡ consensus, live bug daf9fd85): the mempool must REJECT a v7
+// USDSOQ input signed against the wrong (v1) scriptCode instead of relaying it. Before
+// the fix the ATMP script flags omitted SCRIPT_VERIFY_USDSOQ, so a v7 input was
+// anyone-can-spend at accept time → the mis-signed tx relayed, then stalled every block
+// template (ConnectBlock enforces the flag and rejects it → empty blocks). With the
+// mempool now mirroring ConnectBlock's flags, ATMP catches the bad signature up front.
+BOOST_AUTO_TEST_CASE(mempool_rejects_v7_input_signed_with_wrong_scriptcode)
+{
+    const CAmount v7Val = 5 * COIN;
+    COutPoint v7op = SeedV7Coin(v7Val, 0x00);
+    CScript v7Dest = MakeV7Spk(coinbasePkBytes);
+    CMutableTransaction bad = BuildV7SendMisSigned(v7op, v7Val, coinbaseTxns[0], v7Dest);
+
+    CValidationState state;
+    bool missingInputs = false;
+    bool ok = AcceptToMemoryPool(mempool, state, MakeTransactionRef(bad), false,
+                                 &missingInputs, nullptr, false, 0);
+    BOOST_CHECK_MESSAGE(!ok, "mempool must REJECT a v7 input signed with the v1 scriptCode "
+        "(else a tx that ConnectBlock rejects gets relayed and stalls block templates)");
+    BOOST_TEST_MESSAGE("ATMP reject reason: " << state.GetRejectReason());
+    // Confirm it's the SCRIPT-verify check (the flag mirror), not an incidental reject.
+    const std::string& why = state.GetRejectReason();
+    BOOST_CHECK_MESSAGE(why.find("script") != std::string::npos ||
+                        why.find("nullfail") != std::string::npos ||
+                        why.find("mandatory") != std::string::npos,
+        "rejection must be the script-verify flag, got: " + why);
+    BOOST_CHECK(!mempool.exists(bad.GetHash()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -32,7 +32,19 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFe
     nSizeWithDescendants = GetTxSize();
     nModFeesWithDescendants = nFee;
     CAmount nValueIn = tx->GetValueOut() + nFee;
-    assert(inChainInputValue <= nValueIn);
+    // SOQ-USDSOQ-MEMPOOL-CRASH (defense-in-depth): NEVER abort() the daemon here.
+    // For USDSOQ txs, inChainInputValue sums raw coin value (incl. USDSOQ) while
+    // nValueIn uses the SOQ-only fee, so a non-conserving USDSOQ tx makes
+    // inChainInputValue > nValueIn — the original assert() turned that into a
+    // remotely-triggerable node crash. AcceptToMemoryPool now rejects non-conserving
+    // USDSOQ txs before we get here, but inChainInputValue only feeds the priority
+    // heuristic, so if the invariant is ever violated we clamp instead of crashing.
+    if (inChainInputValue > nValueIn) {
+        LogPrintf("CTxMemPoolEntry: clamping inChainInputValue %s > nValueIn %s for tx %s "
+                  "(non-conserving USDSOQ or accounting skew; priority heuristic only)\n",
+                  FormatMoney(inChainInputValue), FormatMoney(nValueIn), tx->GetHash().ToString());
+        inChainInputValue = nValueIn; // member; feeds GetPriority() only
+    }
 
     feeDelta = 0;
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -141,6 +141,7 @@ public:
     unsigned int GetHeight() const { return entryHeight; }
     int64_t GetSigOpCost() const { return sigOpCost; }
     int64_t GetModifiedFee() const { return nFee + feeDelta; }
+    CAmount GetInChainInputValue() const { return inChainInputValue; }
     size_t DynamicMemoryUsage() const { return nUsageSize; }
     const LockPoints& GetLockPoints() const { return lockPoints; }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -861,6 +861,29 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
             }
         }
 
+        // BUG-22: Frozen-UTXO guard must ALSO run at mempool acceptance.
+        // ConnectBlock rejects any spend of a registry-frozen USDSOQ output
+        // (bad-txns-spend-frozen-usdsoq), but without this mirror a frozen-coin
+        // spend is script-valid, relays, and sits in the mempool poisoning
+        // every block template (TestBlockValidity fails) — the same
+        // mempool/consensus divergence class as BUG-21. Mirrors the
+        // ConnectBlock input loop exactly: applies to ALL txs (authority txs
+        // included — a freeze blocks even authority burns of that outpoint),
+        // USDSOQ prevouts only, registry lookup via pcoinsdbview. The registry
+        // is empty until the first post-enforcement freeze, so this adds
+        // nothing until freezes exist (mainnet-inert until USDSOQ activation).
+        for (const auto& txin : tx.vin) {
+            const CCoins* c = view.AccessCoins(txin.prevout.hash);
+            if (c && c->IsAvailable(txin.prevout.n) &&
+                c->vout[txin.prevout.n].IsUSDSOQ() &&
+                pcoinsdbview && pcoinsdbview->IsFrozenOutpoint(txin.prevout)) {
+                return state.DoS(100, false, REJECT_INVALID,
+                    "bad-txns-spend-frozen-usdsoq", false,
+                    strprintf("input %s:%u is a frozen USDSOQ outpoint",
+                        txin.prevout.hash.ToString(), txin.prevout.n));
+            }
+        }
+
         // Keep track of transactions that spend a coinbase, which we re-scan
         // during reorgs to ensure COINBASE_MATURITY is still met.
         bool fSpendsCoinbase = false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3176,37 +3176,49 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             }
         }
 
-        // SOQ-AUD2-002 D1: Persist USDSOQ supply delta to global counter + LevelDB
+        // SOQ-AUD2-002 D1: Apply the USDSOQ supply delta to the global counter + LevelDB.
+        //
+        // BUG-18: ConnectBlock runs with fJustCheck=true for VALIDATION-ONLY dry-runs
+        // (TestBlockValidity, called by CreateNewBlock on every getblocktemplate poll).
+        // The old code mutated the GLOBAL g_usdsoq_supply here unconditionally and only
+        // gated the LevelDB persist on !fJustCheck — so each template poll leaked the
+        // in-memory counter with no rollback. After ~140 polls the supply inflated far
+        // past reality, TestBlockValidity then failed, and the pool fell back to mining
+        // empty (coinbase-only) blocks — blocking ALL USDSOQ tx confirmation.
+        //
+        // Fix: validate the delta on a COPY (so overflow/underflow is still detected
+        // against the real current supply on every path), and COMMIT to the global +
+        // LevelDB ONLY on a real connect (!fJustCheck). A discarded dry-run now leaves
+        // the global untouched. DisconnectBlock reverses the committed delta on reorg.
         if (nUSDSOQMinted > 0 || nUSDSOQBurned > 0) {
-            LogPrintf("USDSOQ: block %d supply delta: minted=%d burned=%d net=%d\n",
-                pindex->nHeight, nUSDSOQMinted, nUSDSOQBurned,
-                nUSDSOQMinted - nUSDSOQBurned);
-
-            // Update in-memory supply counter (checked arithmetic)
-            if (nUSDSOQMinted > 0 && !g_usdsoq_supply.Mint(nUSDSOQMinted)) {
+            CUSDSOQSupply supplyAfter = g_usdsoq_supply; // value copy
+            if (nUSDSOQMinted > 0 && !supplyAfter.Mint(nUSDSOQMinted)) {
                 return state.DoS(100,
                     error("ConnectBlock(): USDSOQ supply overflow on mint of %d at block %d",
                         nUSDSOQMinted, pindex->nHeight),
                     REJECT_INVALID, "bad-usdsoq-supply-overflow");
             }
-            if (nUSDSOQBurned > 0 && !g_usdsoq_supply.Burn(nUSDSOQBurned)) {
+            if (nUSDSOQBurned > 0 && !supplyAfter.Burn(nUSDSOQBurned)) {
                 return state.DoS(100,
                     error("ConnectBlock(): USDSOQ supply underflow on burn of %d at block %d",
                         nUSDSOQBurned, pindex->nHeight),
                     REJECT_INVALID, "bad-usdsoq-supply-underflow");
             }
 
-            // Persist to LevelDB for crash recovery
-            if (!fJustCheck && pcoinsdbview) {
-                if (!pcoinsdbview->WriteUSDSOQSupply(g_usdsoq_supply)) {
+            LogPrintf("USDSOQ: block %d supply delta: minted=%d burned=%d net=%d%s\n",
+                pindex->nHeight, nUSDSOQMinted, nUSDSOQBurned,
+                nUSDSOQMinted - nUSDSOQBurned, fJustCheck ? " (dry-run, not committed)" : "");
+
+            if (!fJustCheck) {
+                g_usdsoq_supply = supplyAfter; // commit only on a real block connect
+                if (pcoinsdbview && !pcoinsdbview->WriteUSDSOQSupply(g_usdsoq_supply)) {
                     LogPrintf("ERROR: USDSOQ: Failed to persist supply to LevelDB at block %d\n",
                         pindex->nHeight);
                 }
+                LogPrintf("USDSOQ: supply state: total_minted=%d total_burned=%d outstanding=%d\n",
+                    g_usdsoq_supply.TotalMinted(), g_usdsoq_supply.TotalBurned(),
+                    g_usdsoq_supply.Outstanding());
             }
-
-            LogPrintf("USDSOQ: supply state: total_minted=%d total_burned=%d outstanding=%d\n",
-                g_usdsoq_supply.TotalMinted(), g_usdsoq_supply.TotalBurned(),
-                g_usdsoq_supply.Outstanding());
         }
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3176,23 +3176,34 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 }
             }
 
-            // Track USDSOQ inputs being spent (consumed supply)
-            for (const auto& txin : tx.vin) {
-                const CCoins* coins = view.AccessCoins(txin.prevout.hash);
-                if (!coins || !coins->IsAvailable(txin.prevout.n))
-                    continue;
-                const CTxOut& prevOut = coins->vout[txin.prevout.n];
-                if (prevOut.IsUSDSOQ()) {
-                    // Defense-in-depth: reject confidential USDSOQ inputs
-                    // Phase 4: use IsConfidential() predicate (v4 witness version)
-                    if (prevOut.IsConfidential()) {
-                        return state.DoS(100,
-                            error("ConnectBlock(): spending confidential USDSOQ input %s:%u"
-                                  " — should not exist",
-                                txin.prevout.hash.ToString(), txin.prevout.n),
-                            REJECT_INVALID, "bad-txns-usdsoq-conf-input");
+            // Track USDSOQ inputs being spent (consumed supply) — AUTHORITY txs only.
+            //
+            // BUG-20: a burn is an authority tx that destroys USDSOQ; a plain transfer is
+            // supply-neutral (its v7 output is NOT counted as minted, per BUG-19 above), so
+            // its inputs must NOT be counted as burned either. Only authority txs move supply.
+            //
+            // The inputs are already spent in the coins view by now (UpdateCoins ran in the
+            // first pass over the block), so the old `view.AccessCoins(...)->IsAvailable`
+            // read here always hit the spent branch and nUSDSOQBurned was silently always 0 —
+            // meaning burns could never decrement the supply. Read the original prevouts from
+            // the block undo instead (the same source DisconnectBlock uses), so burns are
+            // counted correctly AND connect/disconnect stay symmetric on reorg.
+            if (isAuthorityTx && i > 0 && (i - 1) < blockundo.vtxundo.size()) {
+                const CTxUndo& txundo = blockundo.vtxundo[i - 1];
+                for (unsigned int j = 0; j < tx.vin.size() && j < txundo.vprevout.size(); j++) {
+                    const CTxOut& prevOut = txundo.vprevout[j].txout;
+                    if (prevOut.IsUSDSOQ()) {
+                        // Defense-in-depth: reject confidential USDSOQ inputs
+                        // Phase 4: use IsConfidential() predicate (v4 witness version)
+                        if (prevOut.IsConfidential()) {
+                            return state.DoS(100,
+                                error("ConnectBlock(): spending confidential USDSOQ input %s:%u"
+                                      " — should not exist",
+                                    tx.vin[j].prevout.hash.ToString(), tx.vin[j].prevout.n),
+                                REJECT_INVALID, "bad-txns-usdsoq-conf-input");
+                        }
+                        nUSDSOQBurned += prevOut.nValue;
                     }
-                    nUSDSOQBurned += prevOut.nValue;
                 }
             }
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2751,8 +2751,9 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 // always open (signatures always required). No unsigned USDSOQ TX
                 // can exist before BIP9 activates USDSOQ, making this safe.
                 //
-                // STAGENET: nUSDSOQAuthorityEnforcementHeight=37201, exempting
-                // blocks 0-37200 which contain pre-authority CLI test mints.
+                // STAGENET: nUSDSOQAuthorityEnforcementHeight=7700 (recalibrated
+                // 2026-07-04 for the reset chain), exempting the pre-enforcement
+                // drill txs (mint 6501, send 7077, burn 7595).
                 if (pindex->nHeight < consensus.nUSDSOQAuthorityEnforcementHeight) {
                     LogPrintf("USDSOQ: Pre-enforcement height %d < %d — "
                               "skipping authority sig verification for tx %s "

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -820,6 +820,47 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
         CAmount inChainInputValue;
         double dPriority = view.GetPriority(tx, chainActive.Height(), inChainInputValue);
 
+        // SOQ-USDSOQ-MEMPOOL-CRASH: Enforce USDSOQ per-asset conservation HERE, before
+        // constructing the CTxMemPoolEntry below. The full conservation check lives in
+        // Consensus::CheckTxInputs (via CheckInputs), but that does not run until ~200
+        // lines later — and CTxMemPoolEntry's `assert(inChainInputValue <= nValueIn)`
+        // fires first for a non-conserving USDSOQ spend (inChainInputValue sums raw coin
+        // value incl. USDSOQ, while nValueIn = GetValueOut() + SOQ-only fee; the delta is
+        // exactly USDSOQ_in − USDSOQ_out). A non-conserving USDSOQ tx from any peer would
+        // therefore abort() the daemon — a remotely-triggerable crash. Reject it cleanly
+        // here, mirroring the ConnectBlock rule, so mempool policy matches consensus.
+        // Authority txs (OP_5 marker) mint ex nihilo and are exempt, exactly as in
+        // CheckTxInputs; they give USDSOQ_out ≥ USDSOQ_in so the assert never trips.
+        {
+            bool isAuthorityTx = false;
+            for (const auto& txout : tx.vout) {
+                if (txout.scriptPubKey.size() == 34 &&
+                    txout.scriptPubKey[0] == OP_5 && txout.scriptPubKey[1] == 32) {
+                    isAuthorityTx = true;
+                    break;
+                }
+            }
+            if (!isAuthorityTx) {
+                CAmount nUSDSOQIn = 0, nUSDSOQOut = 0;
+                for (const auto& txin : tx.vin) {
+                    const CCoins* c = view.AccessCoins(txin.prevout.hash);
+                    if (c && c->IsAvailable(txin.prevout.n) &&
+                        c->vout[txin.prevout.n].IsUSDSOQ()) {
+                        nUSDSOQIn += c->vout[txin.prevout.n].nValue;
+                    }
+                }
+                for (const auto& txout : tx.vout) {
+                    if (txout.IsUSDSOQ()) nUSDSOQOut += txout.nValue;
+                }
+                if (nUSDSOQIn != nUSDSOQOut) {
+                    return state.DoS(100, false, REJECT_INVALID,
+                        "bad-txns-usdsoq-not-conserved", false,
+                        strprintf("USDSOQ in (%s) != USDSOQ out (%s)",
+                            FormatMoney(nUSDSOQIn), FormatMoney(nUSDSOQOut)));
+                }
+            }
+        }
+
         // Keep track of transactions that spend a coinbase, which we re-scan
         // during reorgs to ensure COINBASE_MATURITY is still met.
         bool fSpendsCoinbase = false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1931,6 +1931,20 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
             const CTransaction& tx = *(block.vtx[i]);
             if (tx.IsCoinBase()) continue;
 
+            // BUG-19: mirror ConnectBlock — only AUTHORITY txs (OP_5 marker) moved the
+            // supply counter, so only they are reversed here. A transfer changed nothing,
+            // so reversing its outputs/inputs would corrupt the supply on reorg (and
+            // desync connect vs disconnect). Detect the authority marker as ConnectBlock does.
+            bool isAuthorityTx = false;
+            for (const auto& txout : tx.vout) {
+                if (txout.scriptPubKey.size() == 34 &&
+                    txout.scriptPubKey[0] == OP_5 && txout.scriptPubKey[1] == 32) {
+                    isAuthorityTx = true;
+                    break;
+                }
+            }
+            if (!isAuthorityTx) continue;
+
             // Count USDSOQ outputs being removed (reverses mints)
             for (const auto& txout : tx.vout) {
                 if (txout.IsUSDSOQ()) {
@@ -3145,9 +3159,16 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                         // Supply invariant maintained: transfers don't change total supply.
                     }
 
-                    // Only count transparent USDSOQ outputs toward minted supply.
-                    // Confidential outputs don't change total supply (transfers only).
-                    if (txout.IsTransparent()) {
+                    // BUG-19: ONLY authority txs (mint/burn/freeze/rotate — OP_5 marker)
+                    // change the USDSOQ supply. A plain user transfer re-emits existing
+                    // USDSOQ in its outputs and MUST be supply-neutral. Counting every
+                    // transparent USDSOQ output as "minted" inflated the supply by the
+                    // transfer amount on every send (the input-burn loop below can't offset
+                    // it — inputs are already spent in the view by the time it runs, so
+                    // nUSDSOQBurned is always 0 here). That inflated supply then made block
+                    // templates carrying a USDSOQ send fail validation → the pool mined empty
+                    // blocks. Gate minting on isAuthorityTx so only real mints move the counter.
+                    if (isAuthorityTx && txout.IsTransparent()) {
                         nUSDSOQMinted += txout.nValue;
                     }
                     // Confidential outputs: value is hidden in commitment.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1090,6 +1090,25 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
             if (v6active(Consensus::DEPLOYMENT_P2WSH_DILITHIUM))   scriptVerifyFlags |= SCRIPT_VERIFY_P2WSH_DILITHIUM;
             if (v6active(Consensus::DEPLOYMENT_DILITHIUM_KEYHASH)) scriptVerifyFlags |= SCRIPT_VERIFY_DILITHIUM_KEYHASH;
             if (v6active(Consensus::DEPLOYMENT_V6_CONTROLFLOW))    scriptVerifyFlags |= SCRIPT_VERIFY_V6_CONTROLFLOW;
+
+            // SOQ-P001 / SOQ-P002 / SOQ-ARCH-001 / SOQ-AUD2-002: mirror the PQ + asset
+            // script flags that ConnectBlock enforces (interpreter.cpp gates the v7 USDSOQ,
+            // PAT-aggregate, LatticeFold and Lattice-BP++ verification on these exact flags).
+            // Without them the mempool verifies those inputs LENIENTLY — a v7 USDSOQ input is
+            // effectively anyone-can-spend at accept time — so a tx that ConnectBlock will
+            // REJECT is accepted and relayed, then sits in the mempool poisoning every block
+            // template until it expires: the pool mines empty (coinbase-only) blocks. That is
+            // exactly what a mis-signed v7 USDSOQ send (wrong scriptCode → NULLFAIL) did on
+            // stagenet (live bug daf9fd85). This is the same policy≡consensus fix the V6
+            // covenant flags above already apply. Match ConnectBlock's activation exactly:
+            //   PAT / LATTICEFOLD  → BIP9 VersionBitsState at the tip (= the next block's pprev)
+            //   LATTICEBP / USDSOQ → height-gated (p96/Option D) at the next block
+            if (VersionBitsState(chainActive.Tip(), cons, Consensus::DEPLOYMENT_CHECKPATAGG, versionbitscache) == THRESHOLD_ACTIVE)
+                scriptVerifyFlags |= SCRIPT_VERIFY_PAT;
+            if (VersionBitsState(chainActive.Tip(), cons, Consensus::DEPLOYMENT_LATTICEFOLD, versionbitscache) == THRESHOLD_ACTIVE)
+                scriptVerifyFlags |= SCRIPT_VERIFY_LATTICEFOLD;
+            if (v6active(Consensus::DEPLOYMENT_LATTICEBP))         scriptVerifyFlags |= SCRIPT_VERIFY_LATTICEBP;
+            if (v6active(Consensus::DEPLOYMENT_USDSOQ))            scriptVerifyFlags |= SCRIPT_VERIFY_USDSOQ;
         }
 
         // Check against previous transactions


### PR DESCRIPTION
## What this merges

The complete USDSOQ live-drill fix arc (2026-07-03/04), all live-proven on stagenet, plus the p96 flag-day commits this branch was cut from.

### The six bugs (each with a regression test)
- **Bug 2** (`9270bd79b`): non-conserving USDSOQ spend crashed the node (CTxMemPoolEntry assert) — remote DoS. ATMP conservation pre-check + clamp-not-assert. *Live-proven: the burn tx crashed the 3 unfixed Hetzner miners; fixed nodes accept it cleanly.*
- **BUG-18** (`e860a6409`): supply-accumulator leak in fJustCheck dry-runs → empty blocks. *Live-proven: old builds persisted 249,000 minted; healed by reindex.*
- **BUG-19** (`e8b41f03b`): transfers counted as mints → supply inflation. *Live-proven: send 03dd0a3a mined block 7077, supply held.*
- **BUG-20** (`a982ee25b`): authority burns never decremented supply. *Live-proven: burn d10c651d mined block 7595, supply 1000→900 fleet-wide.*
- **BUG-21** (`5e5876763`): mempool omitted PAT/LATTICEFOLD/LATTICEBP/USDSOQ script flags ConnectBlock enforces → mis-signed tx poisoned every template. *Live-proven: poison tx auto-evicted on deploy.*
- **BUG-22** (`92522497e`): mempool never checked the frozen-outpoint registry → first freeze would have recreated the empty-block DoS via any wallet. Found by inspection before the first freeze existed.

### Also carried
- `c7f870cd9`: stagenet `nUSDSOQAuthorityEnforcementHeight` 37201→7700 (Casey-ratified 2026-07-04; pre-reset staleness — old value also silently no-opped freeze application).
- **Test-infra fix** (in `92522497e`): TestingSetup's member `pcoinsdbview` shadowed the validation global (NULL in every unit test → registry/persistence consensus paths silently untested). Now wired like production; **full suite 575/575 green** with those paths live.
- Deploy runbook (`doc/design/DL-USDSOQ-MEMPOOL-FIX-DEPLOY-RUNBOOK.md`) incl. the 2026-07-04 incident addendum and deploy #3.

### ⚠️ Merge coupling — p96 flag-day + lw7 ride along
This branch was cut from `consensus/p96-flagday-activation`, so merging it ALSO merges:
- `1cdf892a0` flag-day (height-gated) soft-fork activation (bead p96, Option D)
- `23725c596` fStrictChainId enable (lw7)

Both are **already running on the entire 8-instance stagenet fleet** (deployed with this arc's binaries) — merging aligns main with deployed reality. Mainnet impact: USDSOQ/PAT deployments are NOT_SCHEDULED on mainnet, so the new mempool flags are no-ops there; enforcement-height stays 0 on mainnet; flag-day/lw7 per their own briefs.

### Deployment state
All 8 soqucoind instances run this branch tip (`92522497e` lineage) as of 2026-07-04. Mint→send→burn lifecycle live-proven; freeze drill pending block 7700.

Follow-up: bead `kp5` (evict mempool spends of newly-frozen outpoints at freeze-connect, P2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)