### PR TITLE
policy: gate v5-v9 standardness on activation, closing a mainnet fund-loss path

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -148,6 +148,7 @@ BITCOIN_TESTS =\
   test/univalue_tests.cpp \
   test/util_tests.cpp \
   test/verify_cost_tests.cpp \
+  test/witness_standardness_tests.cpp \
   test/consensus_validation_tests.cpp \
   test/latticefold_tests.cpp \
   test/usdsoq_tests.cpp \

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -32,7 +32,8 @@
      *   DUP CHECKSIG DROP ... repeated 100 times... OP_1
      */
 
-bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType, const bool witnessEnabled)
+bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType, const bool witnessEnabled,
+                WitnessVersionMask activeWitnessVersions)
 {
     std::vector<std::vector<unsigned char> > vSolutions;
     if (!Solver(scriptPubKey, whichType, vSolutions))
@@ -54,34 +55,38 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType, const bool w
     else if (!witnessEnabled && (whichType == TX_WITNESS_V0_KEYHASH || whichType == TX_WITNESS_V0_SCRIPTHASH))
         return false;
 
-    // Reject future witness versions (v2-v16) at policy layer.
-    // These are consensus-valid (anyone-can-spend) but MUST NOT be created
-    // or relayed until the corresponding soft fork activates specific
-    // validation rules for that witness version.
+    // Reject witness versions v2-v16 at the policy layer UNLESS their consensus
+    // rules are active on this chain right now.
+    //
+    // These programs are consensus-valid-as-anyone-can-spend until their soft fork
+    // activates. Relaying one before then is not a soft failure, it is a fund-loss
+    // path: the output confirms and anybody may then spend it.
     // Reference: BIP141 section 4 — prevents premature output creation.
-    // Exceptions:
-    //   OP_5 (0x55) = witness v5 = USDSOQ authority operations
-    //   OP_6 (0x56) = witness v6 = P2WSH-Dilithium covenant script execution
-    //   OP_7 (0x57) = witness v7 = USDSOQ holding (CTxOut Phase 4; spent via the v1 path)
-    //   OP_8 (0x58) = witness v8 = BTCSOQ holding (DL-BTCSOQ-CONSENSUS-NATIVE; v1 spend path)
-    //   OP_9 (0x59) = witness v9 = BTCSOQ authority marker
-    // All ALWAYS_ACTIVE on stagenet; on mainnet each is a flag-height
-    // deployment (p96/Option D), shipped dormant until a height is scheduled.
+    //
+    // This previously carved out v5-v9 UNCONDITIONALLY, which was correct on
+    // stagenet (where those deployments are ALWAYS_ACTIVE) and wrong on mainnet
+    // (where every one of them is nStartTime=0/nTimeout=0 or NOT_SCHEDULED). The
+    // effect on mainnet was that v5-v9 outputs were relay-standard AND
+    // anyone-can-spend simultaneously. Gating on the live activation state makes
+    // policy track consensus on the OUTPUT side, which is the same policy-equals-
+    // consensus rule already applied to the INPUT side after live bug daf9fd85.
+    //
+    // Deliberately a POLICY change, not a consensus one: tightening consensus here
+    // would turn each future activation into a hard fork.
     if (scriptPubKey.size() == 34 &&
         scriptPubKey[0] >= 0x52 && scriptPubKey[0] <= 0x60 &&  // OP_2 through OP_16
-        scriptPubKey[0] != 0x55 &&                              // except OP_5 (USDSOQ authority)
-        scriptPubKey[0] != 0x56 &&                              // except OP_6 (P2WSH-Dilithium)
-        scriptPubKey[0] != 0x57 &&                              // except OP_7 (USDSOQ holding)
-        scriptPubKey[0] != 0x58 &&                              // except OP_8 (BTCSOQ holding)
-        scriptPubKey[0] != 0x59 &&                              // except OP_9 (BTCSOQ authority)
         scriptPubKey[1] == 32) {
-        return false;
+        const int witnessVersion = scriptPubKey[0] - 0x50;      // OP_N encodes N
+        if (!(activeWitnessVersions & WitnessVersionBit(witnessVersion))) {
+            return false;
+        }
     }
 
     return whichType != TX_NONSTANDARD;
 }
 
-bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnessEnabled)
+bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnessEnabled,
+                  WitnessVersionMask activeWitnessVersions)
 {
     if (tx.nVersion > CTransaction::MAX_STANDARD_VERSION || tx.nVersion < 1) {
         reason = "version";
@@ -120,7 +125,7 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnes
     unsigned int nDataOut = 0;
     txnouttype whichType;
     BOOST_FOREACH(const CTxOut& txout, tx.vout) {
-        if (!::IsStandard(txout.scriptPubKey, whichType, witnessEnabled)) {
+        if (!::IsStandard(txout.scriptPubKey, whichType, witnessEnabled, activeWitnessVersions)) {
             reason = "scriptpubkey";
             return false;
         }

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -145,12 +145,29 @@ static const unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS = STANDARD_SCRIPT_
 static const unsigned int STANDARD_LOCKTIME_VERIFY_FLAGS = LOCKTIME_VERIFY_SEQUENCE |
                                                            LOCKTIME_MEDIAN_TIME_PAST;
 
-bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType, const bool witnessEnabled = false);
+/**
+ * Bitmask of witness versions whose CONSENSUS rules are active, bit N = version N.
+ *
+ * Policy must never admit an output whose consensus rule is dormant. A gated
+ * witness version is anyone-can-spend until its deployment activates, so relaying
+ * such an output is a fund-loss path rather than a safe failure: it confirms, and
+ * then anybody may spend it.
+ *
+ * The default of 0 means "nothing gated is active", which is the fail-safe
+ * direction — an unknown activation state rejects rather than relays. Callers that
+ * know the chain state (the mempool acceptance path) pass the real mask.
+ */
+typedef uint32_t WitnessVersionMask;
+static inline WitnessVersionMask WitnessVersionBit(int version) { return (uint32_t)1 << version; }
+
+bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType, const bool witnessEnabled = false,
+                WitnessVersionMask activeWitnessVersions = 0);
     /**
      * Check for standard transaction types
      * @return True if all outputs (scriptPubKeys) use only standard transaction forms
      */
-bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnessEnabled = false);
+bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnessEnabled = false,
+                  WitnessVersionMask activeWitnessVersions = 0);
     /**
      * Check for standard transaction types
      * @param[in] mapInputs    Map of previous transactions that have outputs we're spending

--- a/src/test/btcsoq_tests.cpp
+++ b/src/test/btcsoq_tests.cpp
@@ -291,13 +291,24 @@ BOOST_AUTO_TEST_CASE(solver_classifies_v8_and_v9)
 
 BOOST_AUTO_TEST_CASE(policy_accepts_v8_v9_rejects_v10)
 {
+    // v8/v9 are standard only while DEPLOYMENT_BTCSOQ is active. Before this test
+    // was updated it asserted they were standard unconditionally, which is the
+    // behaviour that made them relay-standard AND anyone-can-spend on mainnet,
+    // where BTCSOQ ships NOT_SCHEDULED. See witness_standardness_tests.cpp.
+    const WitnessVersionMask btcsoqActive = WitnessVersionBit(8) | WitnessVersionBit(9);
+
     txnouttype whichType;
-    BOOST_CHECK(::IsStandard(WitnessScript(OP_8, 0x01), whichType, true));
+    BOOST_CHECK(::IsStandard(WitnessScript(OP_8, 0x01), whichType, true, btcsoqActive));
     BOOST_CHECK(whichType == TX_WITNESS_V8_BTCSOQ);
-    BOOST_CHECK(::IsStandard(WitnessScript(OP_9, 0x02), whichType, true));
+    BOOST_CHECK(::IsStandard(WitnessScript(OP_9, 0x02), whichType, true, btcsoqActive));
     BOOST_CHECK(whichType == TX_WITNESS_V9_BTCSOQ_AUTHORITY);
     // Future witness versions stay policy-rejected until their soft fork.
-    BOOST_CHECK(!::IsStandard(WitnessScript(OP_10, 0x03), whichType, true));
+    BOOST_CHECK(!::IsStandard(WitnessScript(OP_10, 0x03), whichType, true, btcsoqActive));
+
+    // And with the deployment dormant — mainnet's actual state — they are not
+    // standard, so no unspendable-by-anyone-else output can be relayed.
+    BOOST_CHECK(!::IsStandard(WitnessScript(OP_8, 0x01), whichType, true, 0));
+    BOOST_CHECK(!::IsStandard(WitnessScript(OP_9, 0x02), whichType, true, 0));
 }
 
 BOOST_AUTO_TEST_CASE(verifyscript_gates_v8_and_v9)

--- a/src/test/witness_standardness_tests.cpp
+++ b/src/test/witness_standardness_tests.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 The Soqucoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+// Policy must never admit an output whose consensus rule is dormant.
+//
+// A gated witness version is anyone-can-spend until its deployment activates. If
+// relay policy also calls it standard, the two together are a fund-loss path
+// rather than a safe failure: the output relays, confirms, and then anybody may
+// spend it. That combination existed on mainnet for witness versions v5 through
+// v9, because policy.cpp carved them out of the future-version rejection
+// UNCONDITIONALLY — correct on stagenet where those deployments are
+// ALWAYS_ACTIVE, wrong on mainnet where every one of them ships
+// nStartTime=0/nTimeout=0 or NOT_SCHEDULED.
+//
+// These tests pin the rule that replaced the carve-out: a v2-v16 program is
+// standard only while the matching bit is set in the activation mask.
+
+#include "policy/policy.h"
+#include "script/script.h"
+#include "script/standard.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(witness_standardness_tests, BasicTestingSetup)
+
+namespace {
+
+//! A 34-byte witness program: OP_<version> followed by a 32-byte push.
+CScript WitnessProgram(int version)
+{
+    BOOST_REQUIRE(version >= 1 && version <= 16);
+    CScript s;
+    s << CScript::EncodeOP_N(version);
+    s << std::vector<unsigned char>(32, 0x01);
+    BOOST_REQUIRE_EQUAL(s.size(), 34U);
+    return s;
+}
+
+bool StandardWith(const CScript& spk, WitnessVersionMask mask)
+{
+    txnouttype whichType;
+    return IsStandard(spk, whichType, /*witnessEnabled=*/true, mask);
+}
+
+} // namespace
+
+// The regression. Every gated version must be non-standard when nothing is
+// active, which is the state mainnet actually ships in.
+BOOST_AUTO_TEST_CASE(gated_versions_nonstandard_when_dormant)
+{
+    for (int v = 2; v <= 16; ++v) {
+        BOOST_CHECK_MESSAGE(!StandardWith(WitnessProgram(v), 0),
+                            "witness v" << v << " was standard with no deployment active; "
+                            "relay-standard plus anyone-can-spend is a fund-loss path");
+    }
+}
+
+// v5-v9 specifically, because those were the unconditional carve-outs.
+BOOST_AUTO_TEST_CASE(v5_through_v9_were_the_carve_outs)
+{
+    for (int v = 5; v <= 9; ++v) {
+        BOOST_CHECK(!StandardWith(WitnessProgram(v), 0));
+        // ...and become standard only once their own bit is set.
+        BOOST_CHECK(StandardWith(WitnessProgram(v), WitnessVersionBit(v)));
+    }
+}
+
+// The gated set is exactly {v5..v9} — the versions Solver() recognises as named
+// output types. Everything else in v2-v16 is rejected earlier, by Solver itself,
+// and the mask never gets a say. That second layer is why only v5-v9 were ever
+// reachable, and therefore why only v5-v9 were ever the fund-loss path.
+BOOST_AUTO_TEST_CASE(activation_does_not_leak_across_versions)
+{
+    const int gated[] = {5, 6, 7, 8, 9};
+    for (int active : gated) {
+        const WitnessVersionMask mask = WitnessVersionBit(active);
+        for (int v : gated) {
+            const bool standard = StandardWith(WitnessProgram(v), mask);
+            BOOST_CHECK_MESSAGE(standard == (v == active),
+                                "activating v" << active << " changed standardness of v" << v);
+        }
+    }
+}
+
+// Defence in depth: versions Solver() does not name can never be standard, no
+// matter what the activation mask says. If a future change teaches Solver a new
+// version, this test fails and forces a deliberate decision about its mask entry
+// rather than letting it become relayable by accident.
+BOOST_AUTO_TEST_CASE(unrecognised_versions_ignore_the_mask_entirely)
+{
+    // Every bit set — a mask the acceptance path can never actually produce.
+    WitnessVersionMask everything = 0;
+    for (int v = 2; v <= 16; ++v) everything |= WitnessVersionBit(v);
+
+    const int notNamedBySolver[] = {2, 3, 4, 10, 11, 12, 13, 14, 15, 16};
+    for (int v : notNamedBySolver) {
+        BOOST_CHECK_MESSAGE(!StandardWith(WitnessProgram(v), everything),
+                            "witness v" << v << " became standard despite Solver not naming it");
+    }
+}
+
+// The base forms must be unaffected by the change.
+BOOST_AUTO_TEST_CASE(v0_and_v1_unaffected)
+{
+    CScript v0keyhash;
+    v0keyhash << OP_0 << std::vector<unsigned char>(20, 0x02);
+    txnouttype t;
+    BOOST_CHECK(IsStandard(v0keyhash, t, /*witnessEnabled=*/true, 0));
+
+    CScript v0scripthash;
+    v0scripthash << OP_0 << std::vector<unsigned char>(32, 0x03);
+    BOOST_CHECK(IsStandard(v0scripthash, t, /*witnessEnabled=*/true, 0));
+
+    // v1 is the single-key Dilithium form and is not part of the gated range.
+    BOOST_CHECK(StandardWith(WitnessProgram(1), 0));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -663,9 +663,40 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
         return state.DoS(0, false, REJECT_NONSTANDARD, "no-witness-yet", true);
     }
 
+    // Which gated witness versions are actually spendable-by-rule right now.
+    //
+    // A gated witness version is anyone-can-spend until its deployment activates,
+    // so relaying an output of that form before activation is a fund-loss path,
+    // not a safe failure: it confirms, and then anybody may spend it. Policy must
+    // therefore track consensus on the OUTPUT side, exactly as it already does on
+    // the INPUT side (see the scriptVerifyFlags block below, added after live bug
+    // daf9fd85). Anything not listed here stays non-standard, which is the
+    // fail-safe direction.
+    WitnessVersionMask activeWitnessVersions = 0;
+    {
+        const int nNextHeight = chainActive.Height() + 1;
+        const Consensus::Params& cons = Params().GetConsensus(nNextHeight);
+        auto heightActive = [&](Consensus::DeploymentPos pos) {
+            return Consensus::DeploymentActiveAtHeight(nNextHeight, cons, pos);
+        };
+        auto bip9Active = [&](Consensus::DeploymentPos pos) {
+            return VersionBitsState(chainActive.Tip(), cons, pos, versionbitscache) == THRESHOLD_ACTIVE;
+        };
+        // v0/v1 are the always-standard base forms and are handled by Solver.
+        if (bip9Active(Consensus::DEPLOYMENT_CHECKPATAGG))     activeWitnessVersions |= WitnessVersionBit(2);
+        if (bip9Active(Consensus::DEPLOYMENT_LATTICEFOLD))     activeWitnessVersions |= WitnessVersionBit(3);
+        if (heightActive(Consensus::DEPLOYMENT_SOQUOBSCURA))   activeWitnessVersions |= WitnessVersionBit(4);
+        // USDSOQ governs both the v5 authority marker and the v7 holding form.
+        if (heightActive(Consensus::DEPLOYMENT_USDSOQ))        activeWitnessVersions |= WitnessVersionBit(5) | WitnessVersionBit(7);
+        if (heightActive(Consensus::DEPLOYMENT_P2WSH_DILITHIUM)) activeWitnessVersions |= WitnessVersionBit(6);
+        // BTCSOQ governs both the v8 holding form and the v9 authority marker.
+        if (heightActive(Consensus::DEPLOYMENT_BTCSOQ))        activeWitnessVersions |= WitnessVersionBit(8) | WitnessVersionBit(9);
+        // v10-v16 are unallocated: never standard until one is assigned a deployment.
+    }
+
     // Rather not work on nonstandard transactions (unless -testnet/-regtest)
     std::string reason;
-    if (fRequireStandard && !IsStandardTx(tx, reason, witnessEnabled))
+    if (fRequireStandard && !IsStandardTx(tx, reason, witnessEnabled, activeWitnessVersions))
         return state.DoS(0, false, REJECT_NONSTANDARD, reason);
 
     // Only accept nLockTime-using transactions that can be mined in the next


### PR DESCRIPTION
## Why this is split out

This is **one commit lifted off `consensus/soquobscura-tier-a-v10`**, which currently carries 12 commits and 23,292 insertions that are not on `main` and have no PR. Most of that is the vendored SoquObscura verifier and its tooling, and SoquObscura is deliberately tabled.

This commit is not tabled work. It closes a **mainnet loss-of-funds path**, and it is the only one of the 12 that has to land before genesis.

It is fully separable: 6 files, 213 insertions, and **none of its files are touched by any of the other 11 commits**. Nobody has to review 23k lines of vendored C to make mainnet safe.

## The defect

Witness versions v5-v9 were **relay-standard while simultaneously being anyone-can-spend** on mainnet. Premature outputs at those versions would relay and confirm, then be spendable by anyone. That is loss of funds, not a safe failure.

## The fix

Standardness for the gated versions is now conditioned on deployment activation, so while a deployment is dormant its witness version is non-standard and cannot be created by accident.

## Verification

Executed against the already-built test binary, not asserted:

```
Test suite "witness_standardness_tests" has passed with:
  5 test cases out of 5 passed
  185 assertions out of 185 passed

  gated_versions_nonstandard_when_dormant          45 assertions
  v5_through_v9_were_the_carve_outs                30 assertions
  activation_does_not_leak_across_versions         75 assertions
  unrecognised_versions_ignore_the_mask_entirely   30 assertions
  v0_and_v1_unaffected                              5 assertions
```

The original commit also recorded a full-suite run: 629 cases, 3 failures, all three the deliberate zero-witness forgery battery, no new failures.

## ⚠️ Note for the reviewer on CI

`main` is currently **red on 3 deliberate forgery tests** and has been accepted as temporary. A red CI on this PR is therefore **not** a signal by itself. Check that the failures are exactly those 3 and that no new ones appear; do not read green/red at face value.

## What stays behind

The remaining 11 commits (vendored LaZer verifier, HEXL, the pruner, KAT corpus, degenerate-witness class) stay on `consensus/soquobscura-tier-a-v10`. They are tabled per the current sprint and should land on their own terms, reviewed as the large change they are.

Beads: `soqucoin-build-witness-v5-v9-standard-anyonecanspend-4sak`, and the branch-state warning in `.gemini/CURRENT_SPRINT.md`.
