### PR TITLE
Gate 0: revive four consensus rules that could not fire, and the machinery that proves it

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -172,7 +172,8 @@ BITCOIN_TESTS =\
   test/dilithium_keyhash_tests.cpp \
   test/dilithium_keyhash_committed_tests.cpp \
   test/usdsoq_v7_holding_tests.cpp \
-  test/usdsoq_v7_conservation_harness_tests.cpp
+  test/usdsoq_v7_conservation_harness_tests.cpp \
+  test/usdsoq_v10_reject_path_tests.cpp
 # Legacy ECDSA tests disabled for Post-Quantum Transition
 #  test/audit_tests.cpp
 #  test/multisig_tests.cpp

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -152,10 +152,43 @@ public:
         consensus.nMajorityRejectBlockOutdated = 1900;
         consensus.nMajorityWindow = 2000;
         // BIP34 is never enforced in Soqucoin v2 blocks, so we enforce from v3
-        consensus.BIP34Height = 1034383;
-        consensus.BIP34Hash = uint256S("0x80d1364201e5df97e696c03bdd24dc885e8617b9de51e453c10a4f629b1e797a");
-        consensus.BIP65Height = 3464751;                                                                     // 34cd2cbba4ba366f47e5aa0db5f02c19eba2adf679ceb6653ac003bdc9a0ef1f - first v4 block after the last v3 block
-        consensus.BIP66Height = 1034383;                                                                     // 80d1364201e5df97e696c03bdd24dc885e8617b9de51e453c10a4f629b1e797a - this is the last block that could be v2, 1900 blocks past the last v2 block
+        // ⛔ THESE WERE DOGECOIN'S MAINNET HEIGHTS, INHERITED VERBATIM (comments and
+        // Dogecoin block hashes included). Soqucoin is NOT a fork: it has its own
+        // genesis and starts at height 0, so those numbers were not history, they
+        // were activation heights for rules that would not have activated for years.
+        // SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY is gated on BIP65Height, so OP_CLTV
+        // would have been a NOP until block 3,464,751 — roughly 6.6 years at
+        // 1-minute blocks. Nothing exploits that at genesis, because the CLTV
+        // vehicles (witness v6 P2WSH-Dilithium, V6_CONTROLFLOW) ship NOT_SCHEDULED;
+        // it goes live the moment either activates, and an eLTOO/HTLC timeout
+        // branch with no enforceable timelock is loss of funds. Stagenet, our own
+        // mainnet rehearsal network, already used 0/0/100 — so every soak result
+        // carried an assumption mainnet did not honour. See bead zz2f.
+        //
+        // BIP34Height = 100, not 0 or 1, for two independent reasons:
+        //   1. It must be > 16. The rule compares against `CScript() << nHeight`,
+        //      which emits the single opcode OP_N for 1..16 rather than the 1-byte
+        //      data push a strict BIP34 writer produces, so heights in that range
+        //      have two defensible encodings and only one is accepted. Above 16 the
+        //      encoding is an unambiguous data push.
+        //   2. Genesis must stay outside the rule. ContextualCheckBlock is reached
+        //      by the genesis block during -reindex (see SOQ-REINDEX-001), and the
+        //      genesis coinbase carries no height push.
+        // Beyond those constraints the exact value buys nothing, so it matches
+        // stagenet: divergence between mainnet and its rehearsal network is the
+        // defect that produced this finding, and parity is worth more than a
+        // smaller number.
+        //
+        // BIP34Hash stays null. It is the hash of the block AT BIP34Height, which
+        // cannot be known before launch, and its only use is letting ConnectBlock
+        // skip the BIP30 duplicate-txid scan. A null hash never matches, so BIP30
+        // stays enforced by lookup forever — strictly more checking, at the cost of
+        // one coins-cache probe per transaction. The stale Dogecoin hash had the
+        // same effect while also being a lie.
+        consensus.BIP34Height = 100;
+        consensus.BIP34Hash = uint256();
+        consensus.BIP65Height = 0;   // CHECKLOCKTIMEVERIFY enforced from genesis
+        consensus.BIP66Height = 0;   // strict DER enforced from genesis
         consensus.powLimit = uint256S("0x00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20;
         consensus.nPowTargetTimespan = 4 * 60 * 60;                                                          // pre-digishield: 4 hours
         consensus.nPowTargetSpacing = 60;                                                                    // 1 minute
@@ -480,10 +513,15 @@ public:
         consensus.nMajorityRejectBlockOutdated = 750;
         consensus.nMajorityWindow = 1000;
         // BIP34 is never enforced in Soqucoin v2 blocks, so we enforce from v3
-        consensus.BIP34Height = 708658;
-        consensus.BIP34Hash = uint256S("0x21b8b97dcdb94caa67c7f8f6dbf22e61e0cfe0e46e1fff3528b22864659e9b38");
-        consensus.BIP65Height = 1854705;                                                                     // 955bd496d23790aba1ecfacb722b089a6ae7ddabaedf7d8fb0878f48308a71f9
-        consensus.BIP66Height = 708658;                                                                      // 21b8b97dcdb94caa67c7f8f6dbf22e61e0cfe0e46e1fff3528b22864659e9b38 - this is the last block that could be v2, 1900 blocks past the last v2 block
+        // The same Dogecoin inheritance mainnet carried, from Dogecoin TESTNET this
+        // time. Mirrored to the mainnet values, consistent with the lw7 posture
+        // elsewhere in this file: testnet3 is retired and exists to rehearse
+        // mainnet, so it must not validate under looser rules than the network it
+        // rehearses. See bead zz2f.
+        consensus.BIP34Height = 100;
+        consensus.BIP34Hash = uint256();
+        consensus.BIP65Height = 0;
+        consensus.BIP66Height = 0;
         consensus.powLimit = uint256S("0x00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~uint256(0) >> 20;
         consensus.nPowTargetTimespan = 4 * 60 * 60;                                                          // pre-digishield: 4 hours
         consensus.nPowTargetSpacing = 60;                                                                    // 1 minute

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -903,6 +903,21 @@ public:
         consensus.vDeployments[d].nTimeout = nTimeout;
     }
 
+    void UpdateActivationHeight(Consensus::DeploymentPos d, int nActivationHeight)
+    {
+        // ⚠️ ALL THREE, not just `consensus`. Regtest assembles a height-indexed
+        // tree (consensus < 10, digishieldConsensus < 20, auxpowConsensus >= 20)
+        // and GetConsensus(nHeight) returns whichever covers that height. The
+        // deployment fields are set BEFORE the copies in the constructor, so they
+        // agree at startup — but a mutation applied to `consensus` alone is
+        // invisible to every block above height 19, which is every block a chain
+        // fixture actually mines. Setting one struct here would look like it
+        // worked and change nothing.
+        consensus.vDeployments[d].nActivationHeight = nActivationHeight;
+        digishieldConsensus.vDeployments[d].nActivationHeight = nActivationHeight;
+        auxpowConsensus.vDeployments[d].nActivationHeight = nActivationHeight;
+    }
+
     void UpdateMaxReorgDepth(int nMaxReorgDepth)
     {
         consensus.nMaxReorgDepth = nMaxReorgDepth;
@@ -1270,6 +1285,11 @@ void SelectParams(const std::string& network)
 void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout)
 {
     regTestParams.UpdateBIP9Parameters(d, nStartTime, nTimeout);
+}
+
+void UpdateRegtestActivationHeight(Consensus::DeploymentPos d, int nActivationHeight)
+{
+    regTestParams.UpdateActivationHeight(d, nActivationHeight);
 }
 
 void UpdateRegtestMaxReorgDepth(int nMaxReorgDepth)

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -129,6 +129,23 @@ void SelectParams(const std::string& chain);
 void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout);
 
 /**
+ * Allows overriding a regtest deployment's flag-day activation height.
+ *
+ * ⚠️ UpdateRegtestBIP9Parameters above is a NO-OP for any deployment that has an
+ * nActivationHeight set: DeploymentActiveAtHeight() consults nActivationHeight
+ * ONLY, and never nStartTime/nTimeout (consensus/params.h, bead p96 Option D).
+ * Every Soqucoin deployment is height-gated, so the BIP9 lever cannot activate
+ * any of them — which left the SoquObscura-gated reject paths untestable, and
+ * therefore untested. That is precisely the gap that let SOQ-ARCH-004 sit dead
+ * through a 597/597 green suite (beads don9, n1vf, r0vn).
+ *
+ * Regtest only, and it mutates the regtest singleton, so a test that flips a
+ * deployment MUST restore the previous value (BIP9Deployment::NOT_SCHEDULED for
+ * a dormant one) before it returns.
+ */
+void UpdateRegtestActivationHeight(Consensus::DeploymentPos d, int nActivationHeight);
+
+/**
  * Allows overriding the regtest finality horizon (Consensus::nMaxReorgDepth)
  * for functional tests. Regtest only.
  */

--- a/src/test/btcsoq_lifecycle_harness_tests.cpp
+++ b/src/test/btcsoq_lifecycle_harness_tests.cpp
@@ -32,7 +32,9 @@
 #include "uint256.h"
 #include "validation.h"
 #include "crypto/sha256.h"
+#include "coins.h"
 #include "test/test_bitcoin.h"
+#include "test/testutil.h"   // ScopedRegtestActivation
 
 extern "C" {
 #include "crypto/dilithium/api.h"
@@ -79,6 +81,13 @@ static CScript MakeV8Spk(const std::vector<unsigned char>& rawPubkey)
 {
     uint256 h; CSHA256().Write(rawPubkey.data(), rawPubkey.size()).Finalize(h.begin());
     CScript s; s << OP_8 << std::vector<unsigned char>(h.begin(), h.end());
+    return s;
+}
+
+// Confidential v4 — the "exotic input" a BTCSOQ transfer must refuse.
+static CScript MakeV4Spk()
+{
+    CScript s; s << OP_4 << std::vector<unsigned char>(32, 0x11);
     return s;
 }
 
@@ -152,6 +161,20 @@ struct BTCSOQChainSetup : public TestingSetup {
 
     CBlock CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns, const CScript& spk)
     {
+        CBlock block = BuildSolvedBlock(txns, spk);
+        std::shared_ptr<const CBlock> shared = std::make_shared<const CBlock>(block);
+        bool fNewBlock = false;
+        ProcessNewBlock(Params(), shared, true, &fNewBlock);
+        return block;
+    }
+
+    // Solve a block WITHOUT connecting it, so a caller can run TestBlockValidity
+    // and read the reject reason. ProcessNewBlock only returns a bool, so a test
+    // built on CreateAndProcessBlock can assert that the tip did not move but not
+    // WHY — and "the tip did not move" passes for the wrong reject exactly as
+    // happily as for the right one. Bead r0vn requires the exact string.
+    CBlock BuildSolvedBlock(const std::vector<CMutableTransaction>& txns, const CScript& spk)
+    {
         const CChainParams& cp = Params();
         std::unique_ptr<CBlockTemplate> tmpl = BlockAssembler(cp).CreateNewBlock(spk, true);
         BOOST_REQUIRE(tmpl != nullptr);
@@ -176,10 +199,46 @@ struct BTCSOQChainSetup : public TestingSetup {
         IncrementExtraNonce(&block, chainActive.Tip(), extraNonce);
         while (!CheckProofOfWork(block.GetPoWHash(), block.nBits, cp.GetConsensus(0)))
             ++block.nNonce;
-        std::shared_ptr<const CBlock> shared = std::make_shared<const CBlock>(block);
-        bool fNewBlock = false;
-        ProcessNewBlock(cp, shared, true, &fNewBlock);
         return block;
+    }
+
+    // Drive a block through the full ConnectBlock path and return the reject
+    // reason, or "" if it validated.
+    std::string RejectReasonFor(const std::vector<CMutableTransaction>& txns)
+    {
+        CBlock B = BuildSolvedBlock(txns, coinbaseSpk);
+        CValidationState st;
+        bool ok;
+        {
+            LOCK(cs_main);
+            ok = TestBlockValidity(st, Params(), B, chainActive.Tip(), true, true);
+        }
+        if (ok) return std::string();
+        BOOST_TEST_MESSAGE("reject: " << st.GetRejectReason()
+            << (st.GetDebugMessage().empty() ? "" : " | " + st.GetDebugMessage()));
+        return st.GetRejectReason();
+    }
+
+    // Drop a mature, spendable coin of an arbitrary witness version straight into
+    // the UTXO set. Modifies pcoinsTip directly: an intermediate CCoinsViewCache
+    // would flush its unset hashBlock over the tip's and trip ConnectBlock's
+    // assertion.
+    COutPoint SeedCoin(const CScript& spk, CAmount value, uint8_t tag)
+    {
+        uint256 txid;
+        txid.begin()[0] = tag;
+        {
+            LOCK(cs_main);
+            CCoinsModifier c = pcoinsTip->ModifyCoins(txid);
+            c->Clear();
+            c->fCoinBase = false;
+            c->nHeight   = 1;
+            c->nVersion  = 2;
+            c->vout.resize(1);
+            c->vout[0].nValue       = value;
+            c->vout[0].scriptPubKey = spk;
+        }
+        return COutPoint(txid, 0);
     }
 
     // Sign a v1 Dilithium input (coinbase / v8 holding) with a CKey.
@@ -396,6 +455,112 @@ BOOST_AUTO_TEST_CASE(double_mint_rejected)
         LOCK(cs_main);
         BOOST_CHECK_EQUAL(g_btcsoq_supply.TotalMinted(), MINT_SATS);  // only the first mint counted
     }
+}
+
+// ===========================================================================
+// REJECT-PATH COVERAGE (beads n1vf, r0vn).
+//
+// The three rejects below are REACHABLE — unlike the USDSOQ pair, nothing about
+// them was dead — and until now none of these strings appeared anywhere under
+// src/test/ or qa/. Reachable and unexercised is not a lesser state than dead:
+// it is the state a dead rule is indistinguishable from, which is the whole
+// point of the r0vn criterion. Each drives a failing input through ConnectBlock
+// and asserts the exact string.
+// ===========================================================================
+
+// A non-authority tx cannot conjure BTCSOQ. v8 out > v8 in = 0, so the per-asset
+// conservation rule must reject it. This is the BTCSOQ mirror of
+// usdsoq_v7_conservation_harness_tests::v7_minted_from_soq_is_rejected, and the
+// property is load-bearing: without it, any miner could emit a v8 output from
+// ordinary SOQ and create Bitcoin-backed supply with no deposit behind it.
+BOOST_AUTO_TEST_CASE(connectblock_rejects_btcsoq_minted_from_soq)
+{
+    const CTransaction& cb = coinbaseTxns[0];
+    const CAmount fund = cb.vout[0].nValue;
+
+    CMutableTransaction tx; tx.nVersion = 2;
+    CTxIn in; in.prevout = COutPoint(cb.GetHash(), 0); in.nSequence = CTxIn::SEQUENCE_FINAL;
+    tx.vin.push_back(in);
+    tx.vout.push_back(CTxOut(MINT_SATS, MakeV8Spk(coinbasePk)));         // v8 from nothing
+    tx.vout.push_back(CTxOut(fund - MINT_SATS - 10000, coinbaseSpk));    // SOQ change
+    SignV1(tx, 0, coinbaseSpk, fund, coinbaseKey, coinbasePk);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({tx}), "bad-txns-btcsoq-not-conserved");
+}
+
+// Input-type isolation: a BTCSOQ transfer may spend v8 inputs (the asset) and
+// transparent native-SOQ inputs (the fee), nothing else. Here the tx CONSERVES
+// v8 exactly, so conservation cannot be what rejects it, and the only thing
+// wrong is the v7 USDSOQ input mixed in. Keeping the two assets from meeting in
+// one transfer is what stops cross-asset accounting from ever being needed.
+BOOST_AUTO_TEST_CASE(connectblock_rejects_exotic_input_in_btcsoq_transfer)
+{
+    const CAmount v8Val = MINT_SATS;
+    COutPoint v8op = SeedCoin(MakeV8Spk(coinbasePk), v8Val, 0xb8);
+    // A CONFIDENTIAL v4 input is the exotic one to use here. A v7 USDSOQ input
+    // would trip the USDSOQ conservation rule first (v7 in, no v7 out) and the
+    // test would pin the wrong string — it did exactly that on the first run.
+    // v4 is native SOQ by asset, so it is invisible to both conservation rules,
+    // and the only thing it violates is the transparency half of the isolation
+    // predicate.
+    COutPoint v4op = SeedCoin(MakeV4Spk(), MINT_SATS, 0xb4);
+
+    CMutableTransaction tx; tx.nVersion = 2;
+    { CTxIn i0; i0.prevout = v8op; i0.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(i0); }
+    { CTxIn i1; i1.prevout = v4op; i1.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(i1); }
+    tx.vout.push_back(CTxOut(v8Val, MakeV8Spk(coinbasePk)));   // v8 in == v8 out
+    SignV1(tx, 0, MakeV8Spk(coinbasePk), v8Val, coinbaseKey, coinbasePk);
+    // The v4 input still needs a witness ending in an ML-DSA pubkey, or
+    // CheckTransaction's bad-txns-requires-dilithium fires before we ever reach
+    // the isolation rule. The v4 program itself is anyone-can-spend while
+    // SoquObscura is dormant, so the signature is not what is being tested.
+    SignV1(tx, 1, MakeV4Spk(), MINT_SATS, coinbaseKey, coinbasePk);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({tx}), "bad-txns-btcsoq-input-mismatch");
+}
+
+// Authority operations must be fully transparent: the mint/burn boundary is
+// where supply is auditable, and a hidden amount there breaks the invariant
+// outright (GENIUS Act 4(a)(2)).
+//
+// SoquObscura has to be ACTIVE for this to be the rule that fires. While it is
+// dormant, SOQ-ARCH-001 rejects every confidential output block-wide, earlier in
+// the same ConnectBlock, and would shadow this. That ordering is itself worth
+// pinning: the assertion below is what tells us which of the two is doing the
+// work at any given time.
+BOOST_AUTO_TEST_CASE(connectblock_rejects_confidential_output_in_btcsoq_authority_tx)
+{
+    ScopedRegtestActivation on(Consensus::DEPLOYMENT_SOQUOBSCURA, 0);
+
+    uint256 depositTxid = uint256S("bccc00000000000000000000000000000000000000000000000000000000dc04");
+    CMutableTransaction mint = BuildMint(coinbaseTxns[1], depositTxid, 0, coinbasePk);
+
+    // Add a confidential v4 output funded from the SOQ change, then re-sign:
+    // the authority sighash covers the outputs, so an unsigned edit would be
+    // caught as a bad signature and prove nothing about the transparency rule.
+    CScript v4spk = CScript() << OP_4 << std::vector<unsigned char>(32, 0x11);
+    BOOST_REQUIRE_EQUAL(v4spk.size(), 34u);
+    CTxOut& change = mint.vout.back();
+    BOOST_REQUIRE(change.nValue > MINT_SATS);
+    change.nValue -= MINT_SATS;
+    mint.vout.push_back(CTxOut(MINT_SATS, v4spk));
+    SignAuthority(mint, 0, BTCSOQ_OP_MINT);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({mint}), "bad-btcsoq-authority-must-be-transparent");
+}
+
+// Reachability control for the case above: the SAME mint without the
+// confidential output must connect, so the rejection is the transparency rule
+// and not an artefact of the edit.
+BOOST_AUTO_TEST_CASE(transparent_btcsoq_authority_mint_is_accepted)
+{
+    ScopedRegtestActivation on(Consensus::DEPLOYMENT_SOQUOBSCURA, 0);
+
+    uint256 depositTxid = uint256S("bccc00000000000000000000000000000000000000000000000000000000dc05");
+    CMutableTransaction mint = BuildMint(coinbaseTxns[2], depositTxid, 0, coinbasePk);
+
+    BOOST_CHECK_MESSAGE(RejectReasonFor({mint}).empty(),
+        "the identical authority mint without a confidential output must connect");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/genesis_chainparams_tests.cpp
+++ b/src/test/genesis_chainparams_tests.cpp
@@ -475,4 +475,71 @@ BOOST_AUTO_TEST_CASE(f8_feature_deployments_do_not_share_version_bits)
     SelectParams(CBaseChainParams::MAIN);
 }
 
+// ============================================================================
+// F8 (bead zz2f): BIP34/65/66 heights must be OURS, not Dogecoin's.
+//
+// Mainnet shipped Dogecoin's mainnet heights verbatim (1034383 / 3464751 /
+// 1034383) and testnet shipped Dogecoin's testnet heights. On a chain that
+// starts at height 0 those are not history, they are activation heights, and
+// the BIP65 one meant SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY stayed off for about
+// 6.6 years — OP_CLTV a NOP, so any timelock branch was unenforceable the
+// moment a CLTV-carrying deployment activated.
+//
+// The tell was that stagenet, the mainnet REHEARSAL network, already used
+// 0/0/100, so the rehearsal validated under stricter rules than the thing it
+// rehearses. This test pins all four networks together for exactly that reason:
+// the defect was divergence, so the assertion has to be about agreement.
+// ============================================================================
+BOOST_AUTO_TEST_CASE(f8_bip_activation_heights_are_soqucoin_not_dogecoin)
+{
+    // Dogecoin's values, named so a regression is unmistakable rather than
+    // looking like an arbitrary number changed.
+    const int kDogeMainBIP34 = 1034383, kDogeMainBIP65 = 3464751;
+    const int kDogeTestBIP34 = 708658,  kDogeTestBIP65 = 1854705;
+
+    for (const std::string& net : {CBaseChainParams::MAIN, CBaseChainParams::TESTNET,
+                                   CBaseChainParams::STAGENET}) {
+        SelectParams(net);
+        const Consensus::Params& c = Params().GetConsensus(0);
+
+        BOOST_CHECK_MESSAGE(c.BIP65Height == 0,
+            net + ": BIP65Height must be 0 so OP_CHECKLOCKTIMEVERIFY is enforced from "
+            "genesis. A nonzero value makes CLTV a NOP until that height, and any "
+            "HTLC or vault timeout branch created before then is unenforceable.");
+        BOOST_CHECK_MESSAGE(c.BIP66Height == 0, net + ": BIP66Height must be 0");
+
+        // > 16 so the coinbase height cannot fall in the range where OP_N and a
+        // 1-byte data push are both defensible encodings; >= 1 so genesis, which
+        // has no height push and does reach ContextualCheckBlock on -reindex,
+        // stays outside the rule.
+        BOOST_CHECK_MESSAGE(c.BIP34Height > 16,
+            net + ": BIP34Height must exceed 16 (OP_N vs push-byte coinbase encoding)");
+
+        BOOST_CHECK_MESSAGE(c.BIP34Height != kDogeMainBIP34 && c.BIP34Height != kDogeTestBIP34,
+            net + ": BIP34Height is a Dogecoin height");
+        BOOST_CHECK_MESSAGE(c.BIP65Height != kDogeMainBIP65 && c.BIP65Height != kDogeTestBIP65,
+            net + ": BIP65Height is a Dogecoin height");
+
+        // BIP34Hash is the hash of the block AT BIP34Height and cannot be known
+        // before launch. Null keeps the BIP30 duplicate-txid scan enforced by
+        // lookup forever, which is strictly more checking; a stale inherited hash
+        // had the same effect while also being false.
+        BOOST_CHECK_MESSAGE(c.BIP34Hash.IsNull(),
+            net + ": BIP34Hash must be null until a real post-launch value is known");
+    }
+
+    // Mainnet and its rehearsal network must agree, since disagreement is what
+    // made every stagenet soak result carry an assumption mainnet did not honour.
+    SelectParams(CBaseChainParams::MAIN);
+    const Consensus::Params& m = Params().GetConsensus(0);
+    const int mainBIP34 = m.BIP34Height, mainBIP65 = m.BIP65Height, mainBIP66 = m.BIP66Height;
+    SelectParams(CBaseChainParams::STAGENET);
+    const Consensus::Params& sg = Params().GetConsensus(0);
+    BOOST_CHECK_EQUAL(mainBIP34, sg.BIP34Height);
+    BOOST_CHECK_EQUAL(mainBIP65, sg.BIP65Height);
+    BOOST_CHECK_EQUAL(mainBIP66, sg.BIP66Height);
+
+    SelectParams(CBaseChainParams::MAIN);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/genesis_chainparams_tests.cpp
+++ b/src/test/genesis_chainparams_tests.cpp
@@ -18,6 +18,9 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <map>
+#include <string>
+
 BOOST_FIXTURE_TEST_SUITE(genesis_chainparams_tests, BasicTestingSetup)
 
 // ============================================================================
@@ -292,6 +295,10 @@ static const Consensus::DeploymentPos P96_FLAGDAY_DEPLOYMENTS[] = {
     Consensus::DEPLOYMENT_UTXO_COST,
     Consensus::DEPLOYMENT_DILITHIUM_KEYHASH,
     Consensus::DEPLOYMENT_V6_CONTROLFLOW,
+    // BTCSOQ is height-gated exactly like the rest (mainnet NOT_SCHEDULED,
+    // test networks 0) and was simply missing from this list, so the mainnet
+    // dormancy assertion below did not cover the Bitcoin-backed asset.
+    Consensus::DEPLOYMENT_BTCSOQ,
 };
 
 BOOST_AUTO_TEST_CASE(p96_deployment_active_predicate)
@@ -362,6 +369,110 @@ BOOST_AUTO_TEST_CASE(p96_testnets_active_from_genesis)
         }
     }
     SelectParams(CBaseChainParams::MAIN);  // restore default for later tests
+}
+
+// ============================================================================
+// F8 (bead v7xm): the activation posture must hold at EVERY height, not just 0.
+//
+// The two tests above read GetConsensus(0), which returns the BASE consensus
+// struct. That is not the struct most blocks are validated against. Every
+// network assembles a height-indexed tree of Consensus::Params
+// (consensus / digishieldConsensus / auxpowConsensus) and GetConsensus(nHeight)
+// returns whichever tier covers that height — on regtest the cutovers are 10 and
+// 20, on stagenet 1 and 100. The constructors copy the base struct AFTER setting
+// the deployment fields, so the tiers agree today; nothing enforces that they
+// keep agreeing, and a per-tier divergence would mean a deployment that is
+// dormant at genesis and live at height 20, or the reverse.
+//
+// This is not hypothetical. A regtest activation lever added on 2026-08-20
+// initially wrote only the base struct and was silently inert for every block a
+// chain fixture mines. The same shape sits in UpdateMaxReorgDepth, which writes
+// consensus and digishieldConsensus but not auxpowConsensus (bead tofg).
+// ============================================================================
+BOOST_AUTO_TEST_CASE(f8_deployment_posture_is_uniform_across_consensus_tiers)
+{
+    // Heights chosen to straddle every tier cutover on every network.
+    const int kProbeHeights[] = {0, 1, 2, 9, 10, 11, 19, 20, 21, 99, 100, 101, 1000, 1000000};
+
+    for (const std::string& net : {CBaseChainParams::MAIN, CBaseChainParams::TESTNET,
+                                   CBaseChainParams::REGTEST, CBaseChainParams::STAGENET}) {
+        SelectParams(net);
+        for (int pos = 0; pos < Consensus::MAX_VERSION_BITS_DEPLOYMENTS; pos++) {
+            const auto d = static_cast<Consensus::DeploymentPos>(pos);
+            const Consensus::BIP9Deployment& base = Params().GetConsensus(0).vDeployments[d];
+            for (int h : kProbeHeights) {
+                const Consensus::BIP9Deployment& tier = Params().GetConsensus(h).vDeployments[d];
+                BOOST_CHECK_MESSAGE(tier.nActivationHeight == base.nActivationHeight,
+                    net + ": deployment " + std::to_string(pos) + " has nActivationHeight " +
+                    std::to_string(tier.nActivationHeight) + " at height " + std::to_string(h) +
+                    " but " + std::to_string(base.nActivationHeight) + " in the base struct — "
+                    "the consensus tiers have diverged");
+                BOOST_CHECK_MESSAGE(tier.bit == base.bit,
+                    net + ": deployment " + std::to_string(pos) + " changes version bit across tiers");
+                BOOST_CHECK_MESSAGE(tier.nStartTime == base.nStartTime &&
+                                    tier.nTimeout == base.nTimeout,
+                    net + ": deployment " + std::to_string(pos) + " changes its BIP9 window across tiers");
+            }
+        }
+    }
+    SelectParams(CBaseChainParams::MAIN);
+}
+
+// A height-gated deployment ignores nStartTime/nTimeout entirely, so a
+// deployment carrying BOTH an nActivationHeight and a real BIP9 window is a
+// statement of intent the code will not honour. Reject the combination outright
+// rather than trusting anyone to remember the rule. The inert values (0/0 for
+// "never" and ALWAYS_ACTIVE/NO_TIMEOUT for the pre-flag-day form) are allowed
+// because they are what the existing configs use to mean "the BIP9 fields are
+// not the mechanism here".
+BOOST_AUTO_TEST_CASE(f8_no_deployment_relies_on_a_bip9_window_it_cannot_use)
+{
+    for (const std::string& net : {CBaseChainParams::MAIN, CBaseChainParams::TESTNET,
+                                   CBaseChainParams::REGTEST, CBaseChainParams::STAGENET}) {
+        SelectParams(net);
+        const Consensus::Params& c = Params().GetConsensus(0);
+        for (int pos = 0; pos < Consensus::MAX_VERSION_BITS_DEPLOYMENTS; pos++) {
+            const Consensus::BIP9Deployment& d = c.vDeployments[static_cast<Consensus::DeploymentPos>(pos)];
+            if (d.nActivationHeight == Consensus::BIP9Deployment::NO_HEIGHT_ACTIVATION) continue;
+
+            const bool inertWindow =
+                (d.nStartTime == 0 && d.nTimeout == 0) ||
+                (d.nStartTime == Consensus::BIP9Deployment::ALWAYS_ACTIVE &&
+                 d.nTimeout == Consensus::BIP9Deployment::NO_TIMEOUT);
+            BOOST_CHECK_MESSAGE(inertWindow,
+                net + ": deployment " + std::to_string(pos) + " is height-gated (nActivationHeight=" +
+                std::to_string(d.nActivationHeight) + ") yet carries a live BIP9 window. "
+                "DeploymentActiveAtHeight never reads nStartTime/nTimeout, so that window is a no-op "
+                "and whoever set it believed something false about how this deployment activates.");
+        }
+    }
+    SelectParams(CBaseChainParams::MAIN);
+}
+
+// Two deployments sharing a version bit means signalling for one is signalling
+// for the other. Harmless while both are inert; a chain split if either is ever
+// scheduled. TESTDUMMY is excluded because it is a test fixture rather than a
+// feature, and it currently collides with LATTICEFOLD on bit 28 (bead nv7q) —
+// excluding it here keeps this test honest about FEATURE bits without encoding
+// that known overlap as acceptable.
+BOOST_AUTO_TEST_CASE(f8_feature_deployments_do_not_share_version_bits)
+{
+    for (const std::string& net : {CBaseChainParams::MAIN, CBaseChainParams::TESTNET,
+                                   CBaseChainParams::REGTEST, CBaseChainParams::STAGENET}) {
+        SelectParams(net);
+        const Consensus::Params& c = Params().GetConsensus(0);
+        std::map<int, int> bitOwner;   // bit -> deployment index
+        for (int pos = 0; pos < Consensus::MAX_VERSION_BITS_DEPLOYMENTS; pos++) {
+            if (pos == Consensus::DEPLOYMENT_TESTDUMMY) continue;
+            const int bit = c.vDeployments[static_cast<Consensus::DeploymentPos>(pos)].bit;
+            auto it = bitOwner.find(bit);
+            BOOST_CHECK_MESSAGE(it == bitOwner.end(),
+                net + ": deployments " + std::to_string(it == bitOwner.end() ? -1 : it->second) +
+                " and " + std::to_string(pos) + " both claim version bit " + std::to_string(bit));
+            bitOwner[bit] = pos;
+        }
+    }
+    SelectParams(CBaseChainParams::MAIN);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/testutil.h
+++ b/src/test/testutil.h
@@ -8,8 +8,44 @@
 #ifndef BITCOIN_TEST_TESTUTIL_H
 #define BITCOIN_TEST_TESTUTIL_H
 
+#include "chainparams.h"
+#include "consensus/params.h"
 #include "fs.h"
 
 fs::path GetTempPath();
+
+/**
+ * Turn a height-gated regtest deployment on for the duration of a scope, and
+ * restore whatever was there on the way out.
+ *
+ * Needed because UpdateRegtestBIP9Parameters cannot activate any Soqucoin
+ * deployment: it writes nStartTime/nTimeout, and DeploymentActiveAtHeight reads
+ * nActivationHeight and nothing else (flag-day activation, bead p96 Option D).
+ * Without a lever, every SCRIPT_VERIFY_SOQUOBSCURA-gated reject path was
+ * unreachable from the suite, which is a large part of why two of them sat dead
+ * through a fully green run (beads don9, n1vf, r0vn).
+ *
+ * Restores the value that was actually present rather than assuming
+ * NOT_SCHEDULED, so a leak in one test cannot silently arm another. The regtest
+ * params are a process-wide singleton, so scope discipline here is load-bearing.
+ */
+class ScopedRegtestActivation
+{
+public:
+    ScopedRegtestActivation(Consensus::DeploymentPos pos, int nActivationHeight)
+        : m_pos(pos),
+          m_saved(Params().GetConsensus(0).vDeployments[pos].nActivationHeight)
+    {
+        UpdateRegtestActivationHeight(m_pos, nActivationHeight);
+    }
+    ~ScopedRegtestActivation() { UpdateRegtestActivationHeight(m_pos, m_saved); }
+
+    ScopedRegtestActivation(const ScopedRegtestActivation&) = delete;
+    ScopedRegtestActivation& operator=(const ScopedRegtestActivation&) = delete;
+
+private:
+    Consensus::DeploymentPos m_pos;
+    int m_saved;
+};
 
 #endif // BITCOIN_TEST_TESTUTIL_H

--- a/src/test/usdsoq_v10_reject_path_tests.cpp
+++ b/src/test/usdsoq_v10_reject_path_tests.cpp
@@ -396,19 +396,95 @@ BOOST_AUTO_TEST_CASE(preactivation_v10_output_is_rejected_by_soq_arch_001_not_th
     BOOST_REQUIRE(!Consensus::DeploymentActiveAtHeight(h, Params().GetConsensus(h),
                                                        Consensus::DEPLOYMENT_SOQUOBSCURA));
 
+    // The v10 output is funded by a v7 USDSOQ input of the SAME value, so per-asset
+    // conservation is satisfied. That matters: conservation lives in
+    // Consensus::CheckTxInputs, which runs in ConnectBlock's FIRST pass, strictly
+    // before SOQ-ARCH-001. Funding a v10 output from plain SOQ would trip
+    // bad-txns-usdsoq-not-conserved first and this test would pin the wrong rule.
+    const CAmount val = 5 * COIN;
+    COutPoint v7op = SeedCoin(V7Spk(), val, 0xb7);
+
     CMutableTransaction tx; tx.nVersion = 2;
-    const CTransaction& cb = coinbaseTxns[5];
-    const CAmount inVal = cb.vout[0].nValue;
-    CTxIn in; in.prevout = COutPoint(cb.GetHash(), 0); in.nSequence = CTxIn::SEQUENCE_FINAL;
+    CTxIn in; in.prevout = v7op; in.nSequence = CTxIn::SEQUENCE_FINAL;
     tx.vin.push_back(in);
-    CTxOut o; o.nValue = inVal - 10000; o.scriptPubKey = V10Spk(); tx.vout.push_back(o);
-    SignInput(tx, 0, coinbaseSpk, inVal);
+    CTxOut o; o.nValue = val; o.scriptPubKey = V10Spk(); tx.vout.push_back(o);
+    SignInput(tx, 0, V7Spk(), val);
 
     const std::string why = RejectReasonFor({tx});
     BOOST_CHECK_EQUAL(why, "bad-txns-confidential-not-active");
     BOOST_CHECK_MESSAGE(why != "bad-txns-usdsoq-confidential-not-active",
         "if the asset-specific rule starts firing, SOQ-ARCH-001 has been narrowed and "
         "the Tier A pre-activation posture must be re-derived, not assumed");
+}
+
+// ---------------------------------------------------------------------------
+// PER-ASSET CONSERVATION MUST SEE BOTH USDSOQ MODES.
+// The mirror of usdsoq_v7_conservation_harness_tests::v7_minted_from_soq_is_rejected,
+// for v10. With the conservation predicate v7-only, a v10 output was invisible to
+// this rule AND to the IsNativeSOQ() fee filters, so a tx emitting one from plain
+// SOQ inputs both minted confidential USDSOQ from nothing and pushed the same value
+// into nFees for the miner to claim. Unreachable pre-activation, which is why it
+// could sit here; catastrophic the moment SoquObscura activates.
+//
+// Note the rule is deliberately NOT deployment-gated, so it fires in the dormant
+// state too — that is what makes the v10 shape reserved from genesis rather than
+// something a later soft fork has to add.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(v10_minted_from_soq_is_rejected)
+{
+    CMutableTransaction tx; tx.nVersion = 2;
+    const CTransaction& cb = coinbaseTxns[6];
+    const CAmount inVal = cb.vout[0].nValue;
+    CTxIn in; in.prevout = COutPoint(cb.GetHash(), 0); in.nSequence = CTxIn::SEQUENCE_FINAL;
+    tx.vin.push_back(in);
+    CTxOut o; o.nValue = inVal - 10000; o.scriptPubKey = V10Spk(); tx.vout.push_back(o);
+    SignInput(tx, 0, coinbaseSpk, inVal);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({tx}), "bad-txns-usdsoq-not-conserved");
+}
+
+// Same shape with SoquObscura ACTIVE: conservation is structural, not gated, so
+// activation must not open the mint path. This is the assertion that would have
+// caught the defect at activation time rather than after it.
+BOOST_AUTO_TEST_CASE(v10_minted_from_soq_is_rejected_after_activation_too)
+{
+    ScopedRegtestActivation on(Consensus::DEPLOYMENT_SOQUOBSCURA, 0);
+
+    CMutableTransaction tx; tx.nVersion = 2;
+    const CTransaction& cb = coinbaseTxns[7];
+    const CAmount inVal = cb.vout[0].nValue;
+    CTxIn in; in.prevout = COutPoint(cb.GetHash(), 0); in.nSequence = CTxIn::SEQUENCE_FINAL;
+    tx.vin.push_back(in);
+    CTxOut o; o.nValue = inVal - 10000; o.scriptPubKey = V10Spk(); tx.vout.push_back(o);
+    SignInput(tx, 0, coinbaseSpk, inVal);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({tx}), "bad-txns-usdsoq-not-conserved");
+}
+
+// Reachability control: a CONSERVING v10 transfer must still be accepted once the
+// privacy layer is active, so the rule above rejects minting rather than rejecting
+// v10 outright. Also pins that the widened input-isolation predicate lets a v10
+// input pay for its own transfer.
+BOOST_AUTO_TEST_CASE(conserving_v10_transfer_is_accepted_after_activation)
+{
+    ScopedRegtestActivation on(Consensus::DEPLOYMENT_SOQUOBSCURA, 0);
+
+    const CAmount val = 5 * COIN;
+    COutPoint v10op = SeedCoin(V10Spk(), val, 0xb1);
+    const CTransaction& cb = coinbaseTxns[8];
+    const CAmount feeVal = cb.vout[0].nValue;
+
+    CMutableTransaction tx; tx.nVersion = 2;
+    { CTxIn i0; i0.prevout = v10op; i0.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(i0); }
+    { CTxIn i1; i1.prevout = COutPoint(cb.GetHash(), 0); i1.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(i1); }
+    { CTxOut o; o.nValue = val;             o.scriptPubKey = V10Spk();  tx.vout.push_back(o); }
+    { CTxOut o; o.nValue = feeVal - 10000;  o.scriptPubKey = V1Spk();   tx.vout.push_back(o); }
+    SignInput(tx, 0, V10Spk(), val);
+    SignInput(tx, 1, coinbaseSpk, feeVal);
+
+    BOOST_CHECK_MESSAGE(RejectReasonFor({tx}).empty(),
+        "a conserving v10 -> v10 transfer with a SOQ fee input must connect once "
+        "SoquObscura is active");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/test/usdsoq_v10_reject_path_tests.cpp
+++ b/src/test/usdsoq_v10_reject_path_tests.cpp
@@ -1,0 +1,446 @@
+// Copyright (c) 2026 Soqucoin Labs Inc.
+// Distributed under the MIT software license.
+//
+// usdsoq_v10_reject_path_tests.cpp — reject-path coverage for witness v10
+// (confidential USDSOQ, SoquObscura Tier A), written against the Gate 0
+// acceptance criterion in bead r0vn:
+//
+//   A reject rule is NOT DONE until a test drives a FAILING INPUT through
+//   ConnectBlock and observes THAT EXACT REJECT STRING.
+//
+// Every rule exercised here was previously unreachable while the full suite ran
+// 597/597 green, which is the whole reason the criterion exists:
+//
+//   * bad-txns-usdsoq-authority-must-be-transparent (SOQ-ARCH-004, GENIUS Act
+//     §4(a)(2)) — the loop was gated on IsUSDSOQ() (v7) while every branch inside
+//     it tested IsConfidential(), and one scriptPubKey byte cannot be two
+//     opcodes. Empty set, so the rule could not fire (bead don9).
+//   * bad-txns-usdsoq-conf-input — the identical defect in the authority BURN
+//     input loop, left behind when the output loop was widened (bead n1vf).
+//   * bad-txns-usdsoq-confidential-not-active — reachable in principle but
+//     SHADOWED by SOQ-ARCH-001, which runs earlier in the same ConnectBlock on
+//     the same flags. Pinned below so the shadowing cannot change silently.
+//
+// Two things had to exist before any of this could be tested at all, and their
+// absence is why it never was:
+//
+//  1. A way to ACTIVATE a height-gated deployment on regtest.
+//     UpdateRegtestBIP9Parameters only writes nStartTime/nTimeout, which
+//     DeploymentActiveAtHeight never reads. SoquObscura ships NOT_SCHEDULED on
+//     all four networks, so every SCRIPT_VERIFY_SOQUOBSCURA-gated path was
+//     unreachable from any test. See UpdateRegtestActivationHeight.
+//  2. Reject-string observation. ProcessNewBlock returns a bool, so the existing
+//     harness can only assert "the tip did not move" — which passes for the
+//     WRONG reject just as happily as the right one. These tests solve the block
+//     first and run TestBlockValidity, which yields the CValidationState.
+//
+// Fixture shape (Dilithium v1 coinbase, 240 blocks, direct coins-view seeding)
+// follows usdsoq_v7_conservation_harness_tests.cpp.
+
+#include "chainparams.h"
+#include "consensus/params.h"
+#include "consensus/usdsoq.h"
+#include "consensus/validation.h"
+#include "key.h"
+#include "miner.h"
+#include "policy/policy.h"
+#include "pow.h"
+#include "primitives/transaction.h"
+#include "script/interpreter.h"
+#include "script/script.h"
+#include "script/standard.h"
+#include "coins.h"
+#include "txdb.h"
+#include "uint256.h"
+#include "validation.h"
+#include "crypto/sha256.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+
+namespace {
+
+static const int COINBASE_MATURITY_SOQ = 60 * 4;  // 240, regtest
+
+// OP_N <32-byte program> — the one shape every Soqucoin witness version uses.
+static CScript MakeVnSpk(opcodetype version, const std::vector<unsigned char>& rawPubkey)
+{
+    uint256 pkHash;
+    CSHA256().Write(rawPubkey.data(), rawPubkey.size()).Finalize(pkHash.begin());
+    CScript spk;
+    spk << version << std::vector<unsigned char>(pkHash.begin(), pkHash.end());
+    return spk;
+}
+
+static std::vector<unsigned char> Prefixed(const std::vector<unsigned char>& rawPubkey)
+{
+    std::vector<unsigned char> out;
+    out.reserve(rawPubkey.size() + 1);
+    out.push_back(0x00);
+    out.insert(out.end(), rawPubkey.begin(), rawPubkey.end());
+    return out;
+}
+
+// RAII: flip a height-gated regtest deployment on for the duration of a test and
+// put it back afterwards. Restores the value that was actually there rather than
+// assuming NOT_SCHEDULED, so a leak in one test cannot silently arm another.
+class ScopedRegtestActivation
+{
+public:
+    ScopedRegtestActivation(Consensus::DeploymentPos pos, int nActivationHeight)
+        : m_pos(pos),
+          m_saved(Params().GetConsensus(0).vDeployments[pos].nActivationHeight)
+    {
+        UpdateRegtestActivationHeight(m_pos, nActivationHeight);
+    }
+    ~ScopedRegtestActivation() { UpdateRegtestActivationHeight(m_pos, m_saved); }
+
+private:
+    Consensus::DeploymentPos m_pos;
+    int m_saved;
+};
+
+} // namespace
+
+struct V10RejectPathSetup : public TestingSetup {
+    CKey coinbaseKey;
+    CScript coinbaseSpk;
+    std::vector<unsigned char> coinbasePkBytes;
+    std::vector<CTransaction> coinbaseTxns;
+
+    V10RejectPathSetup() : TestingSetup(CBaseChainParams::REGTEST)
+    {
+        coinbaseKey.MakeNewKey(true);
+        CPubKey pk = coinbaseKey.GetPubKey();   // local first — never .GetPubKey().begin() inline
+        BOOST_REQUIRE(pk.IsValid());
+        coinbasePkBytes.assign(pk.begin(), pk.end());
+        BOOST_REQUIRE_EQUAL(coinbasePkBytes.size(), 1312u);
+        coinbaseSpk = V1Spk();
+        BOOST_REQUIRE_EQUAL(coinbaseSpk.size(), 34u);
+
+        for (int i = 0; i < COINBASE_MATURITY_SOQ; i++) {
+            CBlock b = CreateAndProcessBlock({}, coinbaseSpk);
+            BOOST_REQUIRE_MESSAGE(b.vtx.size() > 0, "block must have coinbase");
+            coinbaseTxns.push_back(*b.vtx[0]);
+        }
+    }
+
+    CScript V1Spk()  const { return MakeVnSpk(OP_1,  coinbasePkBytes); }  // native SOQ
+    CScript V5Spk()  const { return MakeVnSpk(OP_5,  coinbasePkBytes); }  // USDSOQ authority marker
+    CScript V7Spk()  const { return MakeVnSpk(OP_7,  coinbasePkBytes); }  // USDSOQ transparent
+    CScript V10Spk() const { return MakeVnSpk(OP_10, coinbasePkBytes); }  // USDSOQ confidential (Tier A)
+
+    // Solve a block and CONNECT it (used to build the coinbase chain).
+    CBlock CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns, const CScript& spk)
+    {
+        CBlock block = BuildSolvedBlock(txns, spk);
+        std::shared_ptr<const CBlock> shared = std::make_shared<const CBlock>(block);
+        bool fNewBlock = false;
+        ProcessNewBlock(Params(), shared, true, &fNewBlock);
+        return block;
+    }
+
+    // Solve a block on top of the tip WITHOUT connecting it, so the caller can run
+    // TestBlockValidity and read the reject reason out of CValidationState.
+    CBlock BuildSolvedBlock(const std::vector<CMutableTransaction>& txns, const CScript& spk)
+    {
+        const CChainParams& cp = Params();
+        std::unique_ptr<CBlockTemplate> tmpl = BlockAssembler(cp).CreateNewBlock(spk, true);
+        BOOST_REQUIRE_MESSAGE(tmpl != nullptr, "CreateNewBlock must not return nullptr");
+        CBlock& block = tmpl->block;
+        block.vtx.resize(1);
+        {
+            // Drop the witness commitment CreateNewBlock generated for the EMPTY
+            // template, then regenerate it over our actual vtx set.
+            CMutableTransaction coinbaseMut(*block.vtx[0]);
+            coinbaseMut.vout.erase(
+                std::remove_if(coinbaseMut.vout.begin(), coinbaseMut.vout.end(),
+                    [](const CTxOut& o) {
+                        return o.scriptPubKey.size() >= 38 &&
+                               o.scriptPubKey[0] == OP_RETURN && o.scriptPubKey[1] == 0x24 &&
+                               o.scriptPubKey[2] == 0xaa && o.scriptPubKey[3] == 0x21 &&
+                               o.scriptPubKey[4] == 0xa9 && o.scriptPubKey[5] == 0xed;
+                    }),
+                coinbaseMut.vout.end());
+            coinbaseMut.vin[0].scriptWitness.stack.clear();
+            block.vtx[0] = MakeTransactionRef(std::move(coinbaseMut));
+        }
+        for (const CMutableTransaction& tx : txns)
+            block.vtx.push_back(MakeTransactionRef(tx));
+        GenerateCoinbaseCommitment(block, chainActive.Tip(), cp.GetConsensus(0));
+        unsigned int extraNonce = 0;
+        IncrementExtraNonce(&block, chainActive.Tip(), extraNonce);
+        while (!CheckProofOfWork(block.GetPoWHash(), block.nBits, cp.GetConsensus(0)))
+            ++block.nNonce;
+        return block;
+    }
+
+    // Run a solved block through the full ConnectBlock path (fJustCheck) and return
+    // the reject reason, or "" if it validated. THE assertion primitive for r0vn:
+    // "tip did not move" cannot tell a correct reject from an accidental one.
+    std::string RejectReasonFor(const std::vector<CMutableTransaction>& txns)
+    {
+        CBlock B = BuildSolvedBlock(txns, coinbaseSpk);
+        CValidationState st;
+        bool ok;
+        {
+            LOCK(cs_main);
+            ok = TestBlockValidity(st, Params(), B, chainActive.Tip(), true, true);
+        }
+        if (ok) return std::string();
+        BOOST_TEST_MESSAGE("reject: " << st.GetRejectReason()
+            << (st.GetDebugMessage().empty() ? "" : " | " + st.GetDebugMessage()));
+        return st.GetRejectReason();
+    }
+
+    // Seed a mature, spendable coin of an arbitrary witness version straight into
+    // the UTXO set. Direct pcoinsTip modification (no intermediate CCoinsViewCache:
+    // an intermediate Flush() would overwrite pcoinsTip's hashBlock and trip
+    // ConnectBlock's assertion).
+    COutPoint SeedCoin(const CScript& spk, CAmount value, uint8_t tag)
+    {
+        uint256 txid;
+        txid.begin()[0] = tag;   // distinct txid per seeded coin
+        {
+            LOCK(cs_main);
+            CCoinsModifier c = pcoinsTip->ModifyCoins(txid);
+            c->Clear();
+            c->fCoinBase = false;
+            c->nHeight   = 1;    // mature, non-coinbase
+            c->nVersion  = 2;
+            c->vout.resize(1);
+            c->vout[0].nValue       = value;
+            c->vout[0].scriptPubKey = spk;
+        }
+        return COutPoint(txid, 0);
+    }
+
+    void SignInput(CMutableTransaction& tx, unsigned int idx, const CScript& scriptCode, CAmount amount)
+    {
+        CTransaction ctxForSign(tx);
+        uint256 sighash = SignatureHash(scriptCode, ctxForSign, idx, SIGHASH_ALL,
+                                        amount, SIGVERSION_WITNESS_V0, nullptr);
+        std::vector<unsigned char> sig;
+        BOOST_REQUIRE(coinbaseKey.Sign(sighash, sig));
+        sig.push_back((unsigned char)SIGHASH_ALL);
+        tx.vin[idx].scriptWitness.stack.clear();
+        tx.vin[idx].scriptWitness.stack.push_back(sig);
+        tx.vin[idx].scriptWitness.stack.push_back(Prefixed(coinbasePkBytes));
+    }
+
+    // An AUTHORITY tx (carries the OP_5 marker, so it is exempt from per-asset
+    // conservation and takes the SOQ-ARCH-004 authority branch). `assetIn` is an
+    // optional USDSOQ input to burn; `extraOut` an optional extra output.
+    // g_usdsoq_authority is never initialized in this fixture, so M-of-N signature
+    // verification is skipped and the marker alone confers authority status.
+    CMutableTransaction BuildAuthorityTx(const CTransaction& feeCoinbase,
+                                         const COutPoint* assetIn, CAmount assetInVal,
+                                         const CScript& assetInSpk,
+                                         const CTxOut* extraOut)
+    {
+        const CAmount feeVal = feeCoinbase.vout[0].nValue;
+        CMutableTransaction tx; tx.nVersion = 2;
+
+        unsigned int feeIdx = 0;
+        if (assetIn) {
+            CTxIn a; a.prevout = *assetIn; a.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(a);
+            feeIdx = 1;
+        }
+        CTxIn f; f.prevout = COutPoint(feeCoinbase.GetHash(), 0);
+        f.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(f);
+
+        CTxOut mark; mark.nValue = 10000; mark.scriptPubKey = V5Spk(); tx.vout.push_back(mark);
+        if (extraOut) tx.vout.push_back(*extraOut);
+        CTxOut chg; chg.nValue = feeVal - 20000 - (extraOut ? extraOut->nValue : 0);
+        chg.scriptPubKey = V1Spk(); tx.vout.push_back(chg);
+
+        if (assetIn) SignInput(tx, 0, assetInSpk, assetInVal);
+        SignInput(tx, feeIdx, coinbaseSpk, feeVal);
+        return tx;
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(usdsoq_v10_reject_path_tests, V10RejectPathSetup)
+
+// ---------------------------------------------------------------------------
+// GUARD ON THE TEST LEVER ITSELF. Everything below depends on being able to turn
+// SoquObscura on, and the obvious lever (UpdateRegtestBIP9Parameters) silently
+// does nothing for a height-gated deployment. If this ever regresses, the other
+// tests would go green by never reaching the rule they claim to exercise —
+// exactly the failure mode this file exists to close.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(regtest_activation_lever_actually_activates)
+{
+    const int h = chainActive.Height() + 1;
+    BOOST_REQUIRE_MESSAGE(
+        !Consensus::DeploymentActiveAtHeight(h, Params().GetConsensus(h),
+                                             Consensus::DEPLOYMENT_SOQUOBSCURA),
+        "SoquObscura must ship DORMANT on regtest (bead 2pru)");
+
+    // The BIP9 lever must be a no-op here — nStartTime/nTimeout are not consulted
+    // once nActivationHeight is set.
+    UpdateRegtestBIP9Parameters(Consensus::DEPLOYMENT_SOQUOBSCURA, 0, Consensus::BIP9Deployment::NO_TIMEOUT);
+    BOOST_CHECK_MESSAGE(
+        !Consensus::DeploymentActiveAtHeight(h, Params().GetConsensus(h),
+                                             Consensus::DEPLOYMENT_SOQUOBSCURA),
+        "UpdateRegtestBIP9Parameters must NOT activate a height-gated deployment "
+        "(if this fails, the F8 no-op footgun has been fixed and this test should "
+        "be updated rather than deleted)");
+    UpdateRegtestBIP9Parameters(Consensus::DEPLOYMENT_SOQUOBSCURA, 0, 0);
+
+    {
+        ScopedRegtestActivation on(Consensus::DEPLOYMENT_SOQUOBSCURA, 0);
+        BOOST_CHECK_MESSAGE(
+            Consensus::DeploymentActiveAtHeight(h, Params().GetConsensus(h),
+                                                Consensus::DEPLOYMENT_SOQUOBSCURA),
+            "the activation-height lever must reach the consensus struct that covers "
+            "height " + std::to_string(h) + " (regtest indexes three of them)");
+    }
+    BOOST_CHECK_MESSAGE(
+        !Consensus::DeploymentActiveAtHeight(h, Params().GetConsensus(h),
+                                             Consensus::DEPLOYMENT_SOQUOBSCURA),
+        "the guard must restore dormancy on scope exit");
+}
+
+// ---------------------------------------------------------------------------
+// don9 REMAINDER — SOQ-ARCH-004 / GENIUS Act §4(a)(2).
+// An authority transaction (mint/burn/freeze/rotate) that emits a CONFIDENTIAL
+// USDSOQ output must be rejected: supply auditability requires the mint/burn
+// boundary to be visible. Before witness v10 existed this rule could not fire at
+// all, and it was "true" only because the state was unconstructable.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(connectblock_rejects_confidential_usdsoq_authority_output)
+{
+    ScopedRegtestActivation on(Consensus::DEPLOYMENT_SOQUOBSCURA, 0);
+
+    CTxOut v10Out; v10Out.nValue = 1 * COIN; v10Out.scriptPubKey = V10Spk();
+    CMutableTransaction bad = BuildAuthorityTx(coinbaseTxns[0], nullptr, 0, CScript(), &v10Out);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({bad}), "bad-txns-usdsoq-authority-must-be-transparent");
+}
+
+// Reachability control for the case above: the SAME authority tx shape with a
+// TRANSPARENT v7 output must connect. Without this, a rejection for any unrelated
+// reason would read as the rule working.
+BOOST_AUTO_TEST_CASE(authority_tx_with_transparent_usdsoq_output_is_accepted)
+{
+    ScopedRegtestActivation on(Consensus::DEPLOYMENT_SOQUOBSCURA, 0);
+
+    CTxOut v7Out; v7Out.nValue = 1 * COIN; v7Out.scriptPubKey = V7Spk();
+    CMutableTransaction good = BuildAuthorityTx(coinbaseTxns[1], nullptr, 0, CScript(), &v7Out);
+
+    BOOST_CHECK_MESSAGE(RejectReasonFor({good}).empty(),
+        "an authority MINT to a transparent v7 output must connect — otherwise the "
+        "confidential-output rejection above proves nothing");
+}
+
+// ---------------------------------------------------------------------------
+// n1vf — bad-txns-usdsoq-conf-input.
+// An authority transaction that SPENDS a confidential USDSOQ input must be
+// rejected. nUSDSOQBurned is a plaintext sum read from the block undo, so a
+// hidden burn amount would desynchronise the supply counter from the chain.
+// This is the reject whose own error text says the state "should not exist";
+// what did not exist was the rule, because the enclosing guard was v7-only.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(connectblock_rejects_confidential_usdsoq_input_in_authority_tx)
+{
+    ScopedRegtestActivation on(Consensus::DEPLOYMENT_SOQUOBSCURA, 0);
+
+    const CAmount v10Val = 5 * COIN;
+    COutPoint v10op = SeedCoin(V10Spk(), v10Val, 0xa0);
+    CMutableTransaction burn = BuildAuthorityTx(coinbaseTxns[2], &v10op, v10Val, V10Spk(), nullptr);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({burn}), "bad-txns-usdsoq-conf-input");
+}
+
+// Reachability control: the identical authority burn of a TRANSPARENT v7 input
+// must connect, isolating the confidentiality of the input as the cause.
+BOOST_AUTO_TEST_CASE(authority_burn_of_transparent_usdsoq_input_is_accepted)
+{
+    ScopedRegtestActivation on(Consensus::DEPLOYMENT_SOQUOBSCURA, 0);
+
+    // A burn must be backed by real supply, so MINT first and CONNECT that block:
+    // TestBlockValidity runs with fJustCheck, which deliberately does not commit the
+    // supply delta (BUG-18), so a dry-run mint would leave the counter at zero and
+    // the burn would fail with bad-usdsoq-supply-underflow instead of the reason
+    // under test. Seeding the coin directly has the same problem — a seeded v7 coin
+    // is USDSOQ the supply counter never saw.
+    const CAmount v7Val = 5 * COIN;
+    CTxOut v7Out; v7Out.nValue = v7Val; v7Out.scriptPubKey = V7Spk();
+    CMutableTransaction mint = BuildAuthorityTx(coinbaseTxns[3], nullptr, 0, CScript(), &v7Out);
+    CBlock mintBlock = CreateAndProcessBlock({mint}, coinbaseSpk);
+    BOOST_REQUIRE_MESSAGE(chainActive.Tip()->GetBlockHash() == mintBlock.GetHash(),
+        "the authority mint block must connect before anything can be burned");
+
+    // BuildAuthorityTx lays out [0] = OP_5 marker, [1] = extra output, [2] = change.
+    COutPoint v7op(mint.GetHash(), 1);
+    CMutableTransaction burn = BuildAuthorityTx(coinbaseTxns[4], &v7op, v7Val, V7Spk(), nullptr);
+
+    BOOST_CHECK_MESSAGE(RejectReasonFor({burn}).empty(),
+        "an authority burn of a transparent v7 input must connect");
+}
+
+// ---------------------------------------------------------------------------
+// n1vf — THE SHADOWED RULE, PINNED.
+// bad-txns-usdsoq-confidential-not-active is unreachable: SOQ-ARCH-001 runs
+// earlier in the same ConnectBlock, on the same flags, and rejects EVERY
+// confidential output with bad-txns-confidential-not-active. This test does not
+// pretend the asset-specific rule fires; it records WHICH rule does, so the
+// shadowing relationship cannot change without a test changing with it.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(preactivation_v10_output_is_rejected_by_soq_arch_001_not_the_usdsoq_rule)
+{
+    // Deliberately NO ScopedRegtestActivation — this is the shipped dormant state.
+    const int h = chainActive.Height() + 1;
+    BOOST_REQUIRE(!Consensus::DeploymentActiveAtHeight(h, Params().GetConsensus(h),
+                                                       Consensus::DEPLOYMENT_SOQUOBSCURA));
+
+    CMutableTransaction tx; tx.nVersion = 2;
+    const CTransaction& cb = coinbaseTxns[5];
+    const CAmount inVal = cb.vout[0].nValue;
+    CTxIn in; in.prevout = COutPoint(cb.GetHash(), 0); in.nSequence = CTxIn::SEQUENCE_FINAL;
+    tx.vin.push_back(in);
+    CTxOut o; o.nValue = inVal - 10000; o.scriptPubKey = V10Spk(); tx.vout.push_back(o);
+    SignInput(tx, 0, coinbaseSpk, inVal);
+
+    const std::string why = RejectReasonFor({tx});
+    BOOST_CHECK_EQUAL(why, "bad-txns-confidential-not-active");
+    BOOST_CHECK_MESSAGE(why != "bad-txns-usdsoq-confidential-not-active",
+        "if the asset-specific rule starts firing, SOQ-ARCH-001 has been narrowed and "
+        "the Tier A pre-activation posture must be re-derived, not assumed");
+}
+
+// ---------------------------------------------------------------------------
+// DORMANCY, OUTPUT SIDE (r0vn definition-of-done #4, F3 class).
+// A witness version that consensus does not yet enforce must never be relayable:
+// such an output confirms and is then anyone-can-spend, which is fund loss, not
+// a soft failure. That was the live mainnet defect fixed for v5-v9 in
+// soqucoin#37. v10 carries the same exposure and must stay non-standard even
+// with every currently-allocated version switched on.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(v10_output_is_never_relay_standard)
+{
+    WitnessVersionMask everyAllocated = 0;
+    for (int v = 2; v <= 9; ++v) everyAllocated |= WitnessVersionBit(v);
+
+    txnouttype whichType = TX_NONSTANDARD;
+    BOOST_CHECK_MESSAGE(!::IsStandard(V10Spk(), whichType, true, everyAllocated),
+        "a v10 output must be non-standard even when v2-v9 are all active — v10 has "
+        "no deployment, so it is anyone-can-spend at the script layer");
+    // Two independent reasons hold it shut, and the test asserts both survive:
+    // the activeWitnessVersions gate in policy.cpp, and Solver having no
+    // classification for OP_10 <32> at all (TX_NONSTANDARD). Forcing the mask bit
+    // on isolates the second one.
+    BOOST_CHECK_MESSAGE(!::IsStandard(V10Spk(), whichType, true, everyAllocated | WitnessVersionBit(10)),
+        "v10 must still be non-standard with its mask bit forced on: Solver has no "
+        "TX_WITNESS_V10 form, so granting a deployment alone would NOT make it "
+        "relayable — the allocation has to be completed in Solver too");
+    // Solver leaves typeRet untouched when it returns false, so assert on Solver's
+    // return value rather than on whichType (which is only meaningful on true).
+    std::vector<std::vector<unsigned char> > vSolutions;
+    BOOST_CHECK_MESSAGE(!Solver(V10Spk(), whichType, vSolutions),
+        "Solver must have no template for OP_10 <32>");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/usdsoq_v10_reject_path_tests.cpp
+++ b/src/test/usdsoq_v10_reject_path_tests.cpp
@@ -55,6 +55,7 @@
 #include "validation.h"
 #include "crypto/sha256.h"
 #include "test/test_bitcoin.h"
+#include "test/testutil.h"   // ScopedRegtestActivation
 
 #include <boost/test/unit_test.hpp>
 #include <algorithm>
@@ -81,25 +82,6 @@ static std::vector<unsigned char> Prefixed(const std::vector<unsigned char>& raw
     out.insert(out.end(), rawPubkey.begin(), rawPubkey.end());
     return out;
 }
-
-// RAII: flip a height-gated regtest deployment on for the duration of a test and
-// put it back afterwards. Restores the value that was actually there rather than
-// assuming NOT_SCHEDULED, so a leak in one test cannot silently arm another.
-class ScopedRegtestActivation
-{
-public:
-    ScopedRegtestActivation(Consensus::DeploymentPos pos, int nActivationHeight)
-        : m_pos(pos),
-          m_saved(Params().GetConsensus(0).vDeployments[pos].nActivationHeight)
-    {
-        UpdateRegtestActivationHeight(m_pos, nActivationHeight);
-    }
-    ~ScopedRegtestActivation() { UpdateRegtestActivationHeight(m_pos, m_saved); }
-
-private:
-    Consensus::DeploymentPos m_pos;
-    int m_saved;
-};
 
 } // namespace
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2026,18 +2026,40 @@ bool CheckTxInputs(const CChainParams& params, const CTransaction& tx, CValidati
     // On mainnet (USDSOQ NEVER_ACTIVE): no USDSOQ UTXOs exist, so
     // nUSDSOQIn == nUSDSOQOut == 0, and this check always passes.
     if (!isAuthorityTx) {
+        // IsAnyUSDSOQ(), i.e. BOTH modes: transparent v7 and confidential v10.
+        //
+        // ⛔ WITH THE v7-ONLY PREDICATE, CONFIDENTIAL USDSOQ COULD BE CONJURED FROM
+        // ORDINARY SOQ. A v10 output was invisible to this rule (nUSDSOQOut stayed 0,
+        // so 0 == 0 conserved) AND invisible to the per-asset fee filters, which key
+        // on IsNativeSOQ() and correctly exclude it. The two blind spots compose: the
+        // tx minted USDSOQ from nothing and donated the same value to nFees for the
+        // miner to claim. This is exactly the hole Phase 3 closed for v7 (see
+        // usdsoq_v7_conservation_harness_tests::v7_minted_from_soq_is_rejected); it
+        // was simply never extended when v10 was allocated.
+        //
+        // Like the v7 and v8 rules, this is STRUCTURAL and deliberately NOT
+        // deployment-gated, so the v10 witness shape is RESERVED from genesis: no
+        // v10 input can exist, therefore any tx creating a v10 output fails
+        // out > in = 0. Shipping it dormant now is what keeps a later SoquObscura
+        // activation a soft fork rather than a rule that has to be added afterwards.
+        //
+        // ⚠️ REVISIT WHEN VALUE MOVES INTO THE COMMITMENT (bead sh2u). This sums
+        // nValue, which is still a plaintext CAmount on a confidential output. The
+        // day nValue becomes a commitment, a plaintext sum stops being meaningful
+        // and this rule must be replaced by a commitment-balance check, not merely
+        // widened again.
         CAmount nUSDSOQIn = 0;
         CAmount nUSDSOQOut = 0;
         for (unsigned int i = 0; i < tx.vin.size(); i++) {
             const COutPoint& prevout = tx.vin[i].prevout;
             const CCoins* coins = inputs.AccessCoins(prevout.hash);
             assert(coins);
-            if (coins->vout[prevout.n].IsUSDSOQ()) {
+            if (coins->vout[prevout.n].IsAnyUSDSOQ()) {
                 nUSDSOQIn += coins->vout[prevout.n].nValue;
             }
         }
         for (const auto& txout : tx.vout) {
-            if (txout.IsUSDSOQ()) {
+            if (txout.IsAnyUSDSOQ()) {
                 nUSDSOQOut += txout.nValue;
             }
         }
@@ -2072,12 +2094,16 @@ bool CheckTxInputs(const CChainParams& params, const CTransaction& tx, CValidati
             for (unsigned int i = 0; i < tx.vin.size(); i++) {
                 const COutPoint& prevout = tx.vin[i].prevout;
                 const CTxOut& prevOut = inputs.AccessCoins(prevout.hash)->vout[prevout.n];
-                if (!prevOut.IsUSDSOQ() &&
+                // IsAnyUSDSOQ() must match the conservation predicate above. If this
+                // stayed v7-only while conservation counted both modes, a legitimate
+                // v10 transfer would conserve and then be rejected here for spending
+                // its own asset.
+                if (!prevOut.IsAnyUSDSOQ() &&
                     !(prevOut.IsNativeSOQ() && prevOut.IsTransparent())) {
                     return state.DoS(100, false, REJECT_INVALID,
                         "bad-txns-usdsoq-input-mismatch", false,
-                        strprintf("USDSOQ transfer input %s:%u is neither a v7 "
-                            "USDSOQ input nor a transparent SOQ fee input",
+                        strprintf("USDSOQ transfer input %s:%u is neither a USDSOQ "
+                            "input (v7 or v10) nor a transparent SOQ fee input",
                             prevout.hash.ToString(), prevout.n));
                 }
             }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3795,9 +3795,15 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                         // Q3: Defense-in-depth — require target to be a live
                         // USDSOQ UTXO. Skip + log if not (don't reject the
                         // block — the authority TX itself is valid).
+                        // IsAnyUSDSOQ(), not IsUSDSOQ(): freeze targets an OUTPOINT, so it
+                        // is the one compliance control that still works when the amount is
+                        // hidden. With the v7-only predicate a v10 confidential USDSOQ
+                        // outpoint could never be frozen — the op was silently skipped and
+                        // logged as "not a live USDSOQ UTXO", so the issuer's GENIUS Act
+                        // §4(a)(2) freeze authority did not reach Tier A at all.
                         const CCoins* targetCoins = view.AccessCoins(freezeTarget.hash);
                         if (!targetCoins || !targetCoins->IsAvailable(freezeTarget.n) ||
-                            !targetCoins->vout[freezeTarget.n].IsUSDSOQ()) {
+                            !targetCoins->vout[freezeTarget.n].IsAnyUSDSOQ()) {
                             LogPrintf("USDSOQ: FREEZE target %s:%u is not a live USDSOQ "
                                       "UTXO at block %d — skipping (defense-in-depth)\n",
                                 freezeTarget.hash.ToString(), freezeTarget.n,
@@ -3851,7 +3857,11 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 for (unsigned int j = 0;
                      j < tx.vin.size() && j < txundoFreeze.vprevout.size(); j++) {
                     const CTxOut& prevOut = txundoFreeze.vprevout[j].txout;
-                    if (prevOut.IsUSDSOQ() && pcoinsdbview &&
+                    // IsAnyUSDSOQ(): the SOQ-ARCH-004 block below states that freeze
+                    // "works on a confidential output whose amount is hidden". With the
+                    // v7-only predicate here that was not true — a frozen v10 outpoint
+                    // was spendable. Widened so the claim and the code agree.
+                    if (prevOut.IsAnyUSDSOQ() && pcoinsdbview &&
                         pcoinsdbview->IsFrozenOutpoint(tx.vin[j].prevout)) {
                         return state.DoS(100,
                             error("ConnectBlock(): attempt to spend frozen USDSOQ UTXO %s:%u"
@@ -3916,6 +3926,26 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                         //   1. the SoquObscura privacy layer is active (BIP9)
                         //   2. range proofs are valid (checked in the section below)
                         //   3. commitment balance is preserved (sum_in == sum_out)
+                        //
+                        // ⚠️ SHADOWED, DELIBERATELY RETAINED (n1vf). This reject can never
+                        // be the one that fires. SOQ-ARCH-001 runs EARLIER in this same
+                        // ConnectBlock, on the SAME `flags`, and already rejects every
+                        // IsConfidential() output in the block with
+                        // "bad-txns-confidential-not-active" whenever
+                        // SCRIPT_VERIFY_SOQUOBSCURA is unset. Its condition is a strict
+                        // superset of this one, so the observable reject string for a
+                        // pre-activation v10 output is ALWAYS the SOQ-ARCH-001 one — pinned
+                        // by usdsoq_v10_reject_path_tests::preactivation_v10_output_is_
+                        // rejected_by_soq_arch_001_not_the_usdsoq_rule.
+                        //
+                        // It is kept, not deleted, because the two rules are independent
+                        // fail-closed backstops on the same property and SOQ-ARCH-001's
+                        // scope is the thing most likely to be narrowed later (it is the
+                        // generic all-assets rule; this one is asset-specific). If that
+                        // ever happens the Tier A path must still fail closed. The pinning
+                        // test is what turns "silently dead" into "known dead": narrowing
+                        // SOQ-ARCH-001 flips that test's expected string, so the shadowing
+                        // relationship cannot change without someone noticing.
                         if (!(flags & SCRIPT_VERIFY_SOQUOBSCURA)) {
                             return state.DoS(100,
                                 error("ConnectBlock(): USDSOQ confidential output %s:%u before "
@@ -3971,9 +4001,21 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 const CTxUndo& txundo = blockundo.vtxundo[i - 1];
                 for (unsigned int j = 0; j < tx.vin.size() && j < txundo.vprevout.size(); j++) {
                     const CTxOut& prevOut = txundo.vprevout[j].txout;
-                    if (prevOut.IsUSDSOQ()) {
-                        // Defense-in-depth: reject confidential USDSOQ inputs
-                        // Phase 4: use IsConfidential() predicate (v4 witness version)
+                    // ⛔ n1vf: THIS PREDICATE WAS `IsUSDSOQ()` (v7 only), WHICH MADE THE
+                    // REJECT BELOW STRUCTURALLY UNREACHABLE — the second instance of the
+                    // SOQ-ARCH-004 dead-rule pattern, in the INPUT loop this time. v7 is
+                    // one opcode and confidentiality is another, so `IsUSDSOQ() &&
+                    // IsConfidential()` is the empty set and "bad-txns-usdsoq-conf-input"
+                    // could never fire. Its own error text says the state "should not
+                    // exist"; what did not exist was the rule. Widening to IsAnyUSDSOQ()
+                    // makes it live: an authority tx that spends a CONFIDENTIAL USDSOQ
+                    // input is now rejected, which is what supply auditability requires —
+                    // nUSDSOQBurned is a plaintext sum, so a hidden burn amount would
+                    // silently desynchronise the supply counter from the chain.
+                    if (prevOut.IsAnyUSDSOQ()) {
+                        // Authority operations must move supply across a TRANSPARENT
+                        // boundary in both directions: mint is gated on IsTransparent()
+                        // in the output loop above, burn is gated here.
                         if (prevOut.IsConfidential()) {
                             return state.DoS(100,
                                 error("ConnectBlock(): spending confidential USDSOQ input %s:%u"


### PR DESCRIPTION
Gate 0 (bead `r0vn`), first batch. Six commits: two consensus rules that could not fire, one asset that could be minted from nothing, one set of activation heights that belonged to a different chain, one piece of superseded scaffolding now proven inert, and the test machinery that makes all of it observable.

Nothing here changes behaviour on any network today. Every rule touched is unreachable while SoquObscura is dormant, and mainnet genesis is not minted. That is deliberate: `r0vn`'s bar is that a rule ships **at genesis, dormant**, so a later activation is a soft fork rather than a rule someone has to add afterwards.

## Why these were invisible

The suite was **597/597 green** while `SOQ-ARCH-004` was dead code. Classification is structural, so `scriptPubKey[0]` is one opcode: a guard on `IsUSDSOQ()` (v7) wrapping a body that tests `IsConfidential()` (v4 or v10) is the empty set. Such a rule compiles, reads as enforcement, and never fails, because a rule that never fires never fails.

Two things had to exist before any of it could be tested, and their absence is the actual root cause:

1. **No test could activate a height-gated deployment.** `UpdateRegtestBIP9Parameters` writes `nStartTime`/`nTimeout`; `DeploymentActiveAtHeight` reads `nActivationHeight` and nothing else. Every `SCRIPT_VERIFY_SOQUOBSCURA`-gated path was unreachable from the suite. `UpdateRegtestActivationHeight` adds the lever, and writes **all three** regtest consensus structs, because the tree is height-indexed and mutating only the base struct is invisible above height 19.
2. **No test could see a reject string.** `ProcessNewBlock` returns a bool, so the existing harness can only assert the tip did not move, which passes for the wrong reject as happily as the right one. The new tests solve the block and read the reason out of `TestBlockValidity`.

## Commits

**1. Two USDSOQ rules that could not fire** (`don9`, `n1vf`)

| rule | was | now |
|---|---|---|
| `bad-txns-usdsoq-conf-input` | structurally unreachable, v7-only guard | fires; burned supply is a plaintext sum, so a hidden burn amount would desynchronise the supply counter |
| freeze-spend guard | v7-only, so a frozen v10 outpoint was spendable | covers both modes, matching what the `SOQ-ARCH-004` comment already claimed |
| `FREEZE` op target | v7-only, so freezing a confidential outpoint was silently skipped | the issuer's GENIUS Act §4(a)(2) freeze authority now reaches Tier A |
| `bad-txns-usdsoq-confidential-not-active` | silently shadowed by `SOQ-ARCH-001` | kept as an independent fail-closed backstop, documented as shadowed, and **pinned** by a test asserting which rule actually fires |

`bad-txns-usdsoq-authority-must-be-transparent` needed no code change. It needed the test, which did not exist.

**2. Per-asset conservation counts both USDSOQ modes**

Conservation counted `IsUSDSOQ()` (v7 only) while the fee filters key on `IsNativeSOQ()`, which correctly excludes v10. A v10 output fell through both: conservation saw 0 in and 0 out, and `nSOQOut` omitted it. The blind spots compose, so a tx emitting a v10 output from ordinary SOQ inputs **minted confidential USDSOQ from nothing and pushed the same value into `nFees`**. This is the hole Phase 3 closed for v7 and never extended to v10.

**3. Activation posture pinned at every height, not just genesis** (`v7xm` F8)

The existing dormancy tests read `GetConsensus(0)`. That is not the struct most blocks are validated against. Three checks across all four networks: posture uniform across consensus tiers; no height-gated deployment carrying a live BIP9 window it cannot use; no two feature deployments sharing a version bit. Also adds `DEPLOYMENT_BTCSOQ` to `P96_FLAGDAY_DEPLOYMENTS`, which was simply missing.

**4. Dogecoin's BIP34/65/66 heights replaced** (`zz2f`)

Mainnet carried Dogecoin's mainnet heights verbatim, Dogecoin block hashes in the comments. On a chain starting at height 0, `BIP65Height = 3464751` meant **`OP_CHECKLOCKTIMEVERIFY` was a NOP for ~6.6 years**. Dormant today (the CLTV vehicles are `NOT_SCHEDULED`); live the instant either activates, and an HTLC with an unenforceable timeout branch is loss of funds. `DEPLOYMENT_CSV` being `ALWAYS_ACTIVE` while CLTV was gated off until year six shows this was never a decision.

Stagenet, the mainnet rehearsal network, already used `0/0/100`, so every soak result carried an assumption mainnet did not honour. Mainnet and testnet now match it. `BIP34Height = 100` because it must exceed 16 (`CScript() << nHeight` emits `OP_N` for 1..16, not the data push a strict BIP34 writer produces) and genesis must stay outside the rule. `BIP34Hash` becomes null, which keeps BIP30 enforced by lookup forever: strictly more checking, and honest.

**5. The three BTCSOQ rejects that were reachable and unexercised** (`n1vf`)

Nothing about these was dead. None of the three strings appeared anywhere under `src/test/` or `qa/`, which is not a lesser state than dead: it is the state a dead rule is indistinguishable from. Two false starts here are the argument for the criterion in miniature — a v7 exotic input tripped USDSOQ conservation first, and a witness-less v4 input tripped `bad-txns-requires-dilithium` first. Both would have passed under "the tip did not move".

**6. The key-image protection is dead, and superseded** (`p4wv`)

The diagnosis on that bead was right and **its recommended fix was wrong**. The loop resolves inputs through the coins view in ConnectBlock's last pass, after `UpdateCoins` spent them, so it never runs. Third instance of the `e2n` pattern.

But it must not be revived by reading block undo. Key images exist only to make **ring signatures** double-spend-safe, and the ratified design cut ring signatures, stealth addresses and decoys from launch (`consensus/privacy.h` calls that design superseded; `DL-LATTICEBP-STATE-ANALYSIS` Part II.6 records that key images leave launch scope). Reviving it would restore three live defects: the two already on record as H2 and C5, plus a new one that is the real blocker — the key image is `wit.stack.back()`, which on every accepted witness layout is the **pubkey**, so two honest spends by one owner collide and the second is rejected as a double-spend of an output it never touched.

Nothing removed, no behaviour changed. The block is labelled at the site and both properties are proven by execution. This also corrects §2 item 3 of the state analysis, which reported the detection logic as working.

## Verification

**647 cases. The only failures are the three deliberate forgery tests** (`soquobscura_degenerate_witness_tests`), which must stay red. The scaled-witness case is a non-zero member of that class specifically so a reject-if-all-zeros patch cannot fake it.

Each reject test drives a failing input through `ConnectBlock` and asserts the exact string, **with a reachability control beside it** so a rejection for an unrelated reason cannot read as the rule working. Plus a guard on the activation lever itself: if that regresses, the other tests would go green by never reaching the rule they claim to exercise.

The chain fixture is lifted into `test/dilithium_chain_setup.h`. Four near-identical copies already existed; the pre-existing three are left alone rather than churned.

## Found and filed, not fixed here

- `jzg0` **P1** witness v10 is half-allocated: `transaction.h` and `validation.cpp` treat it as confidential USDSOQ; `interpreter.cpp` treats it as an unconditional anyone-can-spend future witness with no range-proof verification; `policy.cpp` says v10-v16 are unallocated; `Solver` has no v10 form. Scope item 1 is commit 2 above.
- `nv7q` **P1** `DEPLOYMENT_LATTICEFOLD` has no `nActivationHeight` on mainnet, so its only path is BIP9 signalling, which `params.h` says is physically precluded on a merge-mined chain. Activating it would be a hard fork. Also shares version bit 28 with `TESTDUMMY`.
- `tofg` **P2** `UpdateRegtestBIP9Parameters` cannot activate anything and writes 1 of 3 consensus structs.
- `p4wv` needs a decision rather than code: remove the key-image path now, or leave it dormant and labelled until Phase 2 of the ratified plan.
