### PR TITLE
consensus(usdsoq): input isolation (Option B) + freeze enforcement made LIVE [LOCKSTEP DEPLOY]

### DIFF
--- a/src/test/usdsoq_v7_conservation_harness_tests.cpp
+++ b/src/test/usdsoq_v7_conservation_harness_tests.cpp
@@ -79,6 +79,16 @@ static CScript MakeV5Spk(const std::vector<unsigned char>& rawPubkey)
     return spk;
 }
 
+// V4 confidential scriptPubKey: OP_4 <32-byte commitment>. IsConfidential() true.
+static CScript MakeV4Spk(const std::vector<unsigned char>& rawPubkey)
+{
+    uint256 pkHash;
+    CSHA256().Write(rawPubkey.data(), rawPubkey.size()).Finalize(pkHash.begin());
+    CScript spk;
+    spk << OP_4 << std::vector<unsigned char>(pkHash.begin(), pkHash.end());
+    return spk;
+}
+
 // 0x00-prefixed pubkey for the trailing witness item (FIPS 204 Table 3).
 static std::vector<unsigned char> Prefixed(const std::vector<unsigned char>& rawPubkey)
 {
@@ -253,6 +263,25 @@ struct V7ConservationChainSetup : public TestingSetup {
             c->vout[0].nValue       = value;
             c->vout[0].scriptPubKey = MakeV7Spk(coinbasePkBytes);
             // Phase 4: nVisibility/nAssetType bytes removed; classification is structural (v7 witness = USDSOQ)
+        }
+        return COutPoint(txid, 0);
+    }
+
+    // Seed a confidential v4 coin directly into the UTXO set (Option B negative
+    // test — an exotic input that a transparent USDSOQ transfer must not mix in).
+    COutPoint SeedV4Coin(CAmount value)
+    {
+        uint256 txid = uint256S("0000000000000000000000000000000000000000000000000000000000007c04");
+        {
+            LOCK(cs_main);
+            CCoinsModifier c = pcoinsTip->ModifyCoins(txid);
+            c->Clear();
+            c->fCoinBase = false;
+            c->nHeight   = 1;
+            c->nVersion  = 2;
+            c->vout.resize(1);
+            c->vout[0].nValue       = value;
+            c->vout[0].scriptPubKey = MakeV4Spk(coinbasePkBytes);
         }
         return COutPoint(txid, 0);
     }
@@ -647,6 +676,87 @@ BOOST_AUTO_TEST_CASE(mempool_rejects_spend_of_frozen_v7_outpoint)
     BOOST_CHECK_MESSAGE(ok2, "the identical tx must be ACCEPTED once unfrozen, got: "
         + state2.GetRejectReason());
     BOOST_CHECK(mempool.exists(spend.GetHash()));
+}
+
+// ---------------------------------------------------------------------------
+// e2n: freeze enforcement must be LIVE at CONSENSUS (ConnectBlock), not only at
+// mempool. The old ConnectBlock freeze guard iterated the coins VIEW in the
+// second pass — but UpdateCoins (first pass) had already spent every input, so
+// its `!IsAvailable() → continue` skipped every input: DEAD CODE. Freeze was
+// thus enforced only at mempool (BUG-22 ATMP mirror), so a block assembled
+// off-mempool could spend a frozen coin. The fix reads prevouts from block undo
+// (like the burn loop). This drives a real block: freeze a v7 outpoint, mine a
+// spend of it → block MUST be rejected; then unfreeze and mine → it MUST connect
+// (isolates the freeze guard as the cause). Before the fix, the first block
+// connects (freeze not enforced) and this test fails.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(connectblock_rejects_spend_of_frozen_v7_outpoint)
+{
+    const CAmount v7Val = 5 * COIN;
+    COutPoint v7op = SeedV7Coin(v7Val, 0x00);
+    CScript v7Dest = MakeV7Spk(coinbasePkBytes);
+
+    {
+        LOCK(cs_main);
+        BOOST_REQUIRE(pcoinsdbview->WriteFrozenOutpoint(v7op));
+        BOOST_REQUIRE(pcoinsdbview->IsFrozenOutpoint(v7op));
+    }
+
+    const uint256 tipBefore = chainActive.Tip()->GetBlockHash();
+    CMutableTransaction frozenSpend = BuildV7ToV7Send(v7op, v7Val, coinbaseTxns[0], v7Dest);
+    CBlock B = CreateAndProcessBlock({frozenSpend}, coinbaseSpk);
+    BOOST_CHECK_MESSAGE(chainActive.Tip()->GetBlockHash() != B.GetHash(),
+        "a block spending a registry-frozen USDSOQ outpoint MUST be rejected at "
+        "ConnectBlock (e2n: freeze enforced at consensus, not only mempool)");
+    BOOST_CHECK_MESSAGE(chainActive.Tip()->GetBlockHash() == tipBefore,
+        "tip must be unchanged after the frozen-spend block is rejected");
+
+    // Unfreeze → the same (still-unspent) v7op must now be spendable in a block,
+    // proving the rejection was the freeze guard and not an incidental failure.
+    {
+        LOCK(cs_main);
+        BOOST_REQUIRE(pcoinsdbview->EraseFrozenOutpoint(v7op));
+        BOOST_REQUIRE(!pcoinsdbview->IsFrozenOutpoint(v7op));
+    }
+    CMutableTransaction okSpend = BuildV7ToV7Send(v7op, v7Val, coinbaseTxns[1], v7Dest);
+    CBlock B2 = CreateAndProcessBlock({okSpend}, coinbaseSpk);
+    BOOST_CHECK_MESSAGE(chainActive.Tip()->GetBlockHash() == B2.GetHash(),
+        "once unfrozen, the identical v7 spend must connect");
+}
+
+// ---------------------------------------------------------------------------
+// Option B (0r2/e2n): a transparent USDSOQ transfer may spend v7 USDSOQ inputs
+// and transparent native-SOQ fee inputs, but NOT exotic inputs (e.g. confidential
+// v4). The positive path (v7 + SOQ fee connects) is covered by
+// v7_to_v7_send_conserves. Here a CONSERVING tx (USDSOQ in==out) that mixes a v4
+// confidential input into a v7 transfer must be rejected by CheckTxInputs with
+// bad-txns-usdsoq-input-mismatch. Driven through Consensus::CheckTxInputs directly
+// to isolate the rule from script/policy checks, and to prove it lives in the
+// single chokepoint shared by ConnectBlock and mempool.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(checktxinputs_rejects_exotic_input_in_usdsoq_transfer)
+{
+    const CAmount v7Val = 5 * COIN;
+    COutPoint v7op = SeedV7Coin(v7Val, 0x00);
+    COutPoint v4op = SeedV4Coin(1 * COIN);   // confidential input mixed in as "fee"
+
+    CMutableTransaction tx; tx.nVersion = 2;
+    { CTxIn in; in.prevout = v7op; in.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(in); }
+    { CTxIn in; in.prevout = v4op; in.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(in); }
+    // USDSOQ out == in (conserves); the v4 input's value falls to fee.
+    { CTxOut o; o.nValue = v7Val; o.scriptPubKey = MakeV7Spk(coinbasePkBytes); tx.vout.push_back(o); }
+
+    CValidationState state;
+    bool ok;
+    {
+        LOCK(cs_main);
+        ok = Consensus::CheckTxInputs(Params(), CTransaction(tx), state, *pcoinsTip,
+                                      chainActive.Height() + 1);
+    }
+    BOOST_CHECK_MESSAGE(!ok,
+        "a conserving USDSOQ transfer that mixes a confidential v4 input must be rejected");
+    BOOST_CHECK_MESSAGE(state.GetRejectReason() == "bad-txns-usdsoq-input-mismatch",
+        "reject reason must be Option-B input isolation, got: " + state.GetRejectReason());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1657,6 +1657,41 @@ bool CheckTxInputs(const CChainParams& params, const CTransaction& tx, CValidati
                 strprintf("USDSOQ in (%s) != USDSOQ out (%s)",
                     FormatMoney(nUSDSOQIn), FormatMoney(nUSDSOQOut)));
         }
+
+        // Input-type isolation (Option B — beads 0r2/e2n). A transparent USDSOQ
+        // transfer (any v7 output) may spend ONLY:
+        //   * v7 USDSOQ inputs (the asset being moved), and
+        //   * transparent native-SOQ (v1) inputs (to pay the SOQ fee).
+        // Conservation (above) already guarantees USDSOQ cannot be forged or
+        // converted; this additionally forbids exotic inputs (e.g. confidential
+        // v4) being mixed into a transparent USDSOQ transfer, keeping such
+        // transfers wholly transparent.
+        //
+        // WHY HERE (not ConnectBlock): CheckTxInputs runs with inputs still
+        // available in BOTH validation paths — ConnectBlock's first pass
+        // (via CheckInputs, before UpdateCoins spends them) AND mempool accept
+        // (ATMP → CheckInputs). Enforcing from this single chokepoint makes the
+        // rule LIVE in both, so mempool policy and consensus can never diverge.
+        // The prior ConnectBlock-only rule lived in the SECOND pass, after
+        // UpdateCoins had already spent every input, so its
+        // `!coins->IsAvailable() → continue` guard made it DEAD CODE — it never
+        // rejected anything, which is why a SOQ-fee transfer already connected
+        // and why there was never an actual mempool-poison from it (bead 0r2).
+        // Authority (mint/burn/freeze/rotate) txs are exempt (outer guard).
+        if (nUSDSOQOut > 0) {
+            for (unsigned int i = 0; i < tx.vin.size(); i++) {
+                const COutPoint& prevout = tx.vin[i].prevout;
+                const CTxOut& prevOut = inputs.AccessCoins(prevout.hash)->vout[prevout.n];
+                if (!prevOut.IsUSDSOQ() &&
+                    !(prevOut.IsNativeSOQ() && prevOut.IsTransparent())) {
+                    return state.DoS(100, false, REJECT_INVALID,
+                        "bad-txns-usdsoq-input-mismatch", false,
+                        strprintf("USDSOQ transfer input %s:%u is neither a v7 "
+                            "USDSOQ input nor a transparent SOQ fee input",
+                            prevout.hash.ToString(), prevout.n));
+                }
+            }
+        }
     }
 
     return true;
@@ -2728,14 +2763,9 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             const CTransaction& tx = *(block.vtx[i]);
             if (tx.IsCoinBase()) continue;
 
-            // Determine if this tx has USDSOQ outputs
-            bool txHasUSDSOQ = false;
-            for (const auto& txout : tx.vout) {
-                if (txout.IsUSDSOQ()) {
-                    txHasUSDSOQ = true;
-                    break;
-                }
-            }
+            // (Input-type isolation that formerly read this per-tx "has USDSOQ
+            // output" flag now lives in Consensus::CheckTxInputs (Option B),
+            // enforced live in both the connect and mempool paths — bead 0r2/e2n.)
 
             // =============================================================
             // SOQ-I005: Authority TX detection and M-of-N Dilithium
@@ -3087,51 +3117,35 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 }
             }
 
-            // Input-side validation for non-coinbase transactions
-            for (const auto& txin : tx.vin) {
-                const CCoins* coins = view.AccessCoins(txin.prevout.hash);
-                if (!coins || !coins->IsAvailable(txin.prevout.n))
-                    continue;  // Already caught by HaveInputs check above
-
-                const CTxOut& prevOut = coins->vout[txin.prevout.n];
-
-                // Frozen UTXO guard: reject spending any frozen USDSOQ output.
-                // Checks BOTH:
-                //   1. Legacy: nVisibility high-bit (0x80) — existing chain data
-                //   2. Registry: DB_USDSOQ_FROZEN set — new freeze-registry ops
-                //
-                // Both paths remain active during migration. Once all legacy
-                // frozen UTXOs are re-frozen via the registry (Phase 2),
-                // the nVisibility check can be removed.
-                //
-                // H3 FIX (June 3, 2026): Only enforce freeze on USDSOQ outputs.
-                // If a SOQ output somehow gets the frozen bit set (corruption),
-                // it must NOT become permanently unspendable.
-                if (prevOut.IsUSDSOQ()) {
-                    // Phase 4: freeze enforcement via registry only (nVisibility bit removed)
-                    bool frozenByRegistry = pcoinsdbview &&
-                        pcoinsdbview->IsFrozenOutpoint(txin.prevout);
-                    if (frozenByRegistry) {
+            // Frozen-UTXO guard (registry): reject any spend of a frozen USDSOQ
+            // outpoint. Reads prevouts from the block UNDO data, NOT the coins
+            // view, because by this second pass UpdateCoins (first pass) has
+            // already spent every input — the same reason the burn loop below
+            // reads undo. This runs in fJustCheck too, so TestBlockValidity
+            // rejects a template carrying a frozen spend.
+            //
+            // e2n FIX: the previous freeze guard here iterated the coins VIEW and
+            // bailed via `!coins->IsAvailable() → continue` on every (already
+            // spent) input — it was DEAD CODE, so freeze was enforced ONLY at
+            // mempool (BUG-22, the ATMP mirror). A miner assembling a block
+            // off-mempool could therefore spend a frozen coin. Reading undo makes
+            // consensus enforcement LIVE, matching the ATMP check. Applies to ALL
+            // txs (a freeze blocks even an authority burn of that outpoint),
+            // USDSOQ prevouts only. Input-type isolation formerly co-located here
+            // now lives in Consensus::CheckTxInputs (Option B), enforced live in
+            // both the connect and mempool paths from one chokepoint.
+            if (i > 0 && (i - 1) < blockundo.vtxundo.size()) {
+                const CTxUndo& txundoFreeze = blockundo.vtxundo[i - 1];
+                for (unsigned int j = 0;
+                     j < tx.vin.size() && j < txundoFreeze.vprevout.size(); j++) {
+                    const CTxOut& prevOut = txundoFreeze.vprevout[j].txout;
+                    if (prevOut.IsUSDSOQ() && pcoinsdbview &&
+                        pcoinsdbview->IsFrozenOutpoint(tx.vin[j].prevout)) {
                         return state.DoS(100,
                             error("ConnectBlock(): attempt to spend frozen USDSOQ UTXO %s:%u"
                                   " (registry)",
-                                txin.prevout.hash.ToString(), txin.prevout.n),
+                                tx.vin[j].prevout.hash.ToString(), tx.vin[j].prevout.n),
                             REJECT_INVALID, "bad-txns-spend-frozen-usdsoq");
-                    }
-                }
-
-                // Asset isolation on inputs: if ANY output is USDSOQ,
-                // ALL inputs must also be USDSOQ (or this is a mint tx).
-                // MINT transactions have no USDSOQ inputs by definition
-                // (they create new supply from authority-signed witness).
-                // NOTE: isAuthorityTx was already determined by SOQ-I005
-                // authority detection above — no need to re-scan outputs.
-                if (txHasUSDSOQ && !prevOut.IsUSDSOQ()) {
-                    if (!isAuthorityTx) {
-                        return state.DoS(100,
-                            error("ConnectBlock(): USDSOQ tx has non-USDSOQ input %s:%u",
-                                txin.prevout.hash.ToString(), txin.prevout.n),
-                            REJECT_INVALID, "bad-txns-usdsoq-input-mismatch");
                     }
                 }
             }


### PR DESCRIPTION
## USDSOQ input isolation (Option B) + freeze enforcement — made LIVE (beads 0r2, e2n)

### ⚠️ CONSENSUS TIGHTENING — lockstep deploy only. DO NOT merge-and-deploy piecemeal.
This makes two rules that were **dead code** actually enforced. A block that an old node would connect (a frozen-coin spend, or a USDSOQ transfer mixing an exotic input) is now **rejected**. All fleet nodes must upgrade together, or a node running this will fork off any that don't. Since mainnet has not launched, it ships active-from-genesis there; stagenet needs a coordinated fleet restart.

### The bug
Two USDSOQ input-side checks lived in ConnectBlock's **second** pass, which runs *after* `UpdateCoins` (first pass) has already spent every input. The loop's `if (!coins->IsAvailable()) continue;` guard therefore skipped every input — **both checks were dead code**:
- `bad-txns-usdsoq-input-mismatch` (asset isolation)
- `bad-txns-spend-frozen-usdsoq` (freeze enforcement)

**Proof they were dead:** the existing `v7_to_v7_send_conserves` test (v7 input + native-SOQ fee input) already *connected*; my live `send-usdsoq` reconciliation txs (v7 + SOQ fee) confirmed on-chain; and no test ever exercised a block-level frozen-spend rejection. **Consequence:** freeze was enforced **only at mempool** (the BUG-22 ATMP mirror), so a block assembled off-mempool could spend a frozen (GENIUS-Act compliance) USDSOQ coin. This also corrected my earlier 0r2 assessment — there was never an active SOQ-fee "poison" because the isolation rule never fired.

### The fix (robust, single chokepoint)
- **Isolation → `Consensus::CheckTxInputs`.** It runs with inputs *live* in **both** paths — ConnectBlock's first pass (via `CheckInputs`, before `UpdateCoins`) and mempool accept (ATMP via `CheckInputs`). Enforcing there means one rule, both paths, **mempool/consensus can never diverge** — no separate mirror to keep in sync. Rule (Option B): a transparent USDSOQ transfer (any v7 output) may spend only v7 USDSOQ inputs and transparent native-SOQ (v1) fee inputs. Conservation (already present) still blocks forging/converting. This makes SOQ-fee transfers first-class and rejects exotic (e.g. confidential v4) inputs mixed into a transparent transfer.
- **Freeze → repaired to read prevouts from block undo** (exactly how the burn loop right below already does), so freeze is enforced **live at consensus**, matching the ATMP mirror.
- Removed the dead ConnectBlock loop and its now-unused `txHasUSDSOQ` flag.

### Tests (`usdsoq_v7_conservation_harness_tests`)
- `connectblock_rejects_spend_of_frozen_v7_outpoint` — freeze a v7 outpoint, mine a spend → **rejected**; unfreeze, mine → **connects** (isolates the freeze guard). Fails on the old dead-code path.
- `checktxinputs_rejects_exotic_input_in_usdsoq_transfer` — a conserving v7 transfer that mixes a confidential v4 input → `bad-txns-usdsoq-input-mismatch`.
- Full suite **578/578**.

### Related, already done
- 8nz (supply divergence) — healed by a Services `-reindex-chainstate`; both nodes now match exactly. Closed.
- Option B was chosen by Casey (allow SOQ fee inputs) as the robust long-term model; this implements it as the intended enforcement rather than the dead rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
