### PR TITLE
docs: sync activation model to flag-day reality (v1.5.0)

### DIFF
--- a/doc/GOVERNANCE.md
+++ b/doc/GOVERNANCE.md
@@ -62,10 +62,10 @@ flowchart LR
     A[Proposal] --> B[Community Discussion]
     B --> C[BIP/SIP Draft]
     C --> D[Code Review]
-    D --> E[Testnet Deployment]
-    E --> F[Miner Signaling]
-    F --> G{95% Threshold?}
-    G -->|Yes| H[Activation]
+    D --> E[Testnet + Stagenet Deployment]
+    E --> F[Security Audit]
+    F --> G{Audit Clear?}
+    G -->|Yes| H[Activation Height Set in Release]
     G -->|No| I[Revise/Reject]
 ```
 
@@ -195,7 +195,7 @@ See [INCIDENT_RESPONSE_PLAN.md](INCIDENT_RESPONSE_PLAN.md) for:
 
 ### Governance Participation
 
-- **Miners:** Signal for/against protocol upgrades
+- **Miners:** Choose whether to mine on upgraded software
 - **Node Operators:** Choose software version to run
 - **Community:** Participate in discussions, provide feedback
 

--- a/doc/GOVERNANCE.md
+++ b/doc/GOVERNANCE.md
@@ -18,7 +18,7 @@ Soqucoin follows a **community-driven governance model** similar to Dogecoin, wi
 
 | Component | Description |
 |-----------|-------------|
-| **Consensus Changes** | BIP9 soft fork activation (95% miner signaling) |
+| **Consensus Changes** | Flag-day height activation, scheduled in a released binary after audit clearance |
 | **Hard Forks** | Require community consensus + miner majority |
 | **Emergency Changes** | Core maintainer discretion for critical security |
 
@@ -69,14 +69,19 @@ flowchart LR
     G -->|No| I[Revise/Reject]
 ```
 
-### Soft Fork Activation (BIP9)
+### Soft Fork Activation (Flag-Day by Height)
+
+Soqucoin does not use BIP9 miner signaling. The chain is merge-mined, so its hashpower
+is mercenary Scrypt capacity with no stake in protocol governance; a signaling vote would
+either stall on apathy or reduce to the foundation voting with itself. Instead, each
+soft fork carries an activation height (`nActivationHeight`):
 
 | Parameter | Value |
 |-----------|-------|
-| Activation Threshold | 95% of 10,080 blocks (1 week) |
-| Signaling Window | 10,080 blocks |
-| Timeout | 1 year from start |
-| Lock-in Period | 10,080 blocks |
+| Dormant state | `NOT_SCHEDULED` (feature shipped, not enforceable) |
+| Activation trigger | Security-audit clearance |
+| Scheduling | Activation height set in a released binary, announced in release notes |
+| Enforcement | Consensus-enforced for every block at or above the height |
 
 ---
 
@@ -141,9 +146,9 @@ Like Dogecoin, Soqucoin uses **perpetual tail emission** (no supply cap) to:
 |-------|-------------|----------|
 | **Testnet** | Feature testing | 2+ weeks |
 | **Stagenet** | Mainnet rehearsal | 1+ week |
-| **Signaling** | Miner BIP9 votes | 1 week window |
-| **Lock-in** | Activation guaranteed | 1 week |
-| **Activation** | Feature goes live | Height-based |
+| **Audit** | Independent security review clears the feature | Per audit scope |
+| **Scheduling** | Activation height published in a released binary | Release notes |
+| **Activation** | Consensus enforcement begins at the height | Height-based |
 
 ### Current Deployments
 
@@ -152,7 +157,8 @@ Like Dogecoin, Soqucoin uses **perpetual tail emission** (no supply cap) to:
 | Dilithium Signatures | ✅ ACTIVE | Genesis |
 | SegWit | ✅ ACTIVE | Always-active |
 | CSV (BIP68/112/113) | ✅ ACTIVE | Always-active |
-| LatticeFold+ | 🟡 SIGNALING | Height 100,000 |
+| PAT / LatticeFold+ | ✅ ACTIVE | Always-active |
+| Lattice-BP++, USDSOQ, CTV, APO, CSFS, P2WSH-Dilithium, UTXO Cost, Dilithium Keyhash, V6 Control Flow | 🟡 DORMANT on mainnet | Flag-day height, set after audit clearance (active on test networks) |
 
 ---
 
@@ -204,7 +210,7 @@ See [INCIDENT_RESPONSE_PLAN.md](INCIDENT_RESPONSE_PLAN.md) for:
 | Signatures | ECDSA | **Dilithium (PQ-safe)** |
 | Block Time | 1 minute | 1 minute |
 | Tail Emission | 10,000 DOGE/block | 2,500 SOQ/block |
-| Governance | BIP9 soft forks | BIP9 soft forks |
+| Governance | BIP9 soft forks | Flag-day height activation |
 
 **Key Differentiator:** Soqucoin is the **first quantum-resistant Scrypt chain**.
 

--- a/doc/pool-integration.md
+++ b/doc/pool-integration.md
@@ -40,7 +40,7 @@ soqucoin-cli submitauxblock <hash> <auxpow_hex>
 ### Node Information
 
 ```bash
-soqucoin-cli getblockchaininfo    # Chain state, BIP9 deployments
+soqucoin-cli getblockchaininfo    # Chain state, deployment status
 soqucoin-cli getmininginfo        # Current difficulty, hashrate
 soqucoin-cli getnetworkhashps     # Network hash rate estimate
 soqucoin-cli getblockcount        # Current block height

--- a/doc/specifications/CONSENSUS_COST_SPEC.md
+++ b/doc/specifications/CONSENSUS_COST_SPEC.md
@@ -17,8 +17,11 @@
 > dual-format transactions**. The `nVisibility` field in `CTxOut` determines whether outputs are transparent
 > (default) or confidential. View keys enable selective disclosure for auditors and exchanges.
 >
-> **Activation Model**: All features use **BIP9 deployment** with `ALWAYS_ACTIVE` (genesis features) or
-> `NEVER_ACTIVE` (pending audit). Height-based staged activation has been replaced. See §9.
+> **Activation Model (v1.5.0)**: genesis features are `ALWAYS_ACTIVE`; every post-launch feature
+> activates by **flag-day height** (`nActivationHeight`): `NOT_SCHEDULED` (dormant) on mainnet
+> pending audit, height 0 (active) on stagenet/testnet/regtest. There is **no BIP9 miner
+> signaling**: Soqucoin is merge-mined, so activation is foundation-scheduled in a released
+> binary after audit clearance. See §9.
 >
 > This document reflects the current mainnet candidate specification.
 
@@ -76,36 +79,41 @@ NIST-standardized quantum resistance and is considered acceptable by the cryptog
 
 ### Feature Activation Architecture
 
-Soqucoin uses **BIP9 deployment flags** for feature activation. All features are either `ALWAYS_ACTIVE`
-(enabled from genesis) or `NEVER_ACTIVE` (gated pending audit). There are no height-based activation
-schedules.
+Soqucoin activates features by **flag-day height** (since v1.5.0). Genesis features are
+`ALWAYS_ACTIVE`; post-launch features carry an `nActivationHeight`: `NOT_SCHEDULED`
+(dormant) on mainnet pending audit, height 0 (active) on stagenet/testnet/regtest.
+There is no BIP9 miner-signaling activation.
 
-| Feature | BIP9 Bit | Witness Version | Mainnet Status | Stagenet Status |
-|---------|----------|-----------------|----------------|-----------------|
+| Feature | Bit | Witness Version | Mainnet Status | Stagenet Status |
+|---------|-----|-----------------|----------------|-----------------|
 | **CSV** | 0 | — | ALWAYS_ACTIVE | ALWAYS_ACTIVE |
 | **SegWit** | 1 | — | ALWAYS_ACTIVE | ALWAYS_ACTIVE |
-| **BatchSig** | 2 | — | ALWAYS_ACTIVE | ALWAYS_ACTIVE |
 | **PAT** (`OP_CHECKPATAGG`) | 3 | v2 (`OP_2`) | ALWAYS_ACTIVE | ALWAYS_ACTIVE |
 | **LatticeFold** (`OP_CHECKFOLDPROOF`) | 28 | v3 (`OP_3`) | ALWAYS_ACTIVE | ALWAYS_ACTIVE |
-| **Lattice-BP++** (`OP_LATTICEBP_RANGEPROOF`) | 5 | v4 (`OP_4`) | NEVER_ACTIVE | NEVER_ACTIVE |
-| **USDSOQ** (`OP_USDSOQ_*`) | 6 | v5 (`OP_5`) | NEVER_ACTIVE | NEVER_ACTIVE |
-| **CTV** (`OP_CHECKTEMPLATEVERIFY`) | — | — | ALWAYS_ACTIVE | ALWAYS_ACTIVE |
-| **L2SOQ** (2-of-2 Dilithium + CTV/CSV) | — | v6 (`OP_6`) | Not Active | Prototype |
+| **Lattice-BP++** (`OP_LATTICEBP_RANGEPROOF`) | 5 | v4 (`OP_4`) | Dormant (NOT_SCHEDULED) | Active (height 0) |
+| **USDSOQ** (`OP_USDSOQ_*`) | 6 | v5 (`OP_5`) | Dormant (NOT_SCHEDULED) | Active (height 0) |
+| **CTV** (`OP_CHECKTEMPLATEVERIFY`) | 7 | — | Dormant (NOT_SCHEDULED) | Active (height 0) |
+| **APO** (`SIGHASH_ANYPREVOUT`) | 8 | — | Dormant (NOT_SCHEDULED) | Active (height 0) |
+| **CSFS** (`OP_CHECKSIGFROMSTACK`) | 9 | — | Dormant (NOT_SCHEDULED) | Active (height 0) |
+| **P2WSH-Dilithium / L2SOQ** | 10 | v6 (`OP_6`) | Dormant (NOT_SCHEDULED) | Active (height 0) |
+| **UTXO Cost** | 11 | — | Dormant (NOT_SCHEDULED) | Active (height 0) |
+| **Dilithium Keyhash** (`OP_CHECKDILITHIUMKEYHASH`) | 12 | — | Dormant (NOT_SCHEDULED) | Active (height 0) |
+| **V6 Control Flow** | 13 | — | Dormant (NOT_SCHEDULED) | Active (height 0) |
 
 > [!NOTE]
 > **Witness version routing** in `VerifyScript()`: v0/v1 = Dilithium, v2 = PAT, v3 = LatticeFold,
 > v4 = Lattice-BP++, v5 = USDSOQ, v6 = L2SOQ (Stagenet prototype), v7-v16 = future (anyone-can-spend). Each handler pushes the witness
 > stack into `EvalScript()` with the corresponding opcode. Flag gating ensures soft fork safety.
 >
-> **`NEVER_ACTIVE` features**: When the flag is not set, transactions using that witness version pass
-> as anyone-can-spend (standard BIP141 behavior). This allows future activation via miner signaling
-> without a hard fork.
+> **Dormant features**: When the enforcement flag is not set, transactions using that witness version
+> pass as anyone-can-spend (standard BIP141 behavior). This allows future activation at a published
+> flag-day height without a hard fork.
 
 ### LatticeFold+ Performance (ALWAYS_ACTIVE from Genesis)
 
 > [!NOTE]
 > **Implementation Status**: LatticeFold+ verifier is implemented (`src/crypto/latticefold/verifier.cpp`)
-> based on ePrint 2025/247 (October revision). BIP9 `ALWAYS_ACTIVE` from genesis on both mainnet and
+> based on ePrint 2025/247 (October revision). `ALWAYS_ACTIVE` from genesis on both mainnet and
 > stagenet. The following are **measured values** from benchmarks, not projections.
 
 LatticeFold+ provides **recursive proof composition** for Dilithium batch verification:
@@ -400,18 +408,18 @@ Standard Bitcoin witness limits were designed for ECDSA (~72 byte signatures). D
 
 > **Note**: Fees are **policy**, not consensus. Miners may include any valid transaction regardless of fee. Fee parameters are subject to review based on mainnet economics.
 
-### UTXO Minimum Output Value (Novel — BIP9-Gated)
+### UTXO Minimum Output Value (Novel — Height-Gated)
 
 | Parameter | Value | Type | Notes |
 |-----------|-------|------|-------|
-| **UTXO_COST_PER_BYTE** | 6,500 sat/byte | **Consensus** (BIP9 bit 11) | Cardano-style minimum output value |
+| **UTXO_COST_PER_BYTE** | 6,500 sat/byte | **Consensus** (bit 11, flag-day) | Cardano-style minimum output value |
 | **Minimum Standard Output** | ~0.00325 SOQ | Derived | 6,500 × 50 bytes (typical P2WPKH output) |
 
 > **SOQ-ARCH-003 (May 25, 2026)**: `UTXO_COST_PER_BYTE` enforces a minimum output value
 > proportional to the output's serialized size. This is a **consensus rule** gated by
-> `DEPLOYMENT_UTXO_COST` (BIP9 bit 11):
-> - **Mainnet**: Dormant (`nStartTime=0`) until Phase 2 audit approval
-> - **Stagenet/Testnet/Regtest**: `ALWAYS_ACTIVE`
+> `DEPLOYMENT_UTXO_COST` (bit 11, flag-day height activation):
+> - **Mainnet**: Dormant (`NOT_SCHEDULED`) until Phase 2 audit approval
+> - **Stagenet/Testnet/Regtest**: Active (height 0)
 >
 > Exemptions: `OP_RETURN` outputs and USDSOQ authority markers (`OP_5`/`0x55`).
 > Rejection code: `bad-txns-output-below-utxo-cost`
@@ -466,40 +474,45 @@ Nodes can adjust, miners can override:
 
 ### Overview
 
-Soqucoin uses **BIP9 deployment flags** for all feature activation. Features are either `ALWAYS_ACTIVE`
-(enabled from genesis block 0) or `NEVER_ACTIVE` (gated pending security audit and miner signaling).
-There is no height-based staged activation.
+Soqucoin activates features by **flag-day height** (v1.5.0, PR #26). Genesis features are
+`ALWAYS_ACTIVE`; post-launch features carry `nActivationHeight`: `NOT_SCHEDULED` (dormant)
+on mainnet until the security audit clears and the foundation ships a release with the
+activation height set, height 0 (active) on the test networks. There is no BIP9
+miner-signaling activation: the chain is merge-mined, so hashpower has no signaling
+constituency, and the real activation precondition (audit clearance) is what a height encodes.
 
 > [!IMPORTANT]
 > **Pre-activation behavior**: Transactions using `NEVER_ACTIVE` witness versions (v4, v5) pass as
 > **anyone-can-spend** per BIP141. This is safe: miners won't mine these transactions, and
-> `fRequireStandard=true` on mainnet/stagenet rejects them from the mempool. Activation via BIP9
-> miner signaling will enable full consensus enforcement without a hard fork.
+> `fRequireStandard=true` on mainnet/stagenet rejects them from the mempool. Setting the
+> activation height in a released binary enables full consensus enforcement without a hard fork.
 
 ### Genesis Features (ALWAYS_ACTIVE)
 
 These features are active from block 0 on both mainnet and stagenet:
 
-| Feature | Opcode/Mechanism | Witness Version | BIP9 Bit | What It Does |
-|---------|------------------|-----------------|----------|-------------|
+| Feature | Opcode/Mechanism | Witness Version | Bit | What It Does |
+|---------|------------------|-----------------|-----|-------------|
 | **Dilithium** | Inline in `VerifyScript()` | v0, v1 | — | NIST FIPS 204 quantum-safe signatures |
 | **PAT** | `OP_CHECKPATAGG` | v2 (`OP_2`) | 3 | Merkle-based signature attestation (up to 256 sigs) |
 | **LatticeFold+** | `OP_CHECKFOLDPROOF` | v3 (`OP_3`) | 28 | Recursive batch verification (512 sigs in ~0.75ms) |
 | **AuxPoW** | Merged mining | — | — | Scrypt AuxPoW with unique Chain ID `0x5351` |
 | **SegWit** | BIP141/143/147 | — | 1 | Witness data segregation |
 | **CSV** | BIP68/112/113 | — | 0 | Relative timelocks |
-| **CTV** | `OP_CHECKTEMPLATEVERIFY` (0xb3) | — | — | BIP 119 covenant hash commitment; enables L2SOQ channel settlement |
 
-### Future Features (NEVER_ACTIVE — Pending Audit)
+### Post-Launch Features (Flag-Day, Dormant on Mainnet Pending Audit)
 
-These features exist in the codebase but are gated behind `NEVER_ACTIVE` BIP9 deployments:
+These features exist in the codebase and are **active on stagenet/testnet/regtest
+(height 0)**; on mainnet they stay dormant (`NOT_SCHEDULED`) until the audit clears
+and a release sets the activation height:
 
-| Feature | Opcode | Witness Version | BIP9 Bit | Status | Audit Target |
-|---------|--------|-----------------|----------|--------|-------------|
-| **Lattice-BP++** | `OP_LATTICEBP_RANGEPROOF` (0xfa) | v4 (`OP_4`) | 5 | Code complete, 16/16 tests pass | July 2026 (Halborn) |
-| **USDSOQ** | `OP_USDSOQ_MINT/BURN/FREEZE` | v5 (`OP_5`) | 6 | Code complete, consensus tests pass | Q3–Q4 2026 (Halborn) |
-| **L2SOQ** | 2-of-2 Dilithium P2WSH + CTV/CSV | v6 (`OP_6`) | — | Prototype active (Stagenet, May 2026) | Post-L1 mainnet audit |
-| **UTXO Cost** | Min output value enforcement | — (output value) | 11 | BIP9 dormant (mainnet), ALWAYS_ACTIVE (test) | Phase 2 audit |
+| Feature | Opcode | Witness Version | Bit | Status | Audit Target |
+|---------|--------|-----------------|-----|--------|-------------|
+| **CTV** | `OP_CHECKTEMPLATEVERIFY` (0xb3) | — | 7 | BIP 119 covenant hash; enables L2SOQ settlement | Advisable |
+| **Lattice-BP++** | `OP_LATTICEBP_RANGEPROOF` (0xfa) | v4 (`OP_4`) | 5 | Code complete, 16/16 tests pass | Phase 2 (Halborn) |
+| **USDSOQ** | `OP_USDSOQ_MINT/BURN/FREEZE` | v5 (`OP_5`) | 6 | Full lifecycle proven live on stagenet (July 2026) | Phase 2 (Halborn) |
+| **L2SOQ / P2WSH-Dilithium** | 2-of-2 Dilithium P2WSH + CTV/CSV | v6 (`OP_6`) | 10 | Live on stagenet (Lightning stack) | Post-L1 mainnet audit |
+| **UTXO Cost** | Min output value enforcement | — (output value) | 11 | Dormant (mainnet), active (test networks) | Phase 2 audit |
 
 **Lattice-BP++ (SOQ-P003)**: Verifies lattice-based range proofs (Module-LWE/SIS, n=256, q=8380417, k=4)
 proving transaction amounts ∈ [0, 2^64). Fiat-Shamir binds to sighash + pubkey_hash. Three-mode build guard
@@ -543,7 +556,7 @@ LatticeFold+ provides **recursive proof composition** for Dilithium batch verifi
 
 ### Upgrade & Security Response Policy
 
-- **BIP9 deployments are consensus-frozen** once a tagged release is published
+- **Deployment configuration is consensus-frozen** once a tagged release is published
 - **Activation changes require a new release** with minimum 2-week upgrade window
 - **Security response**: Critical vulnerabilities trigger coordinated disclosure to major miners/exchanges within 24 hours, followed by emergency release
 - **Release signing**: All binaries signed by core maintainers; reproducible builds available
@@ -583,7 +596,7 @@ LatticeFold+ provides **recursive proof composition** for Dilithium batch verifi
 | **Expensive Operations** | Per-op verification costs | Consensus |
 | **Block Size Attacks** | MAX_BLOCK_WEIGHT = 4 MB | Consensus |
 | **Dust Attacks** | DEFAULT_HARD_DUST_LIMIT | Policy |
-| **UTXO Bloat** | UTXO_COST_PER_BYTE = 6,500 (BIP9 bit 11) | Consensus (BIP9-gated) |
+| **UTXO Bloat** | UTXO_COST_PER_BYTE = 6,500 (bit 11) | Consensus (height-gated) |
 
 ---
 
@@ -873,12 +886,12 @@ Soqucoin implements view key functionality (Lattice-BP++ activation) enabling:
 For Halborn audit review, verify:
 1. **No mandatory privacy enforcement** in consensus (`src/validation.cpp`)
 2. **Opt-in flag gating** for Lattice-BP++ (`VerifyScript()` witness v4 handler)
-3. **BIP9 deployment gating** — `DEPLOYMENT_LATTICEBP` must be `NEVER_ACTIVE` before activation
+3. **Deployment gating** — `DEPLOYMENT_LATTICEBP` must remain dormant (`NOT_SCHEDULED`) on mainnet before activation
 4. **Default transparency** maintained for base transactions (`nVisibility=0`)
 
 ---
 
 *Soqucoin Protocol Parameters Specification v4.0*
-*Updated May 20, 2026 — Reflects BIP9 activation model, L2SOQ Stagenet prototype, CTV/CSV covenant opcodes, witness v6 allocation, and USDSOQ code completion*
+*Updated 2026-07-06 — Reflects the flag-day height activation model (v1.5.0, PR #26), L2SOQ Stagenet prototype, CTV/CSV covenant opcodes, witness v6 allocation, and USDSOQ code completion*
 *Soqucoin Core Development Team*
 

--- a/doc/specifications/STAGE_3_LATTICE_BP_ARCHITECTURE.md
+++ b/doc/specifications/STAGE_3_LATTICE_BP_ARCHITECTURE.md
@@ -29,8 +29,9 @@ UTXO carries a visibility mode (`TRANSPARENT` or `CONFIDENTIAL`).
 > dual-format provides larger anonymity sets, eliminates peg-in/peg-out linkability, and requires
 > ~40% less code than extension blocks. See §2 for full comparison.
 >
-> **Activation**: BIP9 `NEVER_ACTIVE` on mainnet/stagenet at genesis. Activates via miner signaling
-> after Halborn audit (target: July 2026). Witness version v4 (`OP_4`).
+> **Activation**: flag-day by height (v1.5.0 model). Dormant (`NOT_SCHEDULED`) on mainnet;
+> the activation height is set in a released binary after the Halborn Phase 2 audit clears.
+> Active from height 0 on stagenet/testnet/regtest. Witness version v4 (`OP_4`).
 
 ---
 
@@ -261,7 +262,7 @@ v6-v16: Future (anyone-can-spend until activated)
 | Stealth addresses + View keys | `src/crypto/latticebp/stealth_address.h` | 166 | ✅ Complete |
 | Test suite | `src/crypto/latticebp/test_latticebp.cpp` | 674 | ✅ 16/16 pass |
 | Consensus opcode | `src/script/interpreter.cpp` (v4 handler) | — | ✅ Wired |
-| BIP9 deployment | `src/chainparams.cpp` (DEPLOYMENT_LATTICEBP) | — | ✅ NEVER_ACTIVE |
+| Deployment (flag-day) | `src/chainparams.cpp` (DEPLOYMENT_LATTICEBP) | — | ✅ Dormant on mainnet; active height 0 on test networks |
 
 ### 3.3 LatticeFold+ Synergy
 
@@ -385,7 +386,7 @@ Additional hardening from PAT audit (SOQ-H001 through H030):
 
 - [ ] Witness v4 handler in `VerifyScript()` → `EvalScript()` dispatch
 - [ ] `SCRIPT_VERIFY_LATTICEBP` flag gating
-- [ ] BIP9 `DEPLOYMENT_LATTICEBP` correctly `NEVER_ACTIVE`
+- [ ] `DEPLOYMENT_LATTICEBP` correctly dormant on mainnet (flag-day `NOT_SCHEDULED`)
 - [ ] Mixed-mode balance verification (transparent + confidential)
 - [ ] Per-asset-type balance isolation (`nAssetType`)
 - [ ] Key-image spent set management and reorg handling
@@ -439,6 +440,6 @@ Additional hardening from PAT audit (SOQ-H001 through H030):
 ---
 
 *Soqucoin Lattice-BP++ Privacy Architecture v2.0*
-*Updated April 27, 2026 — Reflects native dual-format design, actual implementation benchmarks, and BIP9 activation model*
+*Updated April 27, 2026 — Reflects native dual-format design, actual implementation benchmarks, and the flag-day height activation model (updated 2026-07-06)*
 *Patent Pending — Soqucoin Labs Inc.*
 *Soqucoin Core Development Team*

--- a/doc/specifications/STAGE_5_L2_SPECIFICATION.md
+++ b/doc/specifications/STAGE_5_L2_SPECIFICATION.md
@@ -280,7 +280,7 @@ Force Close (ELTOO):
 
 | Deliverable | Owner | Timeline |
 |-------------|-------|----------|
-| L2SOQ activation via BIP9 soft-fork | Core Team | 2 weeks |
+| L2SOQ activation via flag-day height (post-audit) | Core Team | 2 weeks |
 | Liquidity bootstrapping | Community | Ongoing |
 | Multi-hop channel support | Dev Team | Ongoing |
 
@@ -340,7 +340,7 @@ Force Close (ELTOO):
 - [x] Genesis: Dilithium signatures
 - [x] Genesis: LatticeFold+ verification (ALWAYS_ACTIVE)
 - [x] Genesis: CTV + CSV covenant opcodes (ALWAYS_ACTIVE)
-- [ ] Stage 3: Full PQ privacy primitives (Lattice-BP++, BIP9-gated)
+- [ ] Stage 3: Full PQ privacy primitives (Lattice-BP++, height-gated on mainnet; active on stagenet)
 - [x] Stage 4: Solana bridge operational (SoquShield)
 
 ### Soft Prerequisites

--- a/doc/stagenet-mining-guide.md
+++ b/doc/stagenet-mining-guide.md
@@ -213,7 +213,7 @@ Payouts are processed every 10 minutes via PPLNS. Minimum payout: 1 SOQ.
 | Block Time | ~60 seconds |
 | Initial Subsidy | 100,000 SOQ |
 | Halving Interval | 250,000 blocks |
-| Consensus Features | Dilithium signatures, USDSOQ opcodes, Lattice-BP++ privacy (BIP9-gated) |
+| Consensus Features | Dilithium signatures, USDSOQ opcodes, Lattice-BP++ privacy (active on stagenet; height-gated on mainnet) |
 
 ### Seed Nodes
 


### PR DESCRIPTION
Casey flagged that public consensus docs lagged the PR #26 flag-day change. Six docs corrected; the worst was CONSENSUS_COST_SPEC.md, which claimed the exact inverse of reality ('height-based activation has been replaced' by BIP9) and listed Lattice-BP++/USDSOQ as NEVER_ACTIVE on stagenet where both run at height 0 today. GOVERNANCE.md described a 95% miner-signaling vote that has never existed on this chain, plus a fictional 'LatticeFold+ SIGNALING at height 100,000' row.

All statuses now match `src/chainparams.cpp` at v1.5.0 per network, including the previously missing bits 12-13. Documentation only, no code.

Internal counterpart: `.gemini/CONSENSUS_ENGINEERING.md` got the same truth-sync locally (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)