### PR TITLE
Freeze prep: close the pre-freeze list (mxph, iwzf, eolo) and bump to v2.0.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl require autoconf 2.60 (AS_ECHO/AS_ECHO_N)
 AC_PREREQ([2.60])
-define(_CLIENT_VERSION_MAJOR, 1)
-define(_CLIENT_VERSION_MINOR, 6)
+define(_CLIENT_VERSION_MAJOR, 2)
+define(_CLIENT_VERSION_MINOR, 0)
 define(_CLIENT_VERSION_REVISION, 0)
 define(_CLIENT_VERSION_BUILD, 0)
 define(_CLIENT_VERSION_IS_RELEASE, true)
@@ -280,6 +280,34 @@ if test "x$enable_werror" = "xyes"; then
   fi
   AX_CHECK_COMPILE_FLAG([-Werror=vla],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=vla"],,[[$CXXFLAG_WERROR]])
 fi
+
+dnl ============================================================================
+dnl -fno-strict-aliasing: CONSENSUS CORRECTNESS, NOT A WARNING PREFERENCE.
+dnl
+dnl This codebase has already had a strict-aliasing violation change
+dnl consensus-visible behaviour: an aliasing bug in the AES-CTR path made
+dnl seed-derived PUBLIC data depend on the compiler's optimisation level, i.e. a
+dnl chain split produced by a build flag (bead nh6m). That class is silent by
+dnl construction. There is no warning, no test failure and no crash; each build
+dnl is internally consistent and simply disagrees with the other one. It was
+dnl found by diffing two builds, not by running tests.
+dnl
+dnl The flag cannot introduce a bug, because it only makes the compiler more
+dnl conservative, and the cost is bounded: the hot paths here are scrypt and
+dnl SHA256, which are hand-written and largely unaffected by type-based alias
+dnl analysis. For a binary that decides consensus, that trade is one-sided.
+dnl Bead eolo.
+dnl
+dnl ⛔ DELIBERATELY OUTSIDE THE CXXFLAGS_overridden GUARD BELOW. The warning
+dnl flags there are skipped whenever the caller passes explicit CXXFLAGS, which
+dnl is exactly what release builds, distro packagers and the F4 optimisation
+dnl sweep all do. A correctness flag that silently disappears for the builds
+dnl that matter most would be worse than not having it.
+dnl ============================================================================
+AX_CHECK_COMPILE_FLAG([-fno-strict-aliasing],
+                      [CXXFLAGS="$CXXFLAGS -fno-strict-aliasing"
+                       CFLAGS="$CFLAGS -fno-strict-aliasing"],
+                      [AC_MSG_WARN([-fno-strict-aliasing not supported; consensus builds rely on it, see bead eolo])])
 
 if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wall],[CXXFLAGS="$CXXFLAGS -Wall"],,[[$CXXFLAG_WERROR]])

--- a/src/amount.h
+++ b/src/amount.h
@@ -20,16 +20,50 @@ static const CAmount CENT = 1000000;
 
 extern const std::string CURRENCY_UNIT;
 
-/** No amount larger than this (in satoshi) is valid.
+/** No amount larger than this (in shors) is valid.
  *
- * Note that this constant is *not* the total money supply, which in Bitcoin
- * currently happens to be less than 21,000,000 BTC for various reasons, but
- * rather a sanity check. As this sanity check is used by consensus-critical
- * validation code, the exact value of the MAX_MONEY constant is consensus
- * critical; in unusual circumstances like a(nother) overflow bug that allowed
- * for the creation of coins out of thin air modification could lead to a fork.
+ * ⛔ ON SOQUCOIN THIS IS A PER-TRANSACTION CEILING, NOT A SUPPLY BOUND, AND IT
+ * STRUCTURALLY CANNOT BE ONE. Bitcoin sets MAX_MONEY to its total supply, which
+ * makes MoneyRange a loose sanity check no honest value approaches. Neither half
+ * of that holds here:
+ *
+ *   1. THE SUPPLY IS UNBOUNDED. The emission schedule has a perpetual tail of
+ *      2,500 SOQ per block (soqucoin.cpp GetSoqucoinBlockSubsidy), roughly
+ *      1.31B SOQ a year on top of the ~46.875B head supply. No constant can
+ *      bound a supply that grows forever.
+ *   2. EVEN THE HEAD SUPPLY WILL NOT FIT. Accumulators ADD BEFORE THEY CHECK,
+ *      e.g. validation.cpp:1947 does `nValueIn += ...` and only then calls
+ *      MoneyRange. So a sum of two in-range values must not overflow, which
+ *      requires 2 * MAX_MONEY <= INT64_MAX, i.e. MAX_MONEY <= ~46.1B coins.
+ *      Head supply is 46.875B, already past that line. Raising MAX_MONEY to
+ *      "cover the supply" would silently reintroduce the signed-overflow bug
+ *      this constant exists to prevent, and the MoneyRange check downstream
+ *      would be reading an already-wrapped value.
+ *
+ * So 10B coins is a deliberate cap with a 9.2x overflow margin, and the
+ * consequence is real and worth knowing: NO SINGLE TRANSACTION MAY MOVE MORE
+ * THAN 10B SOQ on either side, so a treasury or exchange consolidation larger
+ * than that must be split. (For scale, the largest sum handled to date is the
+ * 4.45B the pool consolidation trapped.)
+ *
+ * The previous comment here claimed "maximum of 100B coins". That was wrong
+ * twice over: the value is 10B, not 100B, and 100B coins in shors is 1e19,
+ * which does not fit in an int64 at all. Do not "fix" the value to match a
+ * comment. See bead iwzf.
+ *
+ * As this sanity check is used by consensus-critical validation code, the exact
+ * value is consensus critical; changing it after genesis is a hard fork.
  * */
-static const CAmount MAX_MONEY = 10000000000 * COIN; // Soqucoin: maximum of 100B coins (given some randomness), max transaction 10,000,000,000
+static const CAmount MAX_MONEY = 10000000000 * COIN; // 10B SOQ, a per-TX ceiling
+
+//! The overflow bound argued for above, enforced rather than trusted: every
+//! accumulator in the validation path adds two in-range amounts before it calls
+//! MoneyRange, so twice MAX_MONEY has to remain representable.
+static_assert(MAX_MONEY > 0 && MAX_MONEY <= 4611686018427387903LL,
+              "MAX_MONEY must satisfy 2 * MAX_MONEY <= INT64_MAX: validation "
+              "accumulators sum before they range-check, so a larger value makes "
+              "the check read an already-overflowed total");
+
 inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
 /**

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -95,7 +95,28 @@ static const CAmount DEFAULT_HARD_DUST_LIMIT = DEFAULT_DUST_LIMIT / 10;
  * SCRIPT_VERIFY_CTV (BIP 119: OP_CHECKTEMPLATEVERIFY, bit 7)
  * SCRIPT_VERIFY_APO (BIP 118: SIGHASH_ANYPREVOUT, bit 8)
  * SCRIPT_VERIFY_CSFS (BIP 348: OP_CHECKSIGFROMSTACK, bit 9)
- * SCRIPT_VERIFY_SCRIPT_RESTORE (Satoshi restoration: OP_MUL/DIV/MOD/CAT/etc)
+ *
+ * ⛔ SCRIPT_VERIFY_SCRIPT_RESTORE WAS ON THIS LIST AND HAD TO COME OFF IT.
+ * The three flags above ADD ENFORCEMENT: setting one makes the mempool reject
+ * scripts it used to accept, and consensus keeps all three NOT_SCHEDULED on
+ * mainnet, so omitting them here leaves policy and consensus agreeing at
+ * off/off until activation brings them together. That is the reasoning below
+ * and it is sound for them.
+ *
+ * SCRIPT_RESTORE is not that kind of flag. It ADDS CAPABILITY: with it OP_MUL
+ * and friends execute, and WITHOUT it they are silent NO-OPS rather than
+ * errors. Consensus sets it unconditionally from genesis (validation.cpp,
+ * "Satoshi script restoration: always-active"), so there is no dormant state to
+ * agree at. Omitting it produced a permanent split in which the same script has
+ * two truth values:
+ *
+ *     0 7 OP_MUL      consensus -> ok[]      (0, FALSE)
+ *                     mempool   -> ok[,07]   (operands left, top is TRUE)
+ *
+ * A transaction spending such an output was accepted and relayed by every node
+ * and could never be mined: accept-then-reject, which is the template-stalling
+ * failure live bug daf9fd85 produced. Grouping a capability flag with three
+ * enforcement flags is what caused it. Bead mxph.
  *
  * These are NOT included in STANDARD_SCRIPT_VERIFY_FLAGS because:
  *
@@ -123,6 +144,11 @@ static const CAmount DEFAULT_HARD_DUST_LIMIT = DEFAULT_DUST_LIMIT / 10;
  *    validator (SOQ-COV-011).
  */
 static const unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY_FLAGS |
+                                                         // Consensus sets this for every block
+                                                         // unconditionally; relay must match or the
+                                                         // restored opcodes mean two different
+                                                         // things on the two paths (bead mxph).
+                                                         SCRIPT_VERIFY_SCRIPT_RESTORE |
                                                          SCRIPT_VERIFY_DERSIG |
                                                          SCRIPT_VERIFY_STRICTENC |
                                                          SCRIPT_VERIFY_MINIMALDATA |

--- a/src/test/consensus_digest_tests.cpp
+++ b/src/test/consensus_digest_tests.cpp
@@ -34,6 +34,8 @@
 // are where a codegen difference could actually express itself.
 
 #include "chainparams.h"
+#include "amount.h"
+#include "consensus/consensus.h"
 #include "consensus/params.h"
 #include "crypto/sha256.h"
 #include "primitives/block.h"
@@ -172,9 +174,25 @@ void AbsorbScriptVerdicts(DigestBuilder& d)
     }
 }
 
+//! Network-independent consensus constants. These live in headers rather than
+//! chainparams, so nothing above would notice them changing — and MAX_MONEY in
+//! particular is consensus-critical (MoneyRange gates every value check) and was
+//! not covered by this digest until 2026-08-20.
+void AbsorbGlobalLimits(DigestBuilder& d)
+{
+    d.I64(MAX_MONEY);
+    d.I64(COIN);
+    d.I64(MAX_BLOCK_WEIGHT);
+    d.I64(MAX_BLOCK_SERIALIZED_SIZE);
+    d.I64(MAX_BLOCK_BASE_SIZE);
+    d.I64(MAX_BLOCK_SIGOPS_COST);
+    d.I64(WITNESS_SCALE_FACTOR);
+}
+
 uint256 ComputeConsensusDigest()
 {
     DigestBuilder d;
+    AbsorbGlobalLimits(d);
 
     for (const std::string& net : {CBaseChainParams::MAIN, CBaseChainParams::TESTNET,
                                    CBaseChainParams::REGTEST, CBaseChainParams::STAGENET}) {
@@ -234,9 +252,20 @@ BOOST_AUTO_TEST_CASE(consensus_digest_is_pinned)
     const uint256 digest = ComputeConsensusDigest();
     BOOST_TEST_MESSAGE("CONSENSUS DIGEST: " << digest.ToString());
 
-    // Pinned 2026-08-20 on the Gate 0 branch, Apple clang 21 arm64 -O2.
+    // Pinned 2026-08-20, Apple clang 21 arm64 -O2, at the v2.0.0 freeze candidate.
+    //
+    // Moved from 0489e98d4d6465a42ef90a0d456c70804794b914cdd0e502ad0bbae3928a9fe7
+    // for ONE reason, verified by isolation rather than assumed: AbsorbGlobalLimits
+    // was added, bringing MAX_MONEY and the block limits under the digest for the
+    // first time. Rebuilding with that call removed reproduced the old value
+    // byte-for-byte on the new binary, which also proves the three other changes
+    // in the same commit moved nothing in consensus:
+    //   * -fno-strict-aliasing (bead eolo) perturbs no computed value;
+    //   * the v2.0.0 version bump does not reach consensus;
+    //   * adding SCRIPT_VERIFY_SCRIPT_RESTORE to relay policy (bead mxph) is
+    //     policy, not consensus.
     const std::string expected =
-        "0489e98d4d6465a42ef90a0d456c70804794b914cdd0e502ad0bbae3928a9fe7";
+        "5effd2ed86326721613bddbbe2002555b217e1008c27668557027dcacf6a7ce0";
 
     BOOST_CHECK_MESSAGE(digest.ToString() == expected,
         "consensus digest is " + digest.ToString() + ", expected " + expected +

--- a/src/test/mempool_consensus_parity_tests.cpp
+++ b/src/test/mempool_consensus_parity_tests.cpp
@@ -25,8 +25,12 @@
 // So the invariant to hold is: EVERY script flag ConnectBlock sets must also be
 // set by the mempool. Extra strictness in the mempool is permitted.
 //
-// ⛔ THAT INVARIANT DOES NOT HOLD TODAY, in the safe direction, for exactly one
-// flag: SCRIPT_VERIFY_SCRIPT_RESTORE. See the last case in this file.
+// THAT INVARIANT NOW HOLDS. It did not until 2026-08-20: SCRIPT_VERIFY_SCRIPT_RESTORE
+// was set unconditionally by ConnectBlock and never by the mempool, and because
+// the restored opcodes are NO-OPS rather than errors without it, the same script
+// had two truth values. Fixed by adding the flag to STANDARD_SCRIPT_VERIFY_FLAGS
+// (bead mxph). These tests now pin the fix; the history is kept in the comments
+// because the reasoning is what stops it being undone.
 
 #include "policy/policy.h"
 #include "script/interpreter.h"
@@ -44,16 +48,6 @@
 BOOST_FIXTURE_TEST_SUITE(mempool_consensus_parity_tests, BasicTestingSetup)
 
 namespace {
-
-//! Evaluate a bare script under the given flags and report the error.
-ScriptError Eval(const CScript& script, unsigned int flags)
-{
-    std::vector<std::vector<unsigned char> > stack;
-    ScriptError serr = SCRIPT_ERR_OK;
-    BaseSignatureChecker checker;
-    EvalScript(stack, script, flags, checker, SIGVERSION_BASE, &serr);
-    return serr;
-}
 
 //! Evaluate and return the resulting stack, rendered for comparison. The error
 //! code alone is not enough: an opcode that becomes a NO-OP still "succeeds",
@@ -93,6 +87,8 @@ BOOST_AUTO_TEST_CASE(mempool_carries_the_unconditional_consensus_flags)
         // CSV is BIP9-gated in ConnectBlock but ALWAYS_ACTIVE on every network,
         // so in practice it is unconditional too.
         { SCRIPT_VERIFY_CHECKSEQUENCEVERIFY,   "SCRIPT_VERIFY_CHECKSEQUENCEVERIFY" },
+        // Added to the policy base on 2026-08-20; see the dedicated case below.
+        { SCRIPT_VERIFY_SCRIPT_RESTORE,        "SCRIPT_VERIFY_SCRIPT_RESTORE" },
     };
 
     for (const Row& r : unconditional) {
@@ -170,145 +166,84 @@ BOOST_AUTO_TEST_CASE(deployment_gated_flags_are_paired)
 // 845h: consensus-valid, never relayable. Pinned rather than fixed, because
 // making the restored opcodes relay-standard is a product decision.
 // ---------------------------------------------------------------------------
-BOOST_AUTO_TEST_CASE(script_restore_is_consensus_active_but_not_relay_standard)
+// THE DIVERGENCE THAT WAS HERE, NOW CLOSED (bead mxph).
+//
+// ConnectBlock sets SCRIPT_VERIFY_SCRIPT_RESTORE unconditionally ("Satoshi
+// script restoration: always-active on Soqucoin, genesis-active, no BIP9 gate
+// needed"). STANDARD_SCRIPT_VERIFY_FLAGS did not contain it, and
+// MANDATORY_SCRIPT_VERIFY_FLAGS is only SCRIPT_VERIFY_P2SH.
+//
+// policy.h SOQ-COV-012 had listed it as an intentional omission alongside
+// SCRIPT_VERIFY_CTV, APO and CSFS. That reasoning was sound for those three and
+// backwards for this one. CTV, APO and CSFS ADD ENFORCEMENT and consensus keeps
+// them NOT_SCHEDULED on mainnet, so policy and consensus agree at off/off until
+// activation. SCRIPT_RESTORE ADDS CAPABILITY and consensus has it on from
+// genesis, so the same omission produced a permanent split instead.
+//
+// And it was not the safe direction, which is why it had to be fixed rather
+// than documented: without the flag the restored opcodes are silent NO-OPS, not
+// errors, so a script SUCCEEDED on both paths while leaving a different stack.
+// `0 7 OP_MUL` left FALSE under consensus and TRUE under relay, so a
+// transaction spending such an output would be accepted and relayed by every
+// node and could never be mined. That is accept-then-reject, the
+// template-stalling failure of live bug daf9fd85.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(script_restore_is_carried_by_relay_policy)
 {
-    BOOST_CHECK_MESSAGE((STANDARD_SCRIPT_VERIFY_FLAGS & SCRIPT_VERIFY_SCRIPT_RESTORE) == 0,
-        "SCRIPT_VERIFY_SCRIPT_RESTORE is now in STANDARD_SCRIPT_VERIFY_FLAGS, so the policy "
-        "and consensus split described here is closed. Update this test rather than deleting "
-        "it, and check whether the SOQ-COV-012 omission list still lists it");
+    BOOST_CHECK_MESSAGE((STANDARD_SCRIPT_VERIFY_FLAGS & SCRIPT_VERIFY_SCRIPT_RESTORE) != 0,
+        "SCRIPT_VERIFY_SCRIPT_RESTORE has left STANDARD_SCRIPT_VERIFY_FLAGS. ConnectBlock "
+        "still sets it for every block, so removing it from relay policy reopens the "
+        "accept-then-reject split described above. If the consensus side became gated "
+        "instead, update both together");
+}
 
-    // Prove the split changes behaviour, and prove WHICH WAY, rather than
-    // reasoning about it. OP_MUL over two small numbers: valid arithmetic.
+// The property that actually matters: a script means the same thing to the
+// mempool and to a block. Same cases that used to diverge.
+BOOST_AUTO_TEST_CASE(restored_opcodes_mean_the_same_thing_on_both_paths)
+{
+    struct Case { const char* name; CScript script; };
+    std::vector<Case> cases;
+    { CScript s; s << CScriptNum(6)  << CScriptNum(7) << OP_MUL; cases.push_back({"OP_MUL", s}); }
+    { CScript s; s << CScriptNum(84) << CScriptNum(2) << OP_DIV; cases.push_back({"OP_DIV", s}); }
+    { CScript s; s << CScriptNum(85) << CScriptNum(4) << OP_MOD; cases.push_back({"OP_MOD", s}); }
+    { CScript s; s << std::vector<unsigned char>{0xaa} << std::vector<unsigned char>{0xbb} << OP_CAT;
+      cases.push_back({"OP_CAT", s}); }
+    // The one that used to flip a truth value: 0 * 7 = 0 is FALSE under
+    // consensus, while skipping the multiply leaves a top element of 0x07,
+    // which is TRUE.
+    { CScript s; s << CScriptNum(0) << CScriptNum(7) << OP_MUL; cases.push_back({"0 7 OP_MUL", s}); }
+
+    // What ConnectBlock uses for these opcodes, versus what the mempool uses.
+    const unsigned int consensusFlags = STANDARD_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_SCRIPT_RESTORE;
+    const unsigned int mempoolFlags   = STANDARD_SCRIPT_VERIFY_FLAGS;
+
+    for (const Case& c : cases) {
+        const std::string consensusView = EvalStack(c.script, consensusFlags);
+        const std::string mempoolView   = EvalStack(c.script, mempoolFlags);
+        BOOST_TEST_MESSAGE(std::string(c.name) + ": consensus " + consensusView +
+                           "  mempool " + mempoolView);
+        BOOST_CHECK_MESSAGE(consensusView == mempoolView,
+            std::string(c.name) + " evaluates differently at relay and in a block: consensus " +
+            consensusView + " versus mempool " + mempoolView + ". A transaction spending such "
+            "an output relays and cannot be mined, which stalls block templates");
+    }
+}
+
+// Guard on the mechanism rather than the outcome. The fix works because the
+// flag is in the policy base; if the restored opcodes ever start erroring
+// without it instead of no-opping, the failure mode changes character and this
+// file's reasoning needs revisiting.
+BOOST_AUTO_TEST_CASE(restored_opcodes_are_still_noops_when_the_flag_is_absent)
+{
     CScript mul;
     mul << CScriptNum(6) << CScriptNum(7) << OP_MUL;
 
-    const ScriptError withFlag = Eval(mul, SCRIPT_VERIFY_SCRIPT_RESTORE);
-    const ScriptError asMempoolSeesIt = Eval(mul, STANDARD_SCRIPT_VERIFY_FLAGS);
-
-    BOOST_TEST_MESSAGE("OP_MUL with SCRIPT_RESTORE:    " << EvalStack(mul, SCRIPT_VERIFY_SCRIPT_RESTORE));
-    BOOST_TEST_MESSAGE("OP_MUL under STANDARD (mempool): " << EvalStack(mul, STANDARD_SCRIPT_VERIFY_FLAGS));
-    BOOST_TEST_MESSAGE("OP_MUL with NO flags:            " << EvalStack(mul, 0));
-
-    BOOST_CHECK_MESSAGE(withFlag == SCRIPT_ERR_OK,
-        "OP_MUL must evaluate when SCRIPT_VERIFY_SCRIPT_RESTORE is set; that is the whole "
-        "point of the flag, and ConnectBlock sets it for every block");
-
-    // MEASURED: without the flag OP_MUL is a silent NO-OP, not an error.
-    //   with SCRIPT_RESTORE     -> ok[2a]      (6 * 7 = 42, executed)
-    //   under STANDARD (mempool) -> ok[06,07]  (untouched, operands still there)
-    // Both "succeed". They leave DIFFERENT STACKS, so the same script has two
-    // truth values. That is not the safe direction after all, and the next case
-    // constructs the consequence.
-    BOOST_CHECK_MESSAGE(asMempoolSeesIt == SCRIPT_ERR_OK,
-        "OP_MUL now errors without SCRIPT_RESTORE rather than acting as a no-op. That would "
-        "actually be an improvement: an error makes the divergence fail closed. Update this "
-        "test and re-check the accept-then-reject case below");
-    BOOST_CHECK_MESSAGE(withFlag == asMempoolSeesIt,
-        "both paths still report success; the divergence is in the STACK, not the error code");
-}
-
-// ---------------------------------------------------------------------------
-// ⛔⛔ THE CONSEQUENCE, CONSTRUCTED. Because the restored opcodes are NO-OPS
-// rather than errors when the flag is clear, a single script has two different
-// truth values: one under the mempool's flag set and another under the flag set
-// ConnectBlock uses. Both directions are reachable, and one of them is the
-// template-stalling shape that live bug daf9fd85 produced.
-//
-// This is what makes the omission unsafe rather than merely restrictive. Had the
-// opcodes been DISABLED without the flag, policy would simply be stricter and
-// the worst case would be an unusable feature. As no-ops they silently change
-// the meaning of a script instead.
-//
-// Reachability: EvalScript runs user-supplied opcodes only from a v6
-// P2WSH-Dilithium witnessScript. v6 is NOT_SCHEDULED on mainnet, so this is not
-// live there, but it is ALWAYS_ACTIVE and relay-standard on stagenet, testnet
-// and regtest, which means the accept-then-reject path is live on the rehearsal
-// network today, and becomes live on mainnet the moment P2WSH-Dilithium
-// activates.
-// ---------------------------------------------------------------------------
-BOOST_AUTO_TEST_CASE(a_single_script_has_two_truth_values_across_the_split)
-{
-    // Note OP_EQUAL is itself gated, on SCRIPT_VERIFY_V6_CONTROLFLOW, and that
-    // flag IS paired across both paths, so it cannot be used to express the
-    // comparison here. The divergence has to be read off the stack directly,
-    // which is also the more honest way to show it.
-
-    // 0 * 7 = 0. Consensus multiplies and leaves an EMPTY stack element, which
-    // is FALSE. The mempool skips the multiply and leaves the operands, whose
-    // top element is 0x07, which is TRUE.
-    CScript falseUnderConsensusTrueUnderRelay;
-    falseUnderConsensusTrueUnderRelay << CScriptNum(0) << CScriptNum(7) << OP_MUL;
-
-    const std::string consensusView = EvalStack(falseUnderConsensusTrueUnderRelay,
-                                                STANDARD_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_SCRIPT_RESTORE);
-    const std::string mempoolView   = EvalStack(falseUnderConsensusTrueUnderRelay,
-                                                STANDARD_SCRIPT_VERIFY_FLAGS);
-
-    BOOST_TEST_MESSAGE("0 7 OP_MUL under consensus flags: " << consensusView);
-    BOOST_TEST_MESSAGE("0 7 OP_MUL under mempool flags:   " << mempoolView);
-
-    BOOST_CHECK_MESSAGE(consensusView != mempoolView,
-        "the same script now evaluates identically on both paths, so the SCRIPT_RESTORE "
-        "divergence is closed. Good; update this test rather than deleting it");
-
-    // Consensus: one empty element, the canonical FALSE.
-    BOOST_CHECK_MESSAGE(consensusView == "ok[]",
-        "expected consensus to compute 0 * 7 = 0 and leave FALSE, got " + consensusView);
-    // Mempool: operands untouched, top element 0x07, which is TRUE.
-    BOOST_CHECK_MESSAGE(mempoolView == "ok[,07]",
-        "expected the mempool to skip the multiply and leave the operands, got " + mempoolView +
-        ". If the shape has changed, re-derive the demonstration; the property under test is "
-        "that the two flag sets disagree about what this script computed");
-}
-
-// The same divergence stated as the invariant it breaks, so the reason it
-// matters does not depend on one hand-built script surviving future edits.
-BOOST_AUTO_TEST_CASE(restored_opcodes_are_noops_not_errors_which_is_the_unsafe_shape)
-{
-    // Every opcode SCRIPT_VERIFY_SCRIPT_RESTORE re-enables. For each one, the
-    // stack it leaves must be the same under both flag sets, or that opcode can
-    // carry a transaction that relays and cannot be mined.
-    struct Case { const char* name; CScript script; };
-    std::vector<Case> cases;
-    {
-        CScript s; s << CScriptNum(6) << CScriptNum(7) << OP_MUL;   cases.push_back({"OP_MUL", s});
-    }
-    {
-        CScript s; s << CScriptNum(84) << CScriptNum(2) << OP_DIV;  cases.push_back({"OP_DIV", s});
-    }
-    {
-        CScript s; s << CScriptNum(85) << CScriptNum(4) << OP_MOD;  cases.push_back({"OP_MOD", s});
-    }
-
-    for (const Case& c : cases) {
-        const std::string consensusView = EvalStack(c.script,
-                                                    STANDARD_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_SCRIPT_RESTORE);
-        const std::string mempoolView = EvalStack(c.script, STANDARD_SCRIPT_VERIFY_FLAGS);
-        BOOST_TEST_MESSAGE(std::string(c.name) + ": consensus " + consensusView +
-                           "  mempool " + mempoolView);
-        BOOST_CHECK_MESSAGE(consensusView != mempoolView,
-            std::string(c.name) + " now agrees across both flag sets. If the omission is "
-            "being closed opcode by opcode that is worse than either end state, because the "
-            "set of scripts that mean two different things becomes harder to describe. Work "
-            "out which ones changed and finish the job");
-    }
-
-    // OP_CAT is the CONTROL, and it is the interesting one. It belongs to the
-    // same Satoshi-restoration family and is described in validation.cpp as
-    // "genesis-active like OP_CAT" — but unlike MUL/DIV/MOD it is NOT gated on
-    // SCRIPT_VERIFY_SCRIPT_RESTORE at all, so both paths agree about it.
-    //
-    // That is what correct looks like, and it shows the divergence is an
-    // accident of which opcodes ended up behind the flag rather than a
-    // considered policy about arithmetic. Whoever decides the fix should note
-    // that half of this feature is already unconditional.
-    CScript cat;
-    cat << std::vector<unsigned char>{0xaa} << std::vector<unsigned char>{0xbb} << OP_CAT;
-    BOOST_CHECK_MESSAGE(
-        EvalStack(cat, STANDARD_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_SCRIPT_RESTORE) ==
-        EvalStack(cat, STANDARD_SCRIPT_VERIFY_FLAGS),
-        "OP_CAT has started depending on SCRIPT_VERIFY_SCRIPT_RESTORE. It was ungated and "
-        "therefore consistent across relay and consensus; gating it extends the divergence");
+    BOOST_CHECK_MESSAGE(EvalStack(mul, SCRIPT_VERIFY_SCRIPT_RESTORE) == "ok[2a]",
+        "OP_MUL must execute when the flag is set");
+    BOOST_CHECK_MESSAGE(EvalStack(mul, 0) == "ok[06,07]",
+        "without the flag OP_MUL is expected to be a silent NO-OP, leaving its operands. If it "
+        "now ERRORS instead, that is a safer shape and the policy fix is belt-and-braces rather "
+        "than load-bearing; re-read bead mxph before relying on either");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The four pre-freeze items, plus the digest gap one of them exposed. Verified together, because three touch the build and the fourth is the thing that would notice if they moved consensus.

## `mxph` — the mempool/consensus split, closed

ConnectBlock sets `SCRIPT_VERIFY_SCRIPT_RESTORE` unconditionally from genesis; relay policy never did. Because the restored opcodes are **silent no-ops rather than errors** without the flag, the same script had two truth values — `0 7 OP_MUL` left FALSE in a block and TRUE at relay. A transaction spending such an output was accepted and relayed by every node and could never be mined: accept-then-reject, the template-stalling failure of `daf9fd85`. Reachable through a v6 witnessScript, so **live on stagenet — the network the soak will run on.**

Fixed by adding the flag to `STANDARD_SCRIPT_VERIFY_FLAGS`. The SOQ-COV-012 omission list now explains why it couldn't stay there: CTV/APO/CSFS **add enforcement** and are `NOT_SCHEDULED`, so omitting them leaves policy and consensus agreeing at off/off. `SCRIPT_RESTORE` **adds capability** and consensus has it on from genesis, so the identical omission produced a permanent split. All five previously-diverging cases now evaluate identically.

## `iwzf` — MAX_MONEY: value unchanged, **my earlier recommendation was wrong**

I proposed raising it to cover the supply. Two facts kill that:

1. **The supply is unbounded** — the emission schedule has a perpetual tail of 2,500 SOQ/block. No constant can bound it.
2. **The accumulators add before they check.** `validation.cpp:1947` does `nValueIn += …` and only then calls `MoneyRange`, so a sum of two in-range amounts must not overflow → `MAX_MONEY ≤ INT64_MAX/2` ≈ **46.1B coins**. Head supply is **46.875B**, already past that line.

| candidate | 2 × MAX_MONEY | fits int64? |
|---|---|---|
| current 10B | 2.0e18 | ✅ 9.2× headroom |
| head supply 46.875B | 9.375e18 | ❌ |
| my proposed 50B | 1.0e19 | ❌ |

Raising it would have **reintroduced the signed overflow this constant exists to prevent**, with `MoneyRange` then reading an already-wrapped total. 10B is a deliberate per-transaction ceiling with a 9.2× margin.

So the fix is the comment — which claimed "100B coins", wrong twice over (the value is 10B, and 100B coins in shors is 1e19 and doesn't fit in an int64 at all). A `static_assert` now enforces the overflow bound so nobody raises it on the strength of a comment.

## `eolo` — `-fno-strict-aliasing`

Added to `CXXFLAGS` and `CFLAGS`. This codebase has already had an aliasing violation make seed-derived public data depend on the optimisation level — a chain split from a build flag, silent by construction.

Deliberately placed **outside** the `CXXFLAGS_overridden` guard: the warning flags there are skipped whenever the caller passes explicit `CXXFLAGS`, which is what release builds, packagers and the F4 sweep all do. A correctness flag that vanishes for exactly those builds is worse than none.

## v2.0.0

Consensus-incompatible with v1.6.0 on a chain that exists today: conservation is now `IsAnyUSDSOQ` and is **not** deployment-gated, so a v10-minting tx is accepted by 1.6.0 and rejected here; LatticeFold retirement and the SoquObscura withdrawal have the same shape. A coordinated flag-day upgrade deserves a major number.

This also settles the open `v7xm` question of whether the fleet runs 1.5.0 or 1.6.0 first: **neither — straight to the freeze tag.**

## The digest gap, and the isolation that proves the rest

`MAX_MONEY` is consensus-critical and was **not covered** by the digest, along with the block weight/size/sigop limits. Absorbed now — and that is the **only** reason the pinned value moves.

**Verified by isolation rather than assumed.** Rebuilding with the new absorption removed reproduces the previous digest `0489e98d…9fe7` byte-for-byte *on the new binary*. That proves:

- `-fno-strict-aliasing` perturbs **no** computed value
- the version bump does not reach consensus
- the policy change is policy

It's also a **seventh independent F4 data point**, this time varying a compiler flag rather than an optimisation level.

## Differential validation, re-run on this build

All **48,888** stagenet blocks replay to the same tip, both reference hashes match, and the UTXO set is **bit-identical** to the pre-change run:

```
hash_serialized f73751d6122a52477052ddf456c30b791efb71d0ccbe1fd5a9abcee166709818
4,442 transactions · 4,888,818,207.48879 SOQ
```

**678 cases, only failures the three deliberate forgery tests.**

## Note

`configure~` is a generated autoconf backup file that is **tracked in git**, so regenerating `configure` dirties it. Left untouched here; worth removing from the index separately.

Beads: `mxph`, `iwzf`, `eolo`, `l3cl`, `x7hb`.
