### PR TITLE
Gate 0 part 2: key-image scaffolding, the witness-version table, LatticeFold retirement, and a consensus digest

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -173,7 +173,9 @@ BITCOIN_TESTS =\
   test/dilithium_keyhash_committed_tests.cpp \
   test/usdsoq_v7_holding_tests.cpp \
   test/usdsoq_v7_conservation_harness_tests.cpp \
-  test/usdsoq_v10_reject_path_tests.cpp
+  test/usdsoq_v10_reject_path_tests.cpp \
+  test/soquobscura_keyimage_deadcode_tests.cpp \
+  test/dilithium_chain_setup.h
 # Legacy ECDSA tests disabled for Post-Quantum Transition
 #  test/audit_tests.cpp
 #  test/multisig_tests.cpp

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -175,6 +175,7 @@ BITCOIN_TESTS =\
   test/usdsoq_v7_conservation_harness_tests.cpp \
   test/usdsoq_v10_reject_path_tests.cpp \
   test/soquobscura_keyimage_deadcode_tests.cpp \
+  test/witness_version_allocation_tests.cpp \
   test/dilithium_chain_setup.h
 # Legacy ECDSA tests disabled for Post-Quantum Transition
 #  test/audit_tests.cpp

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -176,6 +176,7 @@ BITCOIN_TESTS =\
   test/usdsoq_v10_reject_path_tests.cpp \
   test/soquobscura_keyimage_deadcode_tests.cpp \
   test/witness_version_allocation_tests.cpp \
+  test/consensus_digest_tests.cpp \
   test/dilithium_chain_setup.h
 # Legacy ECDSA tests disabled for Post-Quantum Transition
 #  test/audit_tests.cpp

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -550,8 +550,32 @@ public:
 
         // LatticeFold+ activation — ALWAYS_ACTIVE from genesis (April 2026 decision)
         consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].bit = 28;
-        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
-        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        // SOQ-P002: LatticeFold+ is RETIRED on every network, not just mainnet.
+        // It was ALWAYS_ACTIVE here while mainnet had already withdrawn it, so this
+        // network validated under a rule mainnet refuses — and the rule in question
+        // is a verifier that accepts an all-zero witness (see the CMainParams block
+        // for the full reasoning). Withdrawing SoquObscura from the test networks was
+        // done for exactly this reason in bead 2pru; LatticeFold+ has the same defect
+        // and was missed. A rehearsal network running a verifier known to accept
+        // forged proofs is not rehearsing anything.
+        //
+        // Verified safe against the LIVE stagenet chain before making this change:
+        // across all 48,733 blocks there is not one witness-v3 output, and the only
+        // two v6 covenant spends carry the witnessScript
+        // <32> OP_NOP7 <32> OP_NOP7 OP_1, so OP_CHECKFOLDPROOF has never executed.
+        // Clearing the flag therefore cannot alter the validity of any historical
+        // block. (Note the direction matters: for a v3 PROGRAM clearing the flag is a
+        // relaxation, but for OP_CHECKFOLDPROOF inside a script it is a tightening —
+        // SCRIPT_ERR_BAD_OPCODE — which is why the covenant witnessScripts had to be
+        // read rather than assumed.)
+        //
+        // nStartTime=0 / nTimeout=0 => THRESHOLD_FAILED, terminal. This deployment is
+        // queried through VersionBitsState, NOT DeploymentActiveAtHeight, so an
+        // nActivationHeight would be ignored here — do not add one thinking it locks
+        // anything down. Superseded by SoquObscura; witness v3 is retired and must not
+        // be reallocated. See test/witness_version_allocation_tests.cpp.
+        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nStartTime = 0;  // retired
+        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nTimeout = 0;    // never activates
 
         // SoquObscura confidential outputs — WITHDRAWN 2026-08-17 (S1/P2).
         // The consensus range verifier accepts an all-zero witness carrying a correct
@@ -778,8 +802,32 @@ public:
 
         // LatticeFold+ activation — ALWAYS_ACTIVE for regtest
         consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].bit = 28;
-        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
-        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        // SOQ-P002: LatticeFold+ is RETIRED on every network, not just mainnet.
+        // It was ALWAYS_ACTIVE here while mainnet had already withdrawn it, so this
+        // network validated under a rule mainnet refuses — and the rule in question
+        // is a verifier that accepts an all-zero witness (see the CMainParams block
+        // for the full reasoning). Withdrawing SoquObscura from the test networks was
+        // done for exactly this reason in bead 2pru; LatticeFold+ has the same defect
+        // and was missed. A rehearsal network running a verifier known to accept
+        // forged proofs is not rehearsing anything.
+        //
+        // Verified safe against the LIVE stagenet chain before making this change:
+        // across all 48,733 blocks there is not one witness-v3 output, and the only
+        // two v6 covenant spends carry the witnessScript
+        // <32> OP_NOP7 <32> OP_NOP7 OP_1, so OP_CHECKFOLDPROOF has never executed.
+        // Clearing the flag therefore cannot alter the validity of any historical
+        // block. (Note the direction matters: for a v3 PROGRAM clearing the flag is a
+        // relaxation, but for OP_CHECKFOLDPROOF inside a script it is a tightening —
+        // SCRIPT_ERR_BAD_OPCODE — which is why the covenant witnessScripts had to be
+        // read rather than assumed.)
+        //
+        // nStartTime=0 / nTimeout=0 => THRESHOLD_FAILED, terminal. This deployment is
+        // queried through VersionBitsState, NOT DeploymentActiveAtHeight, so an
+        // nActivationHeight would be ignored here — do not add one thinking it locks
+        // anything down. Superseded by SoquObscura; witness v3 is retired and must not
+        // be reallocated. See test/witness_version_allocation_tests.cpp.
+        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nStartTime = 0;  // retired
+        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nTimeout = 0;    // never activates
 
         // SoquObscura confidential outputs — WITHDRAWN 2026-08-17 (S1/P2).
         // ⚠️ Regtest is withdrawn DELIBERATELY, not by oversight. Leaving it active
@@ -1035,8 +1083,32 @@ public:
 
         // LatticeFold deployment - height based, not BIP9
         consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].bit = 28;
-        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
-        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        // SOQ-P002: LatticeFold+ is RETIRED on every network, not just mainnet.
+        // It was ALWAYS_ACTIVE here while mainnet had already withdrawn it, so this
+        // network validated under a rule mainnet refuses — and the rule in question
+        // is a verifier that accepts an all-zero witness (see the CMainParams block
+        // for the full reasoning). Withdrawing SoquObscura from the test networks was
+        // done for exactly this reason in bead 2pru; LatticeFold+ has the same defect
+        // and was missed. A rehearsal network running a verifier known to accept
+        // forged proofs is not rehearsing anything.
+        //
+        // Verified safe against the LIVE stagenet chain before making this change:
+        // across all 48,733 blocks there is not one witness-v3 output, and the only
+        // two v6 covenant spends carry the witnessScript
+        // <32> OP_NOP7 <32> OP_NOP7 OP_1, so OP_CHECKFOLDPROOF has never executed.
+        // Clearing the flag therefore cannot alter the validity of any historical
+        // block. (Note the direction matters: for a v3 PROGRAM clearing the flag is a
+        // relaxation, but for OP_CHECKFOLDPROOF inside a script it is a tightening —
+        // SCRIPT_ERR_BAD_OPCODE — which is why the covenant witnessScripts had to be
+        // read rather than assumed.)
+        //
+        // nStartTime=0 / nTimeout=0 => THRESHOLD_FAILED, terminal. This deployment is
+        // queried through VersionBitsState, NOT DeploymentActiveAtHeight, so an
+        // nActivationHeight would be ignored here — do not add one thinking it locks
+        // anything down. Superseded by SoquObscura; witness v3 is retired and must not
+        // be reallocated. See test/witness_version_allocation_tests.cpp.
+        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nStartTime = 0;  // retired
+        consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nTimeout = 0;    // never activates
 
         // SoquObscura confidential outputs — WITHDRAWN 2026-08-17 (S1/P2).
         // The shipped range verifier accepts an all-zero witness carrying a correct

--- a/src/test/consensus_digest_tests.cpp
+++ b/src/test/consensus_digest_tests.cpp
@@ -1,0 +1,261 @@
+// Copyright (c) 2026 Soqucoin Labs Inc.
+// Distributed under the MIT software license.
+//
+// consensus_digest_tests.cpp — one hash over everything the consensus rules are
+// made of. Bead v7xm, fork-risk class F4 (build-dependent consensus), and the
+// tripwire for the eventual consensus FREEZE.
+//
+// WHY A SINGLE DIGEST. F4's proven instance was a strict-aliasing violation that
+// made seed-derived PUBLIC data depend on the compiler's optimisation level: a
+// chain split from a build flag, invisible to every functional test because both
+// builds were internally consistent (bead nh6m). The only way to catch that
+// class is to compare a build against ANOTHER BUILD, which needs a single value
+// that summarises consensus and is cheap to compute. That is what this is.
+//
+// Two jobs, one artifact:
+//
+//   1. AS A CI TEST it is a freeze tripwire. Any change to a genesis hash, a
+//      derived seed, a deployment parameter, an activation height, the subsidy
+//      schedule, the PoW function or a script verdict moves the digest and fails
+//      here. After the freeze that failure IS the review trigger; before it, the
+//      constant is updated deliberately and the diff says what moved.
+//
+//   2. AS AN F4 HARNESS it is the thing you diff across builds. Compile at
+//      -O0/-O1/-O2/-O3/-Os, and with each available compiler, run
+//      `test_soqucoin --run_test=consensus_digest_tests` and compare the printed
+//      digest. Equal digests are evidence of build-independence; a difference is
+//      an nh6m-class defect and is a launch blocker.
+//
+// ⛔ THE DIGEST DELIBERATELY EXERCISES CODE, NOT JUST CONSTANTS. Reading
+// chainparams fields back would only prove the compiler can copy integers. It
+// therefore also runs scrypt (the PoW function, the heaviest arithmetic in the
+// consensus path), HMAC-SHA256 through the real seed-derivation helper, the
+// subsidy schedule, and the script interpreter over every witness version. Those
+// are where a codegen difference could actually express itself.
+
+#include "chainparams.h"
+#include "consensus/params.h"
+#include "crypto/sha256.h"
+#include "primitives/block.h"
+#include "script/interpreter.h"
+#include "script/script.h"
+#include "soqucoin.h"
+#include "streams.h"
+#include "uint256.h"
+#include "version.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+#include <vector>
+
+BOOST_FIXTURE_TEST_SUITE(consensus_digest_tests, BasicTestingSetup)
+
+namespace {
+
+//! Accumulates every consensus-relevant value into one SHA256.
+class DigestBuilder
+{
+public:
+    void U64(uint64_t v)
+    {
+        // Fixed little-endian, so the digest cannot depend on host endianness or
+        // on how the compiler lays out a struct.
+        unsigned char b[8];
+        for (int i = 0; i < 8; ++i) b[i] = (unsigned char)((v >> (8 * i)) & 0xff);
+        m_h.Write(b, 8);
+    }
+    void I64(int64_t v)   { U64((uint64_t)v); }
+    void Bytes(const unsigned char* p, size_t n) { m_h.Write(p, n); }
+    void Hash(const uint256& h) { m_h.Write(h.begin(), 32); }
+    void Str(const std::string& s) { U64(s.size()); m_h.Write((const unsigned char*)s.data(), s.size()); }
+
+    uint256 Finalize()
+    {
+        uint256 out;
+        m_h.Finalize(out.begin());
+        return out;
+    }
+
+private:
+    CSHA256 m_h;
+};
+
+//! Everything in a Consensus::Params that a validating node acts on.
+void AbsorbConsensus(DigestBuilder& d, const Consensus::Params& c)
+{
+    d.Hash(c.hashGenesisBlock);
+    d.I64(c.nSubsidyHalvingInterval);
+    d.I64(c.BIP34Height);
+    d.Hash(c.BIP34Hash);
+    d.I64(c.BIP65Height);
+    d.I64(c.BIP66Height);
+    d.Hash(c.powLimit);
+    d.I64(c.nPowTargetSpacing);
+    d.I64(c.nPowTargetTimespan);
+    d.I64(c.nRuleChangeActivationThreshold);
+    d.I64(c.nMinerConfirmationWindow);
+    d.I64(c.nCoinbaseMaturity);
+    d.I64(c.nMaxReorgDepth);
+    d.I64(c.dilithiumOnlyHeight);
+    d.I64(c.nAuxpowChainId);
+    d.I64(c.fStrictChainId ? 1 : 0);
+    d.I64(c.nAuxpowStartHeight);
+    d.I64(c.fAllowLegacyBlocks ? 1 : 0);
+    d.I64(c.nHeightEffective);
+    d.I64(c.fPowAllowMinDifficultyBlocks ? 1 : 0);
+    d.I64(c.fPowNoRetargeting ? 1 : 0);
+    d.I64(c.fDigishieldDifficultyCalculation ? 1 : 0);
+    d.I64(c.fSimplifiedRewards ? 1 : 0);
+
+    // The derived privacy seed. THIS is the field whose class of defect F4 exists
+    // for: it is computed at startup by HKDF over the genesis hash, so it is both
+    // public and code-derived, and the nh6m bug made exactly that kind of value
+    // depend on the optimisation level.
+    d.Bytes(c.latticeBPSeed.data(), c.latticeBPSeed.size());
+
+    // Every deployment, every field. A version bit or an activation height moving
+    // is a consensus change and must move the digest.
+    for (int i = 0; i < Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++i) {
+        const Consensus::BIP9Deployment& dep = c.vDeployments[i];
+        d.I64(dep.bit);
+        d.I64(dep.nStartTime);
+        d.I64(dep.nTimeout);
+        d.I64(dep.nActivationHeight);
+    }
+}
+
+//! Exercise the script interpreter over the full witness-version matrix, so a
+//! codegen difference in verification shows up as a digest difference.
+void AbsorbScriptVerdicts(DigestBuilder& d)
+{
+    CMutableTransaction tx;
+    tx.nVersion = 2;
+    CTxIn in;
+    in.prevout = COutPoint(uint256S("0x3333333333333333333333333333333333333333333333333333333333333333"), 0);
+    in.nSequence = CTxIn::SEQUENCE_FINAL;
+    tx.vin.push_back(in);
+    CTxOut o; o.nValue = 50 * COIN; o.scriptPubKey = CScript() << OP_TRUE;
+    tx.vout.push_back(o);
+    const CTransaction ctx(tx);
+
+    const unsigned int flagSets[] = {
+        SCRIPT_VERIFY_WITNESS,
+        SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_USDSOQ,
+        SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_BTCSOQ,
+        SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_SOQUOBSCURA,
+        SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2WSH_DILITHIUM,
+        SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_PAT,
+    };
+
+    for (int version = 0; version <= 16; ++version) {
+        for (size_t programLen : {size_t(20), size_t(32)}) {
+            CScript spk;
+            spk << (version == 0 ? OP_0 : CScript::EncodeOP_N(version));
+            spk << std::vector<unsigned char>(programLen, 0x01);
+            for (unsigned int flags : flagSets) {
+                CScriptWitness w;
+                w.stack.push_back(std::vector<unsigned char>(4, 0x00));
+                w.stack.push_back(std::vector<unsigned char>(4, 0x11));
+                ScriptError serr = SCRIPT_ERR_OK;
+                TransactionSignatureChecker checker(&ctx, 0, 50 * COIN);
+                const bool ok = VerifyScript(CScript(), spk, &w, flags, checker, &serr);
+                d.I64(version);
+                d.I64((int64_t)programLen);
+                d.I64(flags);
+                d.I64(ok ? 1 : 0);
+                d.I64((int64_t)serr);
+            }
+        }
+    }
+}
+
+uint256 ComputeConsensusDigest()
+{
+    DigestBuilder d;
+
+    for (const std::string& net : {CBaseChainParams::MAIN, CBaseChainParams::TESTNET,
+                                   CBaseChainParams::REGTEST, CBaseChainParams::STAGENET}) {
+        SelectParams(net);
+        d.Str(net);
+
+        // Every consensus tier, not just the base struct: each network indexes a
+        // height tree and blocks above a cutover validate against a different one.
+        for (int h : {0, 1, 2, 9, 10, 11, 19, 20, 21, 99, 100, 101, 1000, 1000000}) {
+            d.I64(h);
+            AbsorbConsensus(d, Params().GetConsensus(h));
+        }
+
+        // The genesis block itself, serialised, plus its hash and its PoW hash.
+        // GetPoWHash runs scrypt, which is by far the heaviest arithmetic on the
+        // consensus path and the most likely place for a codegen difference to
+        // become visible.
+        const CBlock& genesis = Params().GenesisBlock();
+        CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+        ss << genesis;
+        d.Bytes((const unsigned char*)ss.data(), ss.size());
+        d.Hash(genesis.GetHash());
+        d.Hash(genesis.hashMerkleRoot);
+        d.Hash(genesis.GetPoWHash());
+
+        // The emission schedule, sampled across every regime boundary that
+        // matters. 47B total supply is a locked figure; a subsidy that moves by
+        // one satoshi at one height is a chain split.
+        const uint256 prevHash = uint256S(
+            "0x4444444444444444444444444444444444444444444444444444444444444444");
+        for (int h : {0, 1, 2, 99, 100, 1000, 100000, 144000, 500000, 1000000,
+                      2000000, 5000000, 10000000}) {
+            d.I64(h);
+            d.I64(GetSoqucoinBlockSubsidy(h, Params().GetConsensus(h), prevHash));
+        }
+    }
+
+    AbsorbScriptVerdicts(d);
+
+    SelectParams(CBaseChainParams::MAIN);
+    return d.Finalize();
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// ⛔ IF THIS FAILS, SOMETHING ABOUT CONSENSUS CHANGED. That is not always wrong,
+// but it is never incidental. Work out WHICH input moved before touching the
+// constant, and update the constant in the same commit as the change that caused
+// it, so the diff carries the explanation.
+//
+// Regenerate with:
+//   src/test/test_soqucoin --run_test=consensus_digest_tests --log_level=message
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(consensus_digest_is_pinned)
+{
+    const uint256 digest = ComputeConsensusDigest();
+    BOOST_TEST_MESSAGE("CONSENSUS DIGEST: " << digest.ToString());
+
+    // Pinned 2026-08-20 on the Gate 0 branch, Apple clang 21 arm64 -O2.
+    const std::string expected =
+        "0489e98d4d6465a42ef90a0d456c70804794b914cdd0e502ad0bbae3928a9fe7";
+
+    BOOST_CHECK_MESSAGE(digest.ToString() == expected,
+        "consensus digest is " + digest.ToString() + ", expected " + expected +
+        ". Identify which consensus input moved before updating the constant.");
+}
+
+// Determinism within a single build. A digest that varies run to run would mean
+// something in the consensus path reads uninitialised memory or unpinned global
+// state, and would also make the cross-build comparison meaningless.
+BOOST_AUTO_TEST_CASE(consensus_digest_is_stable_within_a_build)
+{
+    const uint256 a = ComputeConsensusDigest();
+    const uint256 b = ComputeConsensusDigest();
+    const uint256 c = ComputeConsensusDigest();
+    BOOST_CHECK_MESSAGE(a == b && b == c,
+        "the consensus digest changed between runs in the SAME binary: " +
+        a.ToString() + " / " + b.ToString() + " / " + c.ToString() +
+        ". Something on the consensus path depends on uninitialised memory or on "
+        "mutable global state, which makes any cross-build comparison worthless");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/dilithium_chain_setup.h
+++ b/src/test/dilithium_chain_setup.h
@@ -1,0 +1,196 @@
+// Copyright (c) 2026 Soqucoin Labs Inc.
+// Distributed under the MIT software license.
+//
+// dilithium_chain_setup.h — a regtest chain fixture that drives REAL blocks
+// through ConnectBlock, shared by the consensus reject-path suites.
+//
+// Four near-identical copies of this fixture already exist
+// (usdsoq_v7_conservation_harness, freeze_registry_harness,
+// btcsoq_lifecycle_harness, and one inside usdsoq_v10_reject_path). This header
+// exists so the count stops growing; the pre-existing three are deliberately
+// left alone rather than churned.
+//
+// Two capabilities here are load-bearing and are the reason several consensus
+// rules went untested for so long:
+//
+//   * RejectReasonFor(). ProcessNewBlock returns a bool, so a test built on it
+//     can only assert that the tip did not move — which passes for the WRONG
+//     reject exactly as happily as for the right one. Driving the block through
+//     TestBlockValidity yields the CValidationState and therefore the exact
+//     string that bead r0vn requires.
+//   * SeedCoin(). Drops a mature, spendable coin of an ARBITRARY witness version
+//     straight into the UTXO set, so a test can spend an output type that policy
+//     would never relay and consensus would never let a block create.
+
+#ifndef BITCOIN_TEST_DILITHIUM_CHAIN_SETUP_H
+#define BITCOIN_TEST_DILITHIUM_CHAIN_SETUP_H
+
+#include "chainparams.h"
+#include "coins.h"
+#include "consensus/validation.h"
+#include "crypto/sha256.h"
+#include "key.h"
+#include "miner.h"
+#include "pow.h"
+#include "primitives/transaction.h"
+#include "script/interpreter.h"
+#include "script/script.h"
+#include "test/test_bitcoin.h"
+#include "txdb.h"
+#include "uint256.h"
+#include "validation.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+//! Regtest coinbase maturity (chainparams: 60 * 4).
+static const int DILITHIUM_CHAIN_MATURITY = 240;
+
+//! OP_N <32-byte program> — the one shape every Soqucoin witness version uses.
+inline CScript MakeWitnessSpk(opcodetype version, const std::vector<unsigned char>& rawPubkey)
+{
+    uint256 pkHash;
+    CSHA256().Write(rawPubkey.data(), rawPubkey.size()).Finalize(pkHash.begin());
+    CScript spk;
+    spk << version << std::vector<unsigned char>(pkHash.begin(), pkHash.end());
+    return spk;
+}
+
+//! ML-DSA-44 public keys are 0x00-prefixed on the witness stack (FIPS 204 Table 3).
+inline std::vector<unsigned char> PrefixedPubkey(const std::vector<unsigned char>& rawPubkey)
+{
+    std::vector<unsigned char> out;
+    out.reserve(rawPubkey.size() + 1);
+    out.push_back(0x00);
+    out.insert(out.end(), rawPubkey.begin(), rawPubkey.end());
+    return out;
+}
+
+struct DilithiumChainSetup : public TestingSetup {
+    CKey coinbaseKey;
+    CScript coinbaseSpk;
+    std::vector<unsigned char> coinbasePkBytes;
+    std::vector<CTransaction> coinbaseTxns;
+
+    DilithiumChainSetup() : TestingSetup(CBaseChainParams::REGTEST)
+    {
+        coinbaseKey.MakeNewKey(true);
+        CPubKey pk = coinbaseKey.GetPubKey();   // local first — never .GetPubKey().begin() inline
+        BOOST_REQUIRE(pk.IsValid());
+        coinbasePkBytes.assign(pk.begin(), pk.end());
+        BOOST_REQUIRE_EQUAL(coinbasePkBytes.size(), 1312u);
+        coinbaseSpk = Spk(OP_1);
+        BOOST_REQUIRE_EQUAL(coinbaseSpk.size(), 34u);
+
+        // Dilithium v1 coinbase: regtest sets dilithiumOnlyHeight = 0, so a
+        // legacy P2PK coinbase (what TestChain240Setup would mine) is rejected.
+        for (int i = 0; i < DILITHIUM_CHAIN_MATURITY; i++) {
+            CBlock b = CreateAndProcessBlock({}, coinbaseSpk);
+            BOOST_REQUIRE_MESSAGE(b.vtx.size() > 0, "block must have coinbase");
+            coinbaseTxns.push_back(*b.vtx[0]);
+        }
+    }
+
+    //! scriptPubKey of the given witness version, owned by coinbaseKey.
+    CScript Spk(opcodetype version) const { return MakeWitnessSpk(version, coinbasePkBytes); }
+
+    CBlock CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns, const CScript& spk)
+    {
+        CBlock block = BuildSolvedBlock(txns, spk);
+        std::shared_ptr<const CBlock> shared = std::make_shared<const CBlock>(block);
+        bool fNewBlock = false;
+        ProcessNewBlock(Params(), shared, true, &fNewBlock);
+        return block;
+    }
+
+    //! Solve a block on top of the tip WITHOUT connecting it.
+    CBlock BuildSolvedBlock(const std::vector<CMutableTransaction>& txns, const CScript& spk)
+    {
+        const CChainParams& cp = Params();
+        std::unique_ptr<CBlockTemplate> tmpl = BlockAssembler(cp).CreateNewBlock(spk, true);
+        BOOST_REQUIRE_MESSAGE(tmpl != nullptr, "CreateNewBlock must not return nullptr");
+        CBlock& block = tmpl->block;
+        block.vtx.resize(1);
+        {
+            // Drop the witness commitment CreateNewBlock generated for the EMPTY
+            // template, then regenerate it over our actual vtx set.
+            CMutableTransaction coinbaseMut(*block.vtx[0]);
+            coinbaseMut.vout.erase(
+                std::remove_if(coinbaseMut.vout.begin(), coinbaseMut.vout.end(),
+                    [](const CTxOut& o) {
+                        return o.scriptPubKey.size() >= 38 &&
+                               o.scriptPubKey[0] == OP_RETURN && o.scriptPubKey[1] == 0x24 &&
+                               o.scriptPubKey[2] == 0xaa && o.scriptPubKey[3] == 0x21 &&
+                               o.scriptPubKey[4] == 0xa9 && o.scriptPubKey[5] == 0xed;
+                    }),
+                coinbaseMut.vout.end());
+            coinbaseMut.vin[0].scriptWitness.stack.clear();
+            block.vtx[0] = MakeTransactionRef(std::move(coinbaseMut));
+        }
+        for (const CMutableTransaction& tx : txns)
+            block.vtx.push_back(MakeTransactionRef(tx));
+        GenerateCoinbaseCommitment(block, chainActive.Tip(), cp.GetConsensus(0));
+        unsigned int extraNonce = 0;
+        IncrementExtraNonce(&block, chainActive.Tip(), extraNonce);
+        while (!CheckProofOfWork(block.GetPoWHash(), block.nBits, cp.GetConsensus(0)))
+            ++block.nNonce;
+        return block;
+    }
+
+    //! Run a solved block through the full ConnectBlock path and return the
+    //! reject reason, or "" if it validated. THE assertion primitive for r0vn.
+    std::string RejectReasonFor(const std::vector<CMutableTransaction>& txns)
+    {
+        CBlock B = BuildSolvedBlock(txns, coinbaseSpk);
+        CValidationState st;
+        bool ok;
+        {
+            LOCK(cs_main);
+            ok = TestBlockValidity(st, Params(), B, chainActive.Tip(), true, true);
+        }
+        if (ok) return std::string();
+        BOOST_TEST_MESSAGE("reject: " << st.GetRejectReason()
+            << (st.GetDebugMessage().empty() ? "" : " | " + st.GetDebugMessage()));
+        return st.GetRejectReason();
+    }
+
+    //! Seed a mature, spendable coin of an arbitrary witness version into the UTXO
+    //! set. pcoinsTip is modified directly: an intermediate CCoinsViewCache would
+    //! flush its unset hashBlock over the tip's and trip ConnectBlock's assertion.
+    COutPoint SeedCoin(const CScript& spk, CAmount value, uint8_t tag)
+    {
+        uint256 txid;
+        txid.begin()[0] = tag;   // distinct txid per seeded coin
+        {
+            LOCK(cs_main);
+            CCoinsModifier c = pcoinsTip->ModifyCoins(txid);
+            c->Clear();
+            c->fCoinBase = false;
+            c->nHeight   = 1;    // mature, non-coinbase
+            c->nVersion  = 2;
+            c->vout.resize(1);
+            c->vout[0].nValue       = value;
+            c->vout[0].scriptPubKey = spk;
+        }
+        return COutPoint(txid, 0);
+    }
+
+    //! BIP143 witness-v0 signature over scriptCode, stack = [sig, 0x00||pubkey].
+    void SignInput(CMutableTransaction& tx, unsigned int idx, const CScript& scriptCode, CAmount amount)
+    {
+        CTransaction ctxForSign(tx);
+        uint256 sighash = SignatureHash(scriptCode, ctxForSign, idx, SIGHASH_ALL,
+                                        amount, SIGVERSION_WITNESS_V0, nullptr);
+        std::vector<unsigned char> sig;
+        BOOST_REQUIRE(coinbaseKey.Sign(sighash, sig));
+        sig.push_back((unsigned char)SIGHASH_ALL);
+        tx.vin[idx].scriptWitness.stack.clear();
+        tx.vin[idx].scriptWitness.stack.push_back(sig);
+        tx.vin[idx].scriptWitness.stack.push_back(PrefixedPubkey(coinbasePkBytes));
+    }
+};
+
+#endif // BITCOIN_TEST_DILITHIUM_CHAIN_SETUP_H

--- a/src/test/genesis_chainparams_tests.cpp
+++ b/src/test/genesis_chainparams_tests.cpp
@@ -183,9 +183,15 @@ BOOST_AUTO_TEST_CASE(stagenet_critical_deployments_active)
     BOOST_CHECK_EQUAL(consensus.vDeployments[Consensus::DEPLOYMENT_CHECKPATAGG].nStartTime,
                       Consensus::BIP9Deployment::ALWAYS_ACTIVE);
 
-    // LatticeFold (bit 4) — must be ALWAYS_ACTIVE
-    BOOST_CHECK_EQUAL(consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nStartTime,
-                      Consensus::BIP9Deployment::ALWAYS_ACTIVE);
+    // LatticeFold+ (bit 28) — RETIRED 2026-08-20, must NOT be active. Superseded
+    // by SoquObscura. Mainnet had already withdrawn it (its verifier accepts an
+    // all-zero witness, exactly like the SoquObscura range verifier below), while
+    // stagenet was left ALWAYS_ACTIVE — so the mainnet REHEARSAL network was
+    // validating under a rule mainnet refuses. Withdrawn here for the same reason
+    // SoquObscura was. Full assertions live in
+    // test/witness_version_allocation_tests.cpp.
+    BOOST_CHECK_EQUAL(consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nStartTime, 0);
+    BOOST_CHECK_EQUAL(consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nTimeout, 0);
 
     // SoquObscura (bit 5) — WITHDRAWN 2026-08-17, must NOT be active. Its range
     // verifier accepts an all-zero witness carrying a correct Fiat-Shamir seed.
@@ -205,13 +211,18 @@ BOOST_AUTO_TEST_CASE(regtest_critical_deployments_active)
     SelectParams(CBaseChainParams::REGTEST);
     const Consensus::Params& consensus = Params().GetConsensus(0);
 
-    // PAT, LatticeFold and USDSOQ stay ALWAYS_ACTIVE on regtest.
+    // PAT and USDSOQ stay ALWAYS_ACTIVE on regtest.
     BOOST_CHECK_EQUAL(consensus.vDeployments[Consensus::DEPLOYMENT_CHECKPATAGG].nStartTime,
-                      Consensus::BIP9Deployment::ALWAYS_ACTIVE);
-    BOOST_CHECK_EQUAL(consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nStartTime,
                       Consensus::BIP9Deployment::ALWAYS_ACTIVE);
     BOOST_CHECK_EQUAL(consensus.vDeployments[Consensus::DEPLOYMENT_USDSOQ].nStartTime,
                       Consensus::BIP9Deployment::ALWAYS_ACTIVE);
+
+    // LatticeFold+ — RETIRED 2026-08-20, must NOT be active. Regtest is included
+    // deliberately, on the same reasoning that included it in the SoquObscura
+    // withdrawal below: leaving it active keeps every functional test running
+    // against a verifier known to accept forged proofs.
+    BOOST_CHECK_EQUAL(consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nStartTime, 0);
+    BOOST_CHECK_EQUAL(consensus.vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD].nTimeout, 0);
 
     // SoquObscura — WITHDRAWN 2026-08-17, must NOT be active. Regtest is included
     // in the withdrawal deliberately: leaving it active would keep every

--- a/src/test/soquobscura_keyimage_deadcode_tests.cpp
+++ b/src/test/soquobscura_keyimage_deadcode_tests.cpp
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Soqucoin Labs Inc.
+// Distributed under the MIT software license.
+//
+// soquobscura_keyimage_deadcode_tests.cpp — proof BY EXECUTION that the
+// key-image double-spend protection in ConnectBlock cannot run (bead p4wv).
+//
+// These tests assert that a rule does NOT fire. That is unusual and deliberate.
+// Bead r0vn's whole argument is that "scaffolding that never fires is
+// indistinguishable from scaffolding that works", and the only way to tell the
+// two apart is to execute the case the rule claims to catch and record what
+// actually happens. Until now the answer was inferred from reading; here it is
+// measured.
+//
+// WHAT IS DEAD AND WHY
+//
+// The loop in validation.cpp (SOQ-ARCH-001 Phase 2) resolves each input with
+// view.AccessCoins(prevout.hash)->IsAvailable(n). It runs in the LAST pass over
+// the block, and UpdateCoins already spent every input during the FIRST pass, so
+// IsAvailable is false for all of them and the body is skipped unconditionally.
+// Consequence: four reject strings are unreachable
+// (bad-txns-conf-no-witness, bad-txns-conf-empty-keyimage,
+// bad-txns-conf-duplicate-keyimage, bad-txns-conf-intrablock-duplicate-keyimage),
+// vBlockKeyImages is always empty, and WriteKeyImage is never called by the
+// connect path, so the DB the cross-block check consults is never populated.
+//
+// This is the THIRD instance of one root cause. The freeze guard (bead e2n) and
+// the USDSOQ input-isolation rule (bead 0r2) were both dead for exactly this
+// reason and were both fixed. The asymmetry is visible inside validation.cpp
+// itself: DisconnectBlock's mirror loop does the same walk and works, and its
+// own comment says why — ApplyTxInUndo has already RESTORED the inputs there.
+//
+// ⛔ DO NOT "FIX" THIS BY READING BLOCK UNDO. That was the first instinct and it
+// is wrong. The ratified design (DL-LATTICEBP-STATE-ANALYSIS-2026-07-18 Part II,
+// DL-SOQUOBSCURA-NAMING-POLICY) CUT ring signatures, stealth addresses and
+// decoys from launch, and key images exist only to make ring signatures
+// double-spend-safe. II.6 records the disposition explicitly: "Key images leave
+// launch scope", and Phase 2 says "remove LF+/ring/key-image opcodes from launch
+// rules". Reviving the loop would also revive two known defects that have never
+// executed: H2, WriteKeyImage has no !fJustCheck guard, so every
+// getblocktemplate dry-run would persist key images and the second poll of the
+// same template would reject it as a duplicate (BUG-18 verbatim); and C5, no
+// witness layout satisfies both script verification and key-image extraction.
+//
+// The second test below demonstrates the deeper problem concretely: the
+// "key image" is just wit.stack.back(), so two honest spends by the same key
+// produce the SAME key image. Reviving the rule as written would reject a
+// legitimate transaction.
+
+#include "consensus/params.h"
+#include "consensus/privacy.h"
+#include "test/dilithium_chain_setup.h"
+#include "test/testutil.h"   // ScopedRegtestActivation
+#include "txdb.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(soquobscura_keyimage_deadcode_tests, DilithiumChainSetup)
+
+// ---------------------------------------------------------------------------
+// The measurement. Two CONFIDENTIAL (witness v10) inputs are spent in one
+// transaction, both signed by the same key, so both witness stacks end in the
+// identical 0x00-prefixed pubkey. The key image is defined as the last witness
+// element, so if the loop ran at all the second input would be an intra-block
+// duplicate and the block would be rejected with
+// bad-txns-conf-intrablock-duplicate-keyimage.
+//
+// It connects. And nothing is written to the key-image DB, which is checked
+// directly rather than inferred, so this cannot be read as "the loop ran and the
+// images happened to differ".
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(connectblock_never_extracts_key_images_from_confidential_inputs)
+{
+    ScopedRegtestActivation on(Consensus::DEPLOYMENT_SOQUOBSCURA, 0);
+
+    const CAmount valA = 3 * COIN, valB = 2 * COIN;
+    const CScript v10 = Spk(OP_10);
+    COutPoint a = SeedCoin(v10, valA, 0xc1);
+    COutPoint b = SeedCoin(v10, valB, 0xc2);
+
+    CMutableTransaction tx; tx.nVersion = 2;
+    { CTxIn i0; i0.prevout = a; i0.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(i0); }
+    { CTxIn i1; i1.prevout = b; i1.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(i1); }
+    // USDSOQ conservation counts v10, so the single output carries the full sum.
+    { CTxOut o; o.nValue = valA + valB; o.scriptPubKey = v10; tx.vout.push_back(o); }
+    SignInput(tx, 0, v10, valA);
+    SignInput(tx, 1, v10, valB);
+
+    // Both witnesses end in the same element, so both "key images" are equal.
+    BOOST_REQUIRE(tx.vin[0].scriptWitness.stack.back() == tx.vin[1].scriptWitness.stack.back());
+    const LatticeKeyImageHash ki =
+        LatticeKeyImageHash::FromSerializedKeyImage(tx.vin[0].scriptWitness.stack.back());
+
+    BOOST_CHECK_MESSAGE(RejectReasonFor({tx}).empty(),
+        "a block spending two confidential inputs whose key images are IDENTICAL must be "
+        "rejected once the key-image loop runs. It connects, so the loop does not run: "
+        "it resolves inputs through the coins view in ConnectBlock's LAST pass, after "
+        "UpdateCoins has already spent them (bead p4wv, third instance of the e2n pattern)");
+
+    CBlock connected = CreateAndProcessBlock({tx}, coinbaseSpk);
+    BOOST_REQUIRE_MESSAGE(chainActive.Tip()->GetBlockHash() == connected.GetHash(),
+        "the block must actually connect for the DB assertion below to mean anything");
+
+    bool have;
+    {
+        LOCK(cs_main);
+        have = pcoinsdbview->HaveKeyImage(ki.hash);
+    }
+    BOOST_CHECK_MESSAGE(!have,
+        "ConnectBlock recorded no key image for a confidential spend. vBlockKeyImages is "
+        "always empty, so WriteKeyImage is never reached and the cross-block duplicate "
+        "check has an empty set to consult. Direct evidence, not inference.");
+}
+
+// ---------------------------------------------------------------------------
+// The reason a naive revival would be a regression rather than a fix.
+//
+// The key image is whatever wit.stack.back() happens to be. On every witness
+// layout the node actually accepts today that element is NOT bound to the
+// outpoint being spent: for a Dilithium-path spend it is the pubkey, identical
+// across every output the same key owns. So the moment the loop is made live,
+// two honest spends by one owner collide and the second is rejected as a
+// double-spend of an output it never touched.
+//
+// This test pins the collision itself, independent of whether the loop runs, so
+// the property is recorded before anyone tries to enable the rule.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(key_image_derivation_is_not_bound_to_the_output_being_spent)
+{
+    const CScript v10 = Spk(OP_10);
+    COutPoint a = SeedCoin(v10, 3 * COIN, 0xc3);
+    COutPoint b = SeedCoin(v10, 7 * COIN, 0xc4);   // different outpoint, different value
+
+    CMutableTransaction txA; txA.nVersion = 2;
+    { CTxIn i; i.prevout = a; i.nSequence = CTxIn::SEQUENCE_FINAL; txA.vin.push_back(i); }
+    { CTxOut o; o.nValue = 3 * COIN; o.scriptPubKey = v10; txA.vout.push_back(o); }
+    SignInput(txA, 0, v10, 3 * COIN);
+
+    CMutableTransaction txB; txB.nVersion = 2;
+    { CTxIn i; i.prevout = b; i.nSequence = CTxIn::SEQUENCE_FINAL; txB.vin.push_back(i); }
+    { CTxOut o; o.nValue = 7 * COIN; o.scriptPubKey = v10; txB.vout.push_back(o); }
+    SignInput(txB, 0, v10, 7 * COIN);
+
+    const LatticeKeyImageHash kiA =
+        LatticeKeyImageHash::FromSerializedKeyImage(txA.vin[0].scriptWitness.stack.back());
+    const LatticeKeyImageHash kiB =
+        LatticeKeyImageHash::FromSerializedKeyImage(txB.vin[0].scriptWitness.stack.back());
+
+    BOOST_CHECK_MESSAGE(kiA == kiB,
+        "two spends of DIFFERENT confidential outpoints by the same owner derive the SAME "
+        "key image, because the key image is defined as the last witness element and that "
+        "element is the pubkey. Enabling the ConnectBlock loop without first defining a "
+        "real key image would reject the second honest spend as a double-spend. Key images "
+        "only mean something under ring signatures, which the ratified design cut from "
+        "launch (DL-LATTICEBP-STATE-ANALYSIS Part II, II.6: 'Key images leave launch scope')");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/usdsoq_v10_reject_path_tests.cpp
+++ b/src/test/usdsoq_v10_reject_path_tests.cpp
@@ -37,182 +37,22 @@
 // Fixture shape (Dilithium v1 coinbase, 240 blocks, direct coins-view seeding)
 // follows usdsoq_v7_conservation_harness_tests.cpp.
 
-#include "chainparams.h"
 #include "consensus/params.h"
-#include "consensus/usdsoq.h"
-#include "consensus/validation.h"
-#include "key.h"
-#include "miner.h"
 #include "policy/policy.h"
-#include "pow.h"
-#include "primitives/transaction.h"
-#include "script/interpreter.h"
-#include "script/script.h"
 #include "script/standard.h"
-#include "coins.h"
-#include "txdb.h"
-#include "uint256.h"
-#include "validation.h"
-#include "crypto/sha256.h"
-#include "test/test_bitcoin.h"
+#include "test/dilithium_chain_setup.h"
 #include "test/testutil.h"   // ScopedRegtestActivation
 
 #include <boost/test/unit_test.hpp>
-#include <algorithm>
 
-namespace {
+// The chain fixture, SeedCoin, SignInput and RejectReasonFor now live in
+// test/dilithium_chain_setup.h — four near-identical copies of that fixture
+// already existed and this suite was about to be the fifth.
 
-static const int COINBASE_MATURITY_SOQ = 60 * 4;  // 240, regtest
-
-// OP_N <32-byte program> — the one shape every Soqucoin witness version uses.
-static CScript MakeVnSpk(opcodetype version, const std::vector<unsigned char>& rawPubkey)
-{
-    uint256 pkHash;
-    CSHA256().Write(rawPubkey.data(), rawPubkey.size()).Finalize(pkHash.begin());
-    CScript spk;
-    spk << version << std::vector<unsigned char>(pkHash.begin(), pkHash.end());
-    return spk;
-}
-
-static std::vector<unsigned char> Prefixed(const std::vector<unsigned char>& rawPubkey)
-{
-    std::vector<unsigned char> out;
-    out.reserve(rawPubkey.size() + 1);
-    out.push_back(0x00);
-    out.insert(out.end(), rawPubkey.begin(), rawPubkey.end());
-    return out;
-}
-
-} // namespace
-
-struct V10RejectPathSetup : public TestingSetup {
-    CKey coinbaseKey;
-    CScript coinbaseSpk;
-    std::vector<unsigned char> coinbasePkBytes;
-    std::vector<CTransaction> coinbaseTxns;
-
-    V10RejectPathSetup() : TestingSetup(CBaseChainParams::REGTEST)
-    {
-        coinbaseKey.MakeNewKey(true);
-        CPubKey pk = coinbaseKey.GetPubKey();   // local first — never .GetPubKey().begin() inline
-        BOOST_REQUIRE(pk.IsValid());
-        coinbasePkBytes.assign(pk.begin(), pk.end());
-        BOOST_REQUIRE_EQUAL(coinbasePkBytes.size(), 1312u);
-        coinbaseSpk = V1Spk();
-        BOOST_REQUIRE_EQUAL(coinbaseSpk.size(), 34u);
-
-        for (int i = 0; i < COINBASE_MATURITY_SOQ; i++) {
-            CBlock b = CreateAndProcessBlock({}, coinbaseSpk);
-            BOOST_REQUIRE_MESSAGE(b.vtx.size() > 0, "block must have coinbase");
-            coinbaseTxns.push_back(*b.vtx[0]);
-        }
-    }
-
-    CScript V1Spk()  const { return MakeVnSpk(OP_1,  coinbasePkBytes); }  // native SOQ
-    CScript V5Spk()  const { return MakeVnSpk(OP_5,  coinbasePkBytes); }  // USDSOQ authority marker
-    CScript V7Spk()  const { return MakeVnSpk(OP_7,  coinbasePkBytes); }  // USDSOQ transparent
-    CScript V10Spk() const { return MakeVnSpk(OP_10, coinbasePkBytes); }  // USDSOQ confidential (Tier A)
-
-    // Solve a block and CONNECT it (used to build the coinbase chain).
-    CBlock CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns, const CScript& spk)
-    {
-        CBlock block = BuildSolvedBlock(txns, spk);
-        std::shared_ptr<const CBlock> shared = std::make_shared<const CBlock>(block);
-        bool fNewBlock = false;
-        ProcessNewBlock(Params(), shared, true, &fNewBlock);
-        return block;
-    }
-
-    // Solve a block on top of the tip WITHOUT connecting it, so the caller can run
-    // TestBlockValidity and read the reject reason out of CValidationState.
-    CBlock BuildSolvedBlock(const std::vector<CMutableTransaction>& txns, const CScript& spk)
-    {
-        const CChainParams& cp = Params();
-        std::unique_ptr<CBlockTemplate> tmpl = BlockAssembler(cp).CreateNewBlock(spk, true);
-        BOOST_REQUIRE_MESSAGE(tmpl != nullptr, "CreateNewBlock must not return nullptr");
-        CBlock& block = tmpl->block;
-        block.vtx.resize(1);
-        {
-            // Drop the witness commitment CreateNewBlock generated for the EMPTY
-            // template, then regenerate it over our actual vtx set.
-            CMutableTransaction coinbaseMut(*block.vtx[0]);
-            coinbaseMut.vout.erase(
-                std::remove_if(coinbaseMut.vout.begin(), coinbaseMut.vout.end(),
-                    [](const CTxOut& o) {
-                        return o.scriptPubKey.size() >= 38 &&
-                               o.scriptPubKey[0] == OP_RETURN && o.scriptPubKey[1] == 0x24 &&
-                               o.scriptPubKey[2] == 0xaa && o.scriptPubKey[3] == 0x21 &&
-                               o.scriptPubKey[4] == 0xa9 && o.scriptPubKey[5] == 0xed;
-                    }),
-                coinbaseMut.vout.end());
-            coinbaseMut.vin[0].scriptWitness.stack.clear();
-            block.vtx[0] = MakeTransactionRef(std::move(coinbaseMut));
-        }
-        for (const CMutableTransaction& tx : txns)
-            block.vtx.push_back(MakeTransactionRef(tx));
-        GenerateCoinbaseCommitment(block, chainActive.Tip(), cp.GetConsensus(0));
-        unsigned int extraNonce = 0;
-        IncrementExtraNonce(&block, chainActive.Tip(), extraNonce);
-        while (!CheckProofOfWork(block.GetPoWHash(), block.nBits, cp.GetConsensus(0)))
-            ++block.nNonce;
-        return block;
-    }
-
-    // Run a solved block through the full ConnectBlock path (fJustCheck) and return
-    // the reject reason, or "" if it validated. THE assertion primitive for r0vn:
-    // "tip did not move" cannot tell a correct reject from an accidental one.
-    std::string RejectReasonFor(const std::vector<CMutableTransaction>& txns)
-    {
-        CBlock B = BuildSolvedBlock(txns, coinbaseSpk);
-        CValidationState st;
-        bool ok;
-        {
-            LOCK(cs_main);
-            ok = TestBlockValidity(st, Params(), B, chainActive.Tip(), true, true);
-        }
-        if (ok) return std::string();
-        BOOST_TEST_MESSAGE("reject: " << st.GetRejectReason()
-            << (st.GetDebugMessage().empty() ? "" : " | " + st.GetDebugMessage()));
-        return st.GetRejectReason();
-    }
-
-    // Seed a mature, spendable coin of an arbitrary witness version straight into
-    // the UTXO set. Direct pcoinsTip modification (no intermediate CCoinsViewCache:
-    // an intermediate Flush() would overwrite pcoinsTip's hashBlock and trip
-    // ConnectBlock's assertion).
-    COutPoint SeedCoin(const CScript& spk, CAmount value, uint8_t tag)
-    {
-        uint256 txid;
-        txid.begin()[0] = tag;   // distinct txid per seeded coin
-        {
-            LOCK(cs_main);
-            CCoinsModifier c = pcoinsTip->ModifyCoins(txid);
-            c->Clear();
-            c->fCoinBase = false;
-            c->nHeight   = 1;    // mature, non-coinbase
-            c->nVersion  = 2;
-            c->vout.resize(1);
-            c->vout[0].nValue       = value;
-            c->vout[0].scriptPubKey = spk;
-        }
-        return COutPoint(txid, 0);
-    }
-
-    void SignInput(CMutableTransaction& tx, unsigned int idx, const CScript& scriptCode, CAmount amount)
-    {
-        CTransaction ctxForSign(tx);
-        uint256 sighash = SignatureHash(scriptCode, ctxForSign, idx, SIGHASH_ALL,
-                                        amount, SIGVERSION_WITNESS_V0, nullptr);
-        std::vector<unsigned char> sig;
-        BOOST_REQUIRE(coinbaseKey.Sign(sighash, sig));
-        sig.push_back((unsigned char)SIGHASH_ALL);
-        tx.vin[idx].scriptWitness.stack.clear();
-        tx.vin[idx].scriptWitness.stack.push_back(sig);
-        tx.vin[idx].scriptWitness.stack.push_back(Prefixed(coinbasePkBytes));
-    }
-
-    // An AUTHORITY tx (carries the OP_5 marker, so it is exempt from per-asset
-    // conservation and takes the SOQ-ARCH-004 authority branch). `assetIn` is an
+// USDSOQ-specific on top of the shared chain fixture.
+struct V10RejectPathSetup : public DilithiumChainSetup {
+    // An AUTHORITY tx: it carries the OP_5 marker, so it is exempt from per-asset
+    // conservation and takes the SOQ-ARCH-004 authority branch. `assetIn` is an
     // optional USDSOQ input to burn; `extraOut` an optional extra output.
     // g_usdsoq_authority is never initialized in this fixture, so M-of-N signature
     // verification is skipped and the marker alone confers authority status.
@@ -232,10 +72,10 @@ struct V10RejectPathSetup : public TestingSetup {
         CTxIn f; f.prevout = COutPoint(feeCoinbase.GetHash(), 0);
         f.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(f);
 
-        CTxOut mark; mark.nValue = 10000; mark.scriptPubKey = V5Spk(); tx.vout.push_back(mark);
+        CTxOut mark; mark.nValue = 10000; mark.scriptPubKey = Spk(OP_5); tx.vout.push_back(mark);
         if (extraOut) tx.vout.push_back(*extraOut);
         CTxOut chg; chg.nValue = feeVal - 20000 - (extraOut ? extraOut->nValue : 0);
-        chg.scriptPubKey = V1Spk(); tx.vout.push_back(chg);
+        chg.scriptPubKey = Spk(OP_1); tx.vout.push_back(chg);
 
         if (assetIn) SignInput(tx, 0, assetInSpk, assetInVal);
         SignInput(tx, feeIdx, coinbaseSpk, feeVal);
@@ -296,7 +136,7 @@ BOOST_AUTO_TEST_CASE(connectblock_rejects_confidential_usdsoq_authority_output)
 {
     ScopedRegtestActivation on(Consensus::DEPLOYMENT_SOQUOBSCURA, 0);
 
-    CTxOut v10Out; v10Out.nValue = 1 * COIN; v10Out.scriptPubKey = V10Spk();
+    CTxOut v10Out; v10Out.nValue = 1 * COIN; v10Out.scriptPubKey = Spk(OP_10);
     CMutableTransaction bad = BuildAuthorityTx(coinbaseTxns[0], nullptr, 0, CScript(), &v10Out);
 
     BOOST_CHECK_EQUAL(RejectReasonFor({bad}), "bad-txns-usdsoq-authority-must-be-transparent");
@@ -309,7 +149,7 @@ BOOST_AUTO_TEST_CASE(authority_tx_with_transparent_usdsoq_output_is_accepted)
 {
     ScopedRegtestActivation on(Consensus::DEPLOYMENT_SOQUOBSCURA, 0);
 
-    CTxOut v7Out; v7Out.nValue = 1 * COIN; v7Out.scriptPubKey = V7Spk();
+    CTxOut v7Out; v7Out.nValue = 1 * COIN; v7Out.scriptPubKey = Spk(OP_7);
     CMutableTransaction good = BuildAuthorityTx(coinbaseTxns[1], nullptr, 0, CScript(), &v7Out);
 
     BOOST_CHECK_MESSAGE(RejectReasonFor({good}).empty(),
@@ -330,8 +170,8 @@ BOOST_AUTO_TEST_CASE(connectblock_rejects_confidential_usdsoq_input_in_authority
     ScopedRegtestActivation on(Consensus::DEPLOYMENT_SOQUOBSCURA, 0);
 
     const CAmount v10Val = 5 * COIN;
-    COutPoint v10op = SeedCoin(V10Spk(), v10Val, 0xa0);
-    CMutableTransaction burn = BuildAuthorityTx(coinbaseTxns[2], &v10op, v10Val, V10Spk(), nullptr);
+    COutPoint v10op = SeedCoin(Spk(OP_10), v10Val, 0xa0);
+    CMutableTransaction burn = BuildAuthorityTx(coinbaseTxns[2], &v10op, v10Val, Spk(OP_10), nullptr);
 
     BOOST_CHECK_EQUAL(RejectReasonFor({burn}), "bad-txns-usdsoq-conf-input");
 }
@@ -349,7 +189,7 @@ BOOST_AUTO_TEST_CASE(authority_burn_of_transparent_usdsoq_input_is_accepted)
     // under test. Seeding the coin directly has the same problem — a seeded v7 coin
     // is USDSOQ the supply counter never saw.
     const CAmount v7Val = 5 * COIN;
-    CTxOut v7Out; v7Out.nValue = v7Val; v7Out.scriptPubKey = V7Spk();
+    CTxOut v7Out; v7Out.nValue = v7Val; v7Out.scriptPubKey = Spk(OP_7);
     CMutableTransaction mint = BuildAuthorityTx(coinbaseTxns[3], nullptr, 0, CScript(), &v7Out);
     CBlock mintBlock = CreateAndProcessBlock({mint}, coinbaseSpk);
     BOOST_REQUIRE_MESSAGE(chainActive.Tip()->GetBlockHash() == mintBlock.GetHash(),
@@ -357,7 +197,7 @@ BOOST_AUTO_TEST_CASE(authority_burn_of_transparent_usdsoq_input_is_accepted)
 
     // BuildAuthorityTx lays out [0] = OP_5 marker, [1] = extra output, [2] = change.
     COutPoint v7op(mint.GetHash(), 1);
-    CMutableTransaction burn = BuildAuthorityTx(coinbaseTxns[4], &v7op, v7Val, V7Spk(), nullptr);
+    CMutableTransaction burn = BuildAuthorityTx(coinbaseTxns[4], &v7op, v7Val, Spk(OP_7), nullptr);
 
     BOOST_CHECK_MESSAGE(RejectReasonFor({burn}).empty(),
         "an authority burn of a transparent v7 input must connect");
@@ -384,13 +224,13 @@ BOOST_AUTO_TEST_CASE(preactivation_v10_output_is_rejected_by_soq_arch_001_not_th
     // before SOQ-ARCH-001. Funding a v10 output from plain SOQ would trip
     // bad-txns-usdsoq-not-conserved first and this test would pin the wrong rule.
     const CAmount val = 5 * COIN;
-    COutPoint v7op = SeedCoin(V7Spk(), val, 0xb7);
+    COutPoint v7op = SeedCoin(Spk(OP_7), val, 0xb7);
 
     CMutableTransaction tx; tx.nVersion = 2;
     CTxIn in; in.prevout = v7op; in.nSequence = CTxIn::SEQUENCE_FINAL;
     tx.vin.push_back(in);
-    CTxOut o; o.nValue = val; o.scriptPubKey = V10Spk(); tx.vout.push_back(o);
-    SignInput(tx, 0, V7Spk(), val);
+    CTxOut o; o.nValue = val; o.scriptPubKey = Spk(OP_10); tx.vout.push_back(o);
+    SignInput(tx, 0, Spk(OP_7), val);
 
     const std::string why = RejectReasonFor({tx});
     BOOST_CHECK_EQUAL(why, "bad-txns-confidential-not-active");
@@ -419,7 +259,7 @@ BOOST_AUTO_TEST_CASE(v10_minted_from_soq_is_rejected)
     const CAmount inVal = cb.vout[0].nValue;
     CTxIn in; in.prevout = COutPoint(cb.GetHash(), 0); in.nSequence = CTxIn::SEQUENCE_FINAL;
     tx.vin.push_back(in);
-    CTxOut o; o.nValue = inVal - 10000; o.scriptPubKey = V10Spk(); tx.vout.push_back(o);
+    CTxOut o; o.nValue = inVal - 10000; o.scriptPubKey = Spk(OP_10); tx.vout.push_back(o);
     SignInput(tx, 0, coinbaseSpk, inVal);
 
     BOOST_CHECK_EQUAL(RejectReasonFor({tx}), "bad-txns-usdsoq-not-conserved");
@@ -437,7 +277,7 @@ BOOST_AUTO_TEST_CASE(v10_minted_from_soq_is_rejected_after_activation_too)
     const CAmount inVal = cb.vout[0].nValue;
     CTxIn in; in.prevout = COutPoint(cb.GetHash(), 0); in.nSequence = CTxIn::SEQUENCE_FINAL;
     tx.vin.push_back(in);
-    CTxOut o; o.nValue = inVal - 10000; o.scriptPubKey = V10Spk(); tx.vout.push_back(o);
+    CTxOut o; o.nValue = inVal - 10000; o.scriptPubKey = Spk(OP_10); tx.vout.push_back(o);
     SignInput(tx, 0, coinbaseSpk, inVal);
 
     BOOST_CHECK_EQUAL(RejectReasonFor({tx}), "bad-txns-usdsoq-not-conserved");
@@ -452,16 +292,16 @@ BOOST_AUTO_TEST_CASE(conserving_v10_transfer_is_accepted_after_activation)
     ScopedRegtestActivation on(Consensus::DEPLOYMENT_SOQUOBSCURA, 0);
 
     const CAmount val = 5 * COIN;
-    COutPoint v10op = SeedCoin(V10Spk(), val, 0xb1);
+    COutPoint v10op = SeedCoin(Spk(OP_10), val, 0xb1);
     const CTransaction& cb = coinbaseTxns[8];
     const CAmount feeVal = cb.vout[0].nValue;
 
     CMutableTransaction tx; tx.nVersion = 2;
     { CTxIn i0; i0.prevout = v10op; i0.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(i0); }
     { CTxIn i1; i1.prevout = COutPoint(cb.GetHash(), 0); i1.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(i1); }
-    { CTxOut o; o.nValue = val;             o.scriptPubKey = V10Spk();  tx.vout.push_back(o); }
-    { CTxOut o; o.nValue = feeVal - 10000;  o.scriptPubKey = V1Spk();   tx.vout.push_back(o); }
-    SignInput(tx, 0, V10Spk(), val);
+    { CTxOut o; o.nValue = val;             o.scriptPubKey = Spk(OP_10);  tx.vout.push_back(o); }
+    { CTxOut o; o.nValue = feeVal - 10000;  o.scriptPubKey = Spk(OP_1);   tx.vout.push_back(o); }
+    SignInput(tx, 0, Spk(OP_10), val);
     SignInput(tx, 1, coinbaseSpk, feeVal);
 
     BOOST_CHECK_MESSAGE(RejectReasonFor({tx}).empty(),
@@ -483,21 +323,21 @@ BOOST_AUTO_TEST_CASE(v10_output_is_never_relay_standard)
     for (int v = 2; v <= 9; ++v) everyAllocated |= WitnessVersionBit(v);
 
     txnouttype whichType = TX_NONSTANDARD;
-    BOOST_CHECK_MESSAGE(!::IsStandard(V10Spk(), whichType, true, everyAllocated),
+    BOOST_CHECK_MESSAGE(!::IsStandard(Spk(OP_10), whichType, true, everyAllocated),
         "a v10 output must be non-standard even when v2-v9 are all active — v10 has "
         "no deployment, so it is anyone-can-spend at the script layer");
     // Two independent reasons hold it shut, and the test asserts both survive:
     // the activeWitnessVersions gate in policy.cpp, and Solver having no
     // classification for OP_10 <32> at all (TX_NONSTANDARD). Forcing the mask bit
     // on isolates the second one.
-    BOOST_CHECK_MESSAGE(!::IsStandard(V10Spk(), whichType, true, everyAllocated | WitnessVersionBit(10)),
+    BOOST_CHECK_MESSAGE(!::IsStandard(Spk(OP_10), whichType, true, everyAllocated | WitnessVersionBit(10)),
         "v10 must still be non-standard with its mask bit forced on: Solver has no "
         "TX_WITNESS_V10 form, so granting a deployment alone would NOT make it "
         "relayable — the allocation has to be completed in Solver too");
     // Solver leaves typeRet untouched when it returns false, so assert on Solver's
     // return value rather than on whichType (which is only meaningful on true).
     std::vector<std::vector<unsigned char> > vSolutions;
-    BOOST_CHECK_MESSAGE(!Solver(V10Spk(), whichType, vSolutions),
+    BOOST_CHECK_MESSAGE(!Solver(Spk(OP_10), whichType, vSolutions),
         "Solver must have no template for OP_10 <32>");
 }
 

--- a/src/test/witness_version_allocation_tests.cpp
+++ b/src/test/witness_version_allocation_tests.cpp
@@ -39,6 +39,9 @@
 #include "script/script.h"
 #include "script/standard.h"
 
+#include "chainparams.h"
+#include "consensus/params.h"
+
 #include "test/test_bitcoin.h"
 
 #include <boost/test/unit_test.hpp>
@@ -373,6 +376,75 @@ BOOST_AUTO_TEST_CASE(witness_v0_is_standard_but_unspendable)
         "v0 <32> is expected to reach the Dilithium branch (is_dilithium accepts OP_0 as well "
         "as OP_1), so it should fail on the witness rather than on the shape. If that changed, "
         "the v0/v1 aliasing in interpreter.cpp has moved");
+}
+
+// ---------------------------------------------------------------------------
+// WITNESS v3 / LatticeFold+ IS RETIRED, ON EVERY NETWORK.
+//
+// Superseded by SoquObscura. The verifier reads its own statement fields out of
+// the untrusted proof blob and every algebraic check is homogeneous in the
+// witness, so an all-zero witness satisfies all of them: a proof carrying no
+// valid signature verifies. Mainnet withdrew it; testnet, regtest and stagenet
+// were left ALWAYS_ACTIVE and therefore validated under a rule mainnet refuses,
+// which is the same state bead 2pru withdrew SoquObscura from and the same
+// reasoning. Retired on all four as of 2026-08-20.
+//
+// "Retired" is enforced here rather than asserted in a comment, because the
+// entire lesson of this sweep is that an intention nothing executes is
+// indistinguishable from an intention nobody implemented.
+//
+// ⛔ v3 MUST NOT BE REALLOCATED. It is deliberately left in the anyone-can-spend
+// soft-fork posture rather than turned into a hard script error, which keeps
+// both future options open: burning it later is a tightening (a soft fork, still
+// available), whereas un-burning it would be a hard fork. Reuse is nonetheless
+// the wrong move — v11-v16 are free, so there is no scarcity pressure, and a
+// number that meant "LatticeFold+ batch proof" for a year will stay wrong in
+// somebody's explorer, SDK or document. That is the confusion class that produced
+// the v6 collision. Allocate upward from v11.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(latticefold_is_retired_and_cannot_activate_on_any_network)
+{
+    for (const std::string& net : {CBaseChainParams::MAIN, CBaseChainParams::TESTNET,
+                                   CBaseChainParams::REGTEST, CBaseChainParams::STAGENET}) {
+        SelectParams(net);
+        const Consensus::BIP9Deployment& d =
+            Params().GetConsensus(0).vDeployments[Consensus::DEPLOYMENT_LATTICEFOLD];
+
+        // nStartTime=0 / nTimeout=0 is the terminal THRESHOLD_FAILED idiom: the BIP9
+        // state machine can never leave FAILED, so SCRIPT_VERIFY_LATTICEFOLD is never
+        // set and both entry points stay unreachable — OP_CHECKFOLDPROOF returns
+        // SCRIPT_ERR_BAD_OPCODE, and a witness-v3 program short-circuits to
+        // anyone-can-spend before the verifier is ever called.
+        BOOST_CHECK_MESSAGE(d.nStartTime == 0 && d.nTimeout == 0,
+            net + ": DEPLOYMENT_LATTICEFOLD must stay at nStartTime=0/nTimeout=0. It is "
+            "RETIRED and superseded by SoquObscura, and its verifier accepts an all-zero "
+            "witness, so activating it on any network is a forgery path");
+
+        // This deployment is queried through VersionBitsState, never through
+        // DeploymentActiveAtHeight, so an activation height here would be silently
+        // ignored — someone adding one would believe they had changed something.
+        BOOST_CHECK_MESSAGE(
+            d.nActivationHeight == Consensus::BIP9Deployment::NO_HEIGHT_ACTIVATION,
+            net + ": DEPLOYMENT_LATTICEFOLD has an nActivationHeight, which nothing reads "
+            "for this deployment. Either the query site moved to DeploymentActiveAtHeight "
+            "or someone set a field expecting it to lock the feature down");
+    }
+    SelectParams(CBaseChainParams::MAIN);
+}
+
+// v3 stays anyone-can-spend while retired, which is the posture that keeps the
+// version safe to leave alone: it is not relay-standard (Solver has no v3 form),
+// so no output can be funded into it through normal relay. If v3 ever becomes a
+// hard script error that is a deliberate burn and this test should record it.
+BOOST_AUTO_TEST_CASE(retired_v3_is_still_soft_fork_safe_not_burned)
+{
+    BOOST_CHECK_MESSAGE(ScriptVerdict(Program(3), SCRIPT_VERIFY_WITNESS) == SCRIPT_ERR_OK,
+        "witness v3 is expected to remain anyone-can-spend while retired. If it now errors, "
+        "v3 has been BURNED: reuse would need a hard fork. That is a legitimate choice but "
+        "it must be a deliberate one");
+    BOOST_CHECK_MESSAGE(!StandardWith(Program(3), WitnessVersionBit(3)),
+        "witness v3 must never be relay-standard, even with its mask bit forced on. That is "
+        "the only thing standing between anyone-can-spend and a funded v3 output");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/witness_version_allocation_tests.cpp
+++ b/src/test/witness_version_allocation_tests.cpp
@@ -1,0 +1,378 @@
+// Copyright (c) 2026 Soqucoin Labs Inc.
+// Distributed under the MIT software license.
+//
+// witness_version_allocation_tests.cpp — the witness-version allocation table,
+// derived from script/interpreter.cpp and pinned across every layer that holds
+// an opinion about it. Bead v7xm, fork-risk class F2.
+//
+// ⛔ DERIVE THE TABLE FROM interpreter.cpp, NEVER FROM A DESIGN DOCUMENT. That
+// instruction is on the bead because it has already cost us once: confidential
+// USDSOQ was allocated witness v6 while v6 was ALREADY P2WSH-Dilithium, and the
+// two predicates were byte-for-byte identical. It was green in CI, because
+// nothing compared the two layers. It moved to v10.
+//
+// FOUR LAYERS INDEPENDENTLY ENCODE THIS TABLE, and they can drift apart in
+// silence because no single compilation unit sees more than one of them:
+//
+//   1. script/interpreter.cpp   VerifyScript's shape predicates and their flag
+//                               gates. AUTHORITATIVE: this decides whether a
+//                               coin can actually be spent.
+//   2. script/standard.cpp      Solver's txnouttype. Decides whether an output
+//                               has a name, which is a precondition for relay.
+//   3. validation.cpp/policy.cpp  the activeWitnessVersions mask. Decides
+//                               whether a NAMED version relays right now.
+//   4. primitives/transaction.h asset/visibility predicates. Decides what a
+//                               consensus rule in validation.cpp thinks the
+//                               output IS.
+//
+// A version can be allocated in one and absent from another, and every such gap
+// is a real behaviour with no test behind it. The tests below assert the whole
+// grid rather than one row at a time, so any layer moving on its own fails here.
+//
+// Policy-side behaviour has its own suite (witness_standardness_tests.cpp). This
+// one exists for the SCRIPT side and for the cross-layer agreement, which is
+// where the v6 collision lived and where nothing was looking.
+
+#include "policy/policy.h"
+#include "primitives/transaction.h"
+#include "script/interpreter.h"
+#include "script/script.h"
+#include "script/standard.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+#include <vector>
+
+BOOST_FIXTURE_TEST_SUITE(witness_version_allocation_tests, BasicTestingSetup)
+
+namespace {
+
+//! OP_<version> <32-byte push> — the canonical 34-byte Soqucoin witness program.
+CScript Program(int version, size_t programLen = 32)
+{
+    CScript s;
+    s << (version == 0 ? OP_0 : CScript::EncodeOP_N(version));
+    s << std::vector<unsigned char>(programLen, 0x01);
+    return s;
+}
+
+//! A transaction to spend into, so VerifyScript has a checker to work with.
+CMutableTransaction SpendTx()
+{
+    CMutableTransaction tx;
+    tx.nVersion = 2;
+    CTxIn in;
+    in.prevout = COutPoint(uint256S("0x2222222222222222222222222222222222222222222222222222222222222222"), 0);
+    in.nSequence = CTxIn::SEQUENCE_FINAL;
+    tx.vin.push_back(in);
+    CTxOut o; o.nValue = 50 * COIN; o.scriptPubKey = CScript() << OP_TRUE;
+    tx.vout.push_back(o);
+    return tx;
+}
+
+//! Run VerifyScript against a witness program with the given flags and an
+//! arbitrary (deliberately meaningless) witness. Returns the ScriptError.
+ScriptError ScriptVerdict(const CScript& spk, unsigned int flags, size_t witnessItems = 2)
+{
+    CMutableTransaction spend = SpendTx();
+    CTransaction ctx(spend);
+    CScriptWitness w;
+    for (size_t i = 0; i < witnessItems; ++i)
+        w.stack.push_back(std::vector<unsigned char>(4, 0x00));
+    ScriptError serr = SCRIPT_ERR_OK;
+    TransactionSignatureChecker checker(&ctx, 0, 50 * COIN);
+    VerifyScript(CScript(), spk, &w, flags, checker, &serr);
+    return serr;
+}
+
+bool SolverNames(const CScript& spk, txnouttype& t)
+{
+    std::vector<std::vector<unsigned char> > sols;
+    return Solver(spk, t, sols);
+}
+
+bool StandardWith(const CScript& spk, WitnessVersionMask mask)
+{
+    txnouttype t;
+    return IsStandard(spk, t, /*witnessEnabled=*/true, mask);
+}
+
+//! One row of the table, transcribed from interpreter.cpp's predicates.
+struct Row {
+    int version;
+    const char* predicate;      // the is_* variable in VerifyScript
+    unsigned int gate;          // 0 = ungated
+    bool anyoneCanSpendWhenOff; // soft-fork posture while the gate is clear
+    bool solverNames;           // does Solver give the 34-byte form a name
+};
+
+//! ⛔ TRANSCRIBED FROM script/interpreter.cpp. If a predicate there changes, this
+//! table must change with it and the assertions below will say so.
+const Row TABLE[] = {
+    //  v   predicate               gate                              acs-when-off  named
+    {  0, "is_dilithium",           0,                                false,        true  },
+    {  1, "is_dilithium",           0,                                false,        true  },
+    {  2, "is_pat",                 SCRIPT_VERIFY_PAT,                true,         false },
+    {  3, "is_latticefold",         SCRIPT_VERIFY_LATTICEFOLD,        true,         false },
+    {  4, "is_latticebp_witness",   SCRIPT_VERIFY_SOQUOBSCURA,        true,         false },
+    {  5, "is_usdsoq_witness",      SCRIPT_VERIFY_USDSOQ,             true,         true  },
+    {  6, "is_p2wsh_dilithium",     SCRIPT_VERIFY_P2WSH_DILITHIUM,    true,         true  },
+    {  7, "is_usdsoq_holding",      SCRIPT_VERIFY_USDSOQ,             true,         true  },
+    {  8, "is_btcsoq_holding",      SCRIPT_VERIFY_BTCSOQ,             true,         true  },
+    {  9, "is_btcsoq_authority",    SCRIPT_VERIFY_BTCSOQ,             true,         true  },
+    { 10, "is_future_witness",      0,                                true,         false },
+    { 11, "is_future_witness",      0,                                true,         false },
+    { 12, "is_future_witness",      0,                                true,         false },
+    { 13, "is_future_witness",      0,                                true,         false },
+    { 14, "is_future_witness",      0,                                true,         false },
+    { 15, "is_future_witness",      0,                                true,         false },
+    { 16, "is_future_witness",      0,                                true,         false },
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// SCRIPT LAYER. Every gated version must be anyone-can-spend while its gate is
+// clear. That is the soft-fork posture and it is deliberate; it is also exactly
+// why relay policy must refuse them, which is the other half of the pair and is
+// covered in witness_standardness_tests.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(gated_versions_are_anyone_can_spend_while_dormant)
+{
+    for (const Row& r : TABLE) {
+        if (!r.anyoneCanSpendWhenOff) continue;
+        const ScriptError serr = ScriptVerdict(Program(r.version), SCRIPT_VERIFY_WITNESS);
+        BOOST_CHECK_MESSAGE(serr == SCRIPT_ERR_OK,
+            "witness v" + std::to_string(r.version) + " (" + r.predicate + ") must be "
+            "anyone-can-spend while its gate is clear, got ScriptError " + std::to_string((int)serr));
+    }
+}
+
+// Turning a gate on must actually change that version's behaviour. If it does
+// not, the branch is unreachable and the version is effectively still ungated —
+// the defect class that produced don9 and n1vf on the validation side.
+BOOST_AUTO_TEST_CASE(activating_a_gate_stops_the_version_being_anyone_can_spend)
+{
+    for (const Row& r : TABLE) {
+        if (r.gate == 0) continue;
+        const ScriptError serr = ScriptVerdict(Program(r.version), SCRIPT_VERIFY_WITNESS | r.gate);
+        BOOST_CHECK_MESSAGE(serr != SCRIPT_ERR_OK,
+            "witness v" + std::to_string(r.version) + " (" + r.predicate + ") still verified a "
+            "meaningless witness with its gate SET. Its branch is unreachable, so the gate "
+            "buys nothing and the version is anyone-can-spend in every state");
+    }
+}
+
+// A gate must move only its own version. The v6 collision was two versions
+// sharing one predicate; this is the generalised guard against that shape.
+BOOST_AUTO_TEST_CASE(gates_do_not_leak_across_versions)
+{
+    for (const Row& gated : TABLE) {
+        if (gated.gate == 0) continue;
+        for (const Row& other : TABLE) {
+            if (other.version == gated.version) continue;
+            // Versions sharing a deployment flag by design (v5/v7 on USDSOQ,
+            // v8/v9 on BTCSOQ) are expected to move together.
+            if (other.gate == gated.gate) continue;
+            if (!other.anyoneCanSpendWhenOff) continue;
+            const ScriptError serr = ScriptVerdict(Program(other.version),
+                                                   SCRIPT_VERIFY_WITNESS | gated.gate);
+            BOOST_CHECK_MESSAGE(serr == SCRIPT_ERR_OK,
+                "activating the gate for v" + std::to_string(gated.version) + " changed the "
+                "verdict for v" + std::to_string(other.version) + ". Two versions are sharing a "
+                "predicate, which is the v6 / P2WSH-Dilithium collision shape");
+        }
+    }
+}
+
+// Shapes outside the allocated forms must fail CLOSED at the script layer, not
+// silently succeed. This is the property that makes an unallocated version safe
+// to leave alone.
+BOOST_AUTO_TEST_CASE(unallocated_shapes_fail_closed)
+{
+    // A 22-byte v1 program: right version, wrong program length.
+    BOOST_CHECK_MESSAGE(
+        ScriptVerdict(Program(1, 20), SCRIPT_VERIFY_WITNESS) == SCRIPT_ERR_DISALLOWED_CLASSICAL_CRYPTO,
+        "a witness program of a length no allocated form uses must be rejected outright");
+
+    // A bare push with no version opcode at all.
+    CScript notWitness;
+    notWitness << std::vector<unsigned char>(32, 0x01);
+    BOOST_CHECK_MESSAGE(
+        ScriptVerdict(notWitness, SCRIPT_VERIFY_WITNESS) == SCRIPT_ERR_DISALLOWED_CLASSICAL_CRYPTO,
+        "a non-witness script must be rejected outright, not treated as a future version");
+}
+
+// ---------------------------------------------------------------------------
+// CROSS-LAYER AGREEMENT. Each of these caught, or would have caught, a real
+// divergence. They assert the CURRENT truth so that any layer moving alone is
+// visible; where the current truth is itself a defect it is named as such and
+// tracked on a bead, rather than being quietly encoded as correct.
+// ---------------------------------------------------------------------------
+
+// Solver's named set and the script layer's allocated set are NOT the same set,
+// and the difference has consequences. v2, v3 and v4 are allocated in
+// interpreter.cpp and unnamed by Solver, so they can never be relay-standard no
+// matter what the activation mask says.
+BOOST_AUTO_TEST_CASE(solver_named_set_matches_the_transcribed_table)
+{
+    for (const Row& r : TABLE) {
+        txnouttype t;
+        const bool named = SolverNames(Program(r.version), t);
+        BOOST_CHECK_MESSAGE(named == r.solverNames,
+            "Solver " + std::string(named ? "now names" : "no longer names") + " witness v" +
+            std::to_string(r.version) + ", which the table does not expect. Naming a version is "
+            "what makes it eligible for relay, so this is a policy change and needs to be a "
+            "deliberate one");
+    }
+}
+
+// ⚠️ THE MASK BITS FOR v2, v3 AND v4 ARE DEAD. validation.cpp computes them from
+// DEPLOYMENT_CHECKPATAGG, DEPLOYMENT_LATTICEFOLD and DEPLOYMENT_SOQUOBSCURA, and
+// IsStandard can never consult them, because Solver refuses those shapes first.
+//
+// The consequence is not cosmetic: when SoquObscura activates, a confidential v4
+// output will be consensus-valid and still non-standard, so it cannot propagate
+// through the mempool at all. The privacy layer would be switched on and unable
+// to relay a single transaction. Same for PAT (v2) and LatticeFold (v3).
+//
+// Pinned here rather than fixed: teaching Solver a v4 form is a relay-policy
+// change that belongs with the SoquObscura activation decision, not with a test
+// sweep. Bead v7xm F2.
+BOOST_AUTO_TEST_CASE(mask_bits_for_v2_v3_v4_cannot_affect_standardness)
+{
+    for (int v : {2, 3, 4}) {
+        BOOST_CHECK_MESSAGE(!StandardWith(Program(v), WitnessVersionBit(v)),
+            "witness v" + std::to_string(v) + " became standard once its own mask bit was set. "
+            "If Solver has learned this form, the dead-mask-bit finding is resolved and this "
+            "test should be updated rather than deleted");
+    }
+}
+
+// The asset predicates in transaction.h must agree with the script layer about
+// which opcode means what. This is the exact comparison nobody was making when
+// confidential USDSOQ was given v6, a version P2WSH-Dilithium already owned.
+BOOST_AUTO_TEST_CASE(asset_predicates_agree_with_the_script_layer)
+{
+    CTxOut out;
+    out.nValue = 1 * COIN;
+
+    struct Case { int version; bool usdsoq; bool btcsoq; bool confidential; bool nativeSOQ; };
+    const Case cases[] = {
+        //  v    IsUSDSOQ  IsBTCSOQ  IsConfidential  IsNativeSOQ
+        {   1,   false,    false,    false,          true  },   // plain Dilithium
+        {   4,   false,    false,    true,           true  },   // confidential SOQ, Tier B
+        {   6,   false,    false,    false,          true  },   // P2WSH-Dilithium, NOT confidential USDSOQ
+        {   7,   true,     false,    false,          false },   // transparent USDSOQ
+        {   8,   false,    true,     false,          false },   // BTCSOQ holding
+        {  10,   false,    false,    true,           false },   // confidential USDSOQ, Tier A
+        {  11,   false,    false,    false,          true  },   // unallocated: must claim nothing
+    };
+
+    for (const Case& c : cases) {
+        out.scriptPubKey = Program(c.version);
+        BOOST_CHECK_MESSAGE(out.IsUSDSOQ() == c.usdsoq,
+            "IsUSDSOQ() disagrees with the table for witness v" + std::to_string(c.version));
+        BOOST_CHECK_MESSAGE(out.IsBTCSOQ() == c.btcsoq,
+            "IsBTCSOQ() disagrees with the table for witness v" + std::to_string(c.version));
+        BOOST_CHECK_MESSAGE(out.IsConfidential() == c.confidential,
+            "IsConfidential() disagrees with the table for witness v" + std::to_string(c.version));
+        BOOST_CHECK_MESSAGE(out.IsNativeSOQ() == c.nativeSOQ,
+            "IsNativeSOQ() disagrees with the table for witness v" + std::to_string(c.version) +
+            ". This predicate decides what the miner may claim as fees, so a wrong answer here "
+            "is an inflation bug, not a classification nit");
+    }
+
+    // The collision itself, stated directly: v6 and v10 must never be the same
+    // output. An earlier revision made IsV6ConfidentialUSDSOQ byte-for-byte
+    // identical to is_p2wsh_dilithium, and CI was green.
+    CTxOut v6; v6.scriptPubKey = Program(6);
+    CTxOut v10; v10.scriptPubKey = Program(10);
+    BOOST_CHECK_MESSAGE(!v6.IsV10ConfidentialUSDSOQ(),
+        "a v6 P2WSH-Dilithium covenant output is being classified as confidential USDSOQ. "
+        "That is the exact collision that was caught and moved to v10");
+    BOOST_CHECK_MESSAGE(v10.IsV10ConfidentialUSDSOQ(), "v10 must be confidential USDSOQ");
+    BOOST_CHECK(!v6.IsConfidential());
+}
+
+// The free range, derived rather than asserted from memory. Anything an
+// allocation touches at ANY layer is taken; the remainder is what a future
+// feature may use. Deriving it is the point: the v6 collision happened because
+// someone consulted a document.
+BOOST_AUTO_TEST_CASE(free_witness_versions_are_v11_through_v16)
+{
+    std::vector<int> free_;
+    for (int v = 2; v <= 16; ++v) {
+        CTxOut o; o.scriptPubKey = Program(v);
+        txnouttype t;
+        const bool claimedByScript  = ScriptVerdict(Program(v), SCRIPT_VERIFY_WITNESS) == SCRIPT_ERR_OK &&
+                                      v <= 9;   // v10-v16 are anyone-can-spend by default, not claimed
+        const bool claimedBySolver  = SolverNames(Program(v), t);
+        const bool claimedByAsset   = o.IsUSDSOQ() || o.IsBTCSOQ() || o.IsConfidential() ||
+                                      o.IsV10ConfidentialUSDSOQ() || o.IsV4ConfidentialSOQ();
+        if (!claimedByScript && !claimedBySolver && !claimedByAsset) free_.push_back(v);
+    }
+
+    const std::vector<int> expected = {11, 12, 13, 14, 15, 16};
+    BOOST_CHECK_MESSAGE(free_ == expected,
+        "the free witness-version range has moved. v10 is TAKEN (confidential USDSOQ, Tier A) "
+        "even though interpreter.cpp still treats it as a generic future version, which is the "
+        "half-allocation tracked on bead jzg0. Derive this list from the code before allocating "
+        "anything, never from a design document");
+}
+
+// ⚠️ WITNESS v0 IS RELAY-STANDARD AND NOT SPENDABLE AS ITS NAME IMPLIES.
+// Solver names both v0 forms, so IsStandard accepts them with an empty mask (the
+// v2-v16 gate does not cover v0). The script layer disagrees with both:
+//
+//   v0 <20>  P2WPKH-shaped. VerifyScript requires a 34-byte program for the
+//            Dilithium path, so a 22-byte script matches nothing and is rejected
+//            outright. The output relays, confirms, and can never be spent.
+//   v0 <32>  P2WSH-shaped to Solver, but is_dilithium accepts OP_0 exactly like
+//            OP_1, so the script layer treats the program as SHA256(pubkey) and
+//            demands a Dilithium signature. A real script hash is not a pubkey
+//            hash, so those funds are gone too.
+//
+// Exposure is narrow: utiladdress.cpp hardcodes witness version 1, so no address
+// encodes to v0 and only a hand-built scriptPubKey gets there. It is not zero,
+// because a generic Bitcoin library pointed at our HRP produces v0 P2WPKH by
+// default, and that is precisely what an exchange integrating from scratch
+// reaches for. Same family as the SDK builders that hardcoded the stagenet HRP.
+//
+// Pinned, not fixed. The fix is a policy change (refuse v0 the way v5-v9 are
+// refused while dormant), which is cheap and consensus-neutral, but the wallet
+// and script/standard.cpp still carry v0 plumbing and that wants its own look.
+// Bead v7xm F2.
+BOOST_AUTO_TEST_CASE(witness_v0_is_standard_but_unspendable)
+{
+    const CScript keyhashShape   = Program(0, 20);   // OP_0 <20>, 22 bytes
+    const CScript scripthashShape = Program(0, 32);  // OP_0 <32>, 34 bytes
+
+    BOOST_CHECK_MESSAGE(StandardWith(keyhashShape, 0),
+        "if v0 <20> has become non-standard the divergence is fixed and this test should be "
+        "updated rather than deleted");
+    BOOST_CHECK_MESSAGE(StandardWith(scripthashShape, 0),
+        "if v0 <32> has become non-standard the divergence is fixed");
+
+    BOOST_CHECK_MESSAGE(
+        ScriptVerdict(keyhashShape, SCRIPT_VERIFY_WITNESS) == SCRIPT_ERR_DISALLOWED_CLASSICAL_CRYPTO,
+        "a relay-standard v0 <20> output must at least fail CLOSED at the script layer. "
+        "Standard plus spendable-by-anyone would be the v5-v9 fund-loss shape again; "
+        "standard plus spendable-by-nobody is a burn, which is what this asserts");
+
+    // v0 <32> takes the Dilithium branch, so it fails on the signature rather
+    // than on the shape. Different error, same practical outcome for a caller
+    // who thought they were creating P2WSH.
+    const ScriptError v0script = ScriptVerdict(scripthashShape, SCRIPT_VERIFY_WITNESS);
+    BOOST_CHECK_MESSAGE(v0script != SCRIPT_ERR_OK,
+        "v0 <32> must not be anyone-can-spend");
+    BOOST_CHECK_MESSAGE(v0script != SCRIPT_ERR_DISALLOWED_CLASSICAL_CRYPTO,
+        "v0 <32> is expected to reach the Dilithium branch (is_dilithium accepts OP_0 as well "
+        "as OP_1), so it should fail on the witness rather than on the shape. If that changed, "
+        "the v0/v1 aliasing in interpreter.cpp has moved");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4705,8 +4705,20 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     //   * no witness layout satisfies both script verification and key-image
     //     extraction (C5, same document).
     //
-    // Removal belongs to Phase 2 of that plan, after the crypto rebuild. Left in
-    // place, clearly labelled, rather than deleted mid-Gate-0.
+    // DECIDED 2026-08-20: leave it here, labelled, until Phase 2 of that plan
+    // removes it after the crypto rebuild. Waiting is safe because the hazard is
+    // that dead scaffolding gets MISTAKEN for enforcement, and that is closed by
+    // this comment plus an executing test rather than by deletion. The code being
+    // present costs nothing while the deployment is NOT_SCHEDULED everywhere.
+    //
+    // ⚠️ WHEN PHASE 2 DELETES THIS, DELETE THE DisconnectBlock MIRROR WITH IT.
+    // That loop WORKS (ApplyTxInUndo restores the inputs before it runs), so it is
+    // the half that looks correct in review and survives a careless deletion,
+    // which would leave erase-without-write. Delete
+    // test/soquobscura_keyimage_deadcode_tests.cpp in the same commit too: it
+    // asserts this loop does not fire, and once the loop is gone that assertion
+    // is vacuous — a green test proving nothing, which is the exact failure mode
+    // this whole arc is about.
     //
     // Original intent, for whoever picks up Phase 2: witness v4 confidential
     // inputs were to carry the key image as the LAST stack element, after the

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4665,19 +4665,54 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     // =========================================================================
     // SOQ-ARCH-001 Phase 2: Key-Image Double-Spend Protection
-    // When DEPLOYMENT_SOQUOBSCURA is active, extract key-images from confidential
-    // transaction witness data and enforce uniqueness. A key-image that has
-    // already been recorded in a previous block constitutes a double-spend of
-    // a confidential output.
     //
-    // Witness v4 confidential inputs carry their key-image as the LAST element
-    // of the witness stack (after the ring signature and range proof data).
-    // Format: [ring_sig_data...] [range_proof_data...] [key_image_bytes]
+    // ⛔⛔ THIS BLOCK IS DEAD CODE AND ENFORCES NOTHING. It is residue of a
+    // SUPERSEDED design. Do not read it as protection, and do not "fix" it
+    // without reading the two paragraphs below. Bead p4wv.
     //
-    // The key-image bytes are hashed to a 32-byte LatticeKeyImageHash via
-    // SHA256 before storage (see consensus/privacy.h) for LevelDB efficiency.
+    // WHY IT CANNOT RUN. Inputs are resolved through
+    // view.AccessCoins(...)->IsAvailable(), but this is the LAST pass over the
+    // block and UpdateCoins spent every input during the FIRST pass, so the
+    // guard skips all of them and the body never executes. Four reject strings
+    // are therefore unreachable (bad-txns-conf-no-witness,
+    // bad-txns-conf-empty-keyimage, bad-txns-conf-duplicate-keyimage,
+    // bad-txns-conf-intrablock-duplicate-keyimage), vBlockKeyImages is always
+    // empty, and WriteKeyImage below is never called, so the DB that the
+    // cross-block check consults is never populated by the connect path. This
+    // is the THIRD instance of one root cause: the freeze guard (bead e2n) and
+    // the USDSOQ input-isolation rule (bead 0r2) were dead for exactly this
+    // reason. The asymmetry is visible in this file: DisconnectBlock's mirror
+    // loop works, and says why — ApplyTxInUndo has RESTORED the inputs there.
+    // Proven by execution in test/soquobscura_keyimage_deadcode_tests.cpp.
     //
-    // ConnectBlock writes new key-images; DisconnectBlock erases them.
+    // WHY THE FIX IS NOT "READ BLOCK UNDO". Key images exist only to make RING
+    // SIGNATURES double-spend-safe, and the ratified design CUT ring signatures,
+    // stealth addresses and decoys from launch
+    // (DL-LATTICEBP-STATE-ANALYSIS-2026-07-18 Part II.6, "Key images leave
+    // launch scope"; Phase 2, "remove LF+/ring/key-image opcodes from launch
+    // rules"; DL-SOQUOBSCURA-NAMING-POLICY). Spends are outpoint-addressed
+    // today, so the UTXO set already prevents double-spends and this layer adds
+    // nothing. Reviving it as written would introduce THREE live defects:
+    //   * the "key image" is just wit.stack.back(), which on every witness
+    //     layout the node accepts today is the PUBKEY, not anything bound to the
+    //     outpoint. Two honest spends by one owner collide, and the second is
+    //     rejected as a double-spend of an output it never touched (pinned by
+    //     the second case in that test file);
+    //   * WriteKeyImage below has no !fJustCheck guard, so every
+    //     getblocktemplate dry-run would persist key images and the next poll of
+    //     the same template would reject it as a duplicate. BUG-18 verbatim;
+    //     already filed as H2 in the state analysis;
+    //   * no witness layout satisfies both script verification and key-image
+    //     extraction (C5, same document).
+    //
+    // Removal belongs to Phase 2 of that plan, after the crypto rebuild. Left in
+    // place, clearly labelled, rather than deleted mid-Gate-0.
+    //
+    // Original intent, for whoever picks up Phase 2: witness v4 confidential
+    // inputs were to carry the key image as the LAST stack element, after the
+    // ring signature and range proof — [ring_sig][range_proof][key_image] —
+    // hashed to a 32-byte LatticeKeyImageHash for LevelDB (consensus/privacy.h).
+    // ConnectBlock writes; DisconnectBlock erases.
     // =========================================================================
     std::vector<LatticeKeyImageHash> vBlockKeyImages;  // Track for DisconnectBlock undo
 


### PR DESCRIPTION
Continues Gate 0 after #38 merged. Those five commits landed; these five were pushed to the same branch afterwards and were therefore **not** in that merge — verified with `merge-base --is-ancestor`, not by looking at a badge.

Same posture as #38: nothing changes behaviour on any live network, and every rule touched is unreachable while its deployment is dormant.

## `p4wv` — the key-image protection is dead, and superseded

`52be6a3fa`, `44c516b40`

The loop resolves inputs through `view.AccessCoins(...)->IsAvailable()` in `ConnectBlock`'s **last** pass, after `UpdateCoins` spent them all, so it never executes. Third instance of the `e2n` pattern; the asymmetry is visible in the same file, since `DisconnectBlock`'s mirror works and its comment says why.

**Proven by execution, not by reading.** A block spending two confidential inputs whose key images are byte-identical connects, and `HaveKeyImage` is then queried directly and finds nothing — so it cannot be read as "the loop ran and the images differed".

⛔ **The fix I originally filed on that bead — read block undo — was wrong**, and I wrote it before reading the design log. Key images exist only to make **ring signatures** double-spend-safe, and ring signatures were cut from launch by ratified decision (`consensus/privacy.h` calls that design superseded; `DL-LATTICEBP-STATE-ANALYSIS` II.6 records that key images leave launch scope). Reviving it would restore three live defects: H2 and C5, already on file, plus a new one that is the real blocker — the key image is `wit.stack.back()`, which on every accepted layout is the **pubkey**, so two honest spends by one owner collide and the second is rejected as a double-spend of an output it never touched.

Decided: leave it labelled until Phase 2. Nothing removed. This also corrects §2 item 3 of that state analysis, which reported the detection logic as working.

## `v7xm` F2 — the witness-version allocation table

`1a81d0b3d`

Derived mechanically from `interpreter.cpp` and pinned across the four layers that each hold an opinion and none of which sees another. That blind spot is where the v6 / P2WSH-Dilithium collision lived.

Confirmed by execution: every gate is real, gates do not leak across versions except the deliberate v5/v7 and v8/v9 pairs, unallocated shapes fail closed, and **the free range derives to v11-v16, not v10-v16**.

| bead | finding, pinned not fixed |
|---|---|
| `845h` **P1** | mask bits for v2/v3/v4 are **dead** — Solver has no form for those versions, so `IsStandard` can never consult them. **Activating SoquObscura would leave confidential v4 outputs consensus-valid and non-standard**, unable to relay at all. Mirror of the v5-v9 defect. |
| `trp6` **P2** | witness v0 is relay-standard and **unspendable in both shapes**. Fails closed (a burn, not the v5-v9 theft shape) and the test asserts that so it cannot become the worse variant. v0 and v1 are also script-layer aliases. |

## LatticeFold+ retired on every network

`12019d361` — Casey's call: deprecated in favour of SoquObscura, permanently locked down.

Mainnet had withdrawn it. **Testnet, regtest and stagenet were still `ALWAYS_ACTIVE`**, so three networks had both entry points live against a verifier that mainnet's own comment describes as accepting an all-zero witness. Stagenet, the *mainnet rehearsal network*, was validating under a rule mainnet refuses — the same state and reasoning as the SoquObscura withdrawal (`2pru`), which LatticeFold was simply missed by. Bead `2bdr`.

**Verified against the live chain first**, because clearing the flag is not uniformly a relaxation: for a v3 program it means anyone-can-spend, but for `OP_CHECKFOLDPROOF` inside a script it means `SCRIPT_ERR_BAD_OPCODE`, a tightening that could invalidate history. All 48,733 stagenet blocks: **zero v3 outputs**; six v6 covenants, two spent, both witnessScripts `push32 OP_NOP7 push32 OP_NOP7 OP_1`. `OP_CHECKFOLDPROOF` has never executed.

⛔ `nActivationHeight` is a **no-op** for this deployment (queried via `VersionBitsState`), which is what bead `nv7q` had recommended setting. The test asserts both the terminal idiom and the *absence* of an activation height so nobody repeats it.

v3 is deliberately left anyone-can-spend rather than burned — burning stays available later as a soft fork, un-burning would not. **Allocate upward from v11.**

## `v7xm` F4 — the consensus digest

`0f4471d3e`

F4's proven instance was a strict-aliasing violation that made seed-derived public data depend on the optimisation level: a chain split from a build flag, invisible because each build was internally consistent (`nh6m`). Nothing catches that from inside one build. It needs a single value that summarises consensus and can be diffed against another build, and no such value existed.

One SHA256 over every `Consensus::Params` field on all four networks at fourteen heights, every deployment field, each genesis block plus its hash, merkle root and **PoW hash**, the subsidy at thirteen heights, and the interpreter's verdict for all seventeen witness versions across two program lengths and six flag sets. It deliberately runs **code**, not just constants — scrypt, HKDF and the interpreter are where a codegen difference could actually express itself.

Two jobs from one artifact: a freeze tripwire in CI, and the comparator for the cross-build sweep. A second case asserts stability across three runs in the same binary, since a wandering digest would make every cross-build comparison worthless.

Pinned on Apple clang 21 / arm64 / -O2. **CI executes this suite on Linux x86_64 under GCC, so merging it measures the compiler and architecture axis rather than only asserting it.**

## Expected CI

Linux x86_64 will report the **three deliberate forgery failures** in `soquobscura_degenerate_witness_tests`, exactly as `main` already does. Any *fourth* failure is real. In particular a `consensus_digest_tests` failure there would mean the digest differs between Apple clang arm64 and GCC x86-64, which is an `nh6m`-class finding and a launch blocker.
