### PR TITLE
consensus: withdraw OP_CHECKFOLDPROOF from mainnet launch consensus

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -199,11 +199,35 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_CHECKPATAGG].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_CHECKPATAGG].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
-        // LatticeFold+ activation — ALWAYS_ACTIVE from genesis (April 2026 decision)
-        // SOQ-P002: No BIP9 signaling needed — new chain, privacy from block 0
+        // SOQ-P002: LatticeFold+ (OP_CHECKFOLDPROOF) — WITHDRAWN from launch consensus.
+        // This was ALWAYS_ACTIVE from genesis under the April 2026 "new chain, privacy from
+        // block 0" decision. That decision is withdrawn: the verifier reads the statement
+        // fields (t_coeffs, c) from the untrusted proof blob and every algebraic check is
+        // homogeneous in the witness, so the all-zero witness satisfies all of them. The only
+        // non-homogeneous check is the Fiat-Shamir seed, a public value the spender recomputes.
+        // A proof carrying no valid Dilithium signature therefore verifies. Consensus gates
+        // this opcode via BIP9 VersionBitsState (validation.cpp:1470/3131), NOT the vestigial
+        // nLatticeFoldActivationHeight below, so ALWAYS_ACTIVE was a live mainnet forgery path
+        // from genesis.
+        //
+        // nStartTime=0 / nTimeout=0 => THRESHOLD_FAILED (terminal, never ACTIVE), the same
+        // never-active idiom used for LATTICEBP below. SCRIPT_VERIFY_LATTICEFOLD is then never
+        // set on mainnet, which makes both entry points unreachable: OP_CHECKFOLDPROOF in a
+        // script returns SCRIPT_ERR_BAD_OPCODE (interpreter.cpp:316) and the witness-v3 program
+        // short-circuits before EvalCheckFoldProof (interpreter.cpp:1652).
+        //
+        // Witness v3 (OP_3) stays relay-nonstandard via the BIP141 s4 future-witness rejection
+        // in policy.cpp — it is NOT one of the v5-v9 carve-outs — so a v3 output cannot be
+        // funded through normal relay while it is anyone-can-spend. Do not add OP_3 to those
+        // carve-outs while this deployment is inactive.
+        //
+        // The confidential-transaction purpose is served by the flag-2 aggregation (pack) path.
+        // Reactivate on mainnet only with a real prover, a statement anchored to a commitment
+        // fixed OUTSIDE the proof, and a re-audit. Regression guard:
+        // latticefold_tests.cpp: mainnet_latticefold_deployment_never_active.
         consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].bit = 28;
-        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
-        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nStartTime = 0;  // Not started
+        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nTimeout = 0;    // Never activates
 
         // SOQ-P003: Lattice-BP++ Range Proofs — NOT ACTIVE (future soft-fork)
         // Post-quantum confidential transaction amount hiding using Ring-LWE
@@ -290,8 +314,8 @@ public:
         // DL-P96-BLOCK-VERSION-ACTIVATION.md). All ship NOT_SCHEDULED (dormant) — a
         // coordinated release sets a real height for each as its Halborn Phase 2
         // scope clears. The nStartTime/nTimeout above are retained but NOT consulted
-        // for these deployments. (CHECKPATAGG/LATTICEFOLD stay always-active on BIP9;
-        // CSV/SegWit stay on the historical BIP9 windows.)
+        // for these deployments. (CHECKPATAGG stays always-active on BIP9; LATTICEFOLD is
+        // BIP9-inactive above; CSV/SegWit stay on the historical BIP9 windows.)
         consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEBP].nActivationHeight        = Consensus::BIP9Deployment::NOT_SCHEDULED;
         consensus.vDeployments[Consensus::DEPLOYMENT_USDSOQ].nActivationHeight           = Consensus::BIP9Deployment::NOT_SCHEDULED;
         consensus.vDeployments[Consensus::DEPLOYMENT_BTCSOQ].nActivationHeight           = Consensus::BIP9Deployment::NOT_SCHEDULED;
@@ -311,7 +335,10 @@ public:
         consensus.defaultAssumeValid = uint256S("0x00");
         consensus.dilithiumOnlyHeight = 0;
         consensus.dilithiumOnlyHeight = 0;
-        consensus.nLatticeFoldActivationHeight = 0; // Active from genesis
+        // VESTIGIAL: never read by consensus (BIP9 VersionBitsState is the only gate for
+        // DEPLOYMENT_LATTICEFOLD). Retained only so the struct layout is unchanged. Do NOT
+        // wire this up as an activation path — it would bypass the deactivation above.
+        consensus.nLatticeFoldActivationHeight = 0;
 
         // AuxPoW parameters
         consensus.nAuxpowChainId = 0x5351;   // "SQ" = Soqucoin (unique chain ID)

--- a/src/rpc/privacy.cpp
+++ b/src/rpc/privacy.cpp
@@ -334,7 +334,8 @@ static UniValue getprivacystatus(const JSONRPCRequest& request)
         Consensus::DEPLOYMENT_LATTICEBP);
     bool latticebpActive = (latticebpState == THRESHOLD_ACTIVE);
 
-    // LatticeFold is always active (separate from Lattice-BP++)
+    // LatticeFold+ (separate from Lattice-BP++). Withdrawn from launch consensus:
+    // inactive on mainnet, still ALWAYS_ACTIVE on the test networks.
     ThresholdState latticefoldState = VersionBitsTipState(
         consensusParams,
         Consensus::DEPLOYMENT_LATTICEFOLD);

--- a/src/test/latticefold_tests.cpp
+++ b/src/test/latticefold_tests.cpp
@@ -5,6 +5,12 @@
 // Tests the new API with external binding (sighash, pubkey_hash, dilithium_sigs).
 
 #include "crypto/latticefold/verifier.h"
+#include "chainparams.h"
+#include "chainparamsbase.h"
+#include "consensus/params.h"
+#include "policy/policy.h"
+#include "script/script.h"
+#include "script/standard.h"
 #include "test/test_bitcoin.h"
 #include "uint256.h"
 
@@ -128,6 +134,90 @@ BOOST_AUTO_TEST_CASE(external_binding_different_sighash)
     std::vector<unsigned char> vch(8816, 0);
     BOOST_CHECK(!EvalCheckFoldProof(vch, sighash1, pk_hash, sigs));
     BOOST_CHECK(!EvalCheckFoldProof(vch, sighash2, pk_hash, sigs));
+}
+
+// =========================================================================
+// Launch-consensus withdrawal guard (Option A).
+//
+// OP_CHECKFOLDPROOF is withdrawn from mainnet: the verifier reads the
+// statement (t_coeffs, c) from the untrusted blob and every algebraic check
+// is homogeneous in the witness, so the all-zero witness satisfies all of
+// them; the one non-homogeneous check is a public recomputable Fiat-Shamir
+// seed. Mainnet DEPLOYMENT_LATTICEFOLD was ALWAYS_ACTIVE from genesis, and a
+// prior branch-landing recipe silently dropped the deactivation once already.
+// These assertions are the guard against that happening again.
+//
+// NOTE: these tests intentionally assert CONFIGURATION, not verifier
+// behaviour. The forgery is still reachable wherever the deployment is active
+// (the test networks, deliberately, as a playground). What must never regress
+// is that mainnet cannot reach it.
+// =========================================================================
+
+BOOST_AUTO_TEST_CASE(mainnet_latticefold_deployment_never_active)
+{
+    const CChainParams& mainParams = Params(CBaseChainParams::MAIN);
+
+    // Mainnet consensus is a height-indexed BST (consensus -> auxpowConsensus),
+    // and the tiers are COPIES taken during CMainParams construction. Assert every
+    // tier, not just the root: a tier added or re-copied before the deployment
+    // block would silently resurrect the opcode above that height.
+    const uint32_t heights[] = {0, 1, 2, 100000, 10000000};
+
+    for (uint32_t h : heights) {
+        const Consensus::Params& consensus = mainParams.GetConsensus(h);
+        const Consensus::BIP9Deployment& lf =
+            consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD];
+
+        // nStartTime=0 / nTimeout=0 => the BIP9 state machine reaches
+        // THRESHOLD_FAILED (terminal) for every block, so SCRIPT_VERIFY_LATTICEFOLD
+        // is never set on mainnet and EvalCheckFoldProof is unreachable there.
+        BOOST_CHECK_MESSAGE(lf.nStartTime != Consensus::BIP9Deployment::ALWAYS_ACTIVE,
+            "mainnet DEPLOYMENT_LATTICEFOLD must NOT be ALWAYS_ACTIVE at height " << h
+            << " — OP_CHECKFOLDPROOF accepts a zero witness and is withdrawn from "
+            "launch consensus");
+        BOOST_CHECK_EQUAL(lf.nStartTime, 0);
+        BOOST_CHECK_EQUAL(lf.nTimeout, 0);
+
+        // The flag-day (p96/Option D) path must not be wired up either, or it would
+        // activate the opcode by height and bypass the BIP9 deactivation entirely.
+        BOOST_CHECK_EQUAL(lf.nActivationHeight,
+                          Consensus::BIP9Deployment::NO_HEIGHT_ACTIVATION);
+        BOOST_CHECK(!Consensus::DeploymentActiveAtHeight(
+            h, consensus, Consensus::DEPLOYMENT_LATTICEFOLD));
+
+        // The sibling range-proof deployment (bead x1wf, same zero-generator
+        // class) must likewise stay inactive on mainnet.
+        const Consensus::BIP9Deployment& bp =
+            consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEBP];
+        BOOST_CHECK_MESSAGE(bp.nStartTime != Consensus::BIP9Deployment::ALWAYS_ACTIVE,
+            "mainnet DEPLOYMENT_LATTICEBP must NOT be ALWAYS_ACTIVE at height " << h);
+        BOOST_CHECK_EQUAL(bp.nActivationHeight,
+                          Consensus::BIP9Deployment::NOT_SCHEDULED);
+        BOOST_CHECK(!Consensus::DeploymentActiveAtHeight(
+            h, consensus, Consensus::DEPLOYMENT_LATTICEBP));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(witness_v3_output_is_relay_nonstandard)
+{
+    // Containment for the anyone-can-spend posture the deactivation creates.
+    // With SCRIPT_VERIFY_LATTICEFOLD unset, a v3 program short-circuits to
+    // success (interpreter.cpp:1652) — i.e. anyone-can-spend. That is only safe
+    // while v3 outputs cannot be funded through normal relay.
+    //
+    // v3 = OP_3 (0x53) falls inside the BIP141 s4 future-witness rejection range
+    // (OP_2..OP_16) in policy.cpp and is NOT one of the OP_5..OP_9 carve-outs.
+    // If someone adds OP_3 to those carve-outs while the deployment is inactive,
+    // this test fails — and it must, because that combination is the v6 hazard
+    // (see covenant_tests.cpp: htlc_v6_output_is_relay_standard).
+    CScript v3out;
+    v3out << OP_3 << std::vector<unsigned char>(32, 0xab);
+    BOOST_REQUIRE_EQUAL(v3out.size(), 34U);
+
+    txnouttype whichType;
+    BOOST_CHECK_MESSAGE(!::IsStandard(v3out, whichType, /*witnessEnabled=*/true),
+        "witness v3 must stay relay-nonstandard while DEPLOYMENT_LATTICEFOLD is "
+        "inactive, otherwise v3 outputs are fundable AND anyone-can-spend");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Mainnet `DEPLOYMENT_LATTICEFOLD` is currently BIP9 `ALWAYS_ACTIVE` from genesis on `main`, but the LatticeFold+ verifier accepts a proof authorised by **no valid signature**. This PR deactivates it on mainnet and adds regression tests so the state cannot silently recur.

Mainnet is unlaunched, so no funds are or were exposed.

## The defect

The statement fields (`t_coeffs`, `c`) are read from the untrusted proof blob, and every algebraic check is **homogeneous in the witness** — so the all-zero witness satisfies all of them:

- range `0 == 0`
- per-row Ajtai `A*0 == 0`
- sumcheck `0 == 0`
- folded commitment `0 == 0`

The one non-homogeneous check is the Fiat-Shamir seed, which is a **public value the spender recomputes and plants**. Verified through the real script entry point `EvalCheckFoldProof(blob, sighash, pubkey_hash, sigs)`:

```
pass 1 (all-zero blob): reject   expected_seed=4ef6a7fb3500f396d631c3fd8a13d428
pass 2 (planted seed):  ACCEPT
```

Consensus gates the opcode via BIP9 `VersionBitsState` (`validation.cpp:1470` mempool, `:3131` ConnectBlock), **not** the vestigial `nLatticeFoldActivationHeight`, so `ALWAYS_ACTIVE` is a live mainnet forgery path from genesis.

## Why this is a re-landing

This deactivation existed once, as `d6ef1150d` on `consensus/latticefold-mainnet-deactivate`. The BTCSOQ history replay that became #32 deliberately left that commit behind as belonging to another arc, on the assumption that the privacy arc would deliver it separately. That arc never landed, so `main` regained the always-active configuration. The ops recipe that carried the drop instruction has been corrected.

## The fix

`nStartTime=0 / nTimeout=0` gives `THRESHOLD_FAILED` (terminal, never `ACTIVE`), mirroring the `LATTICEBP` never-active idiom. `SCRIPT_VERIFY_LATTICEFOLD` is then never set on mainnet, closing both entry points:

- `OP_CHECKFOLDPROOF` in a script returns `SCRIPT_ERR_BAD_OPCODE` (`interpreter.cpp:316`)
- a witness-v3 program short-circuits before the verifier (`interpreter.cpp:1652`)

The flag is not in `STANDARD_SCRIPT_VERIFY_FLAGS` and has no other set-site, and both gates use the same BIP9 query, so **policy still matches consensus** (no template-expiry / empty-block hazard). Mainnet-only; test networks stay `ALWAYS_ACTIVE` as a playground.

## Anyone-can-spend posture is contained

The resulting posture for witness v3 is the standard soft-fork posture, and it is contained: v3 = `OP_3` sits inside the BIP141 §4 future-witness relay rejection in `policy.cpp` and is **not** one of the `OP_5..OP_9` carve-outs, so a v3 output cannot be funded through normal relay. This is what makes it unlike the v6 exposure.

## Tests

- `mainnet_latticefold_deployment_never_active` — asserts `nStartTime`/`nTimeout`, that the flag-day (p96/Option D) path is not wired up, and the sibling `LATTICEBP` state, **across every height tier of the mainnet consensus BST** (the tiers are copies taken during `CMainParams` construction, so a root-only assertion would miss a re-copy).
- `witness_v3_output_is_relay_nonstandard` — fails if `OP_3` is ever added to the policy carve-outs while the deployment is inactive.

Full unit suite **598 cases green**.

**Known limit of the guard:** these tests catch someone editing the chainparams line back. They cannot catch dropping the whole commit, since the tests travel with the fix. Any future history replay must check what it leaves behind.

## Follow-up (not in this PR)

The verifier itself is unchanged and remains permissive on the test networks, where the deployment is intentionally active. Reactivating on mainnet requires a real prover, the statement anchored to a commitment fixed **outside** the proof, and a re-audit.