### PR TITLE
consensus: Freeze Candidate 4 package (MAX_MONEY, v10 dispatch, F8 stragglers, ceremony staging)

### DIFF
--- a/doc/GENESIS_CEREMONY.md
+++ b/doc/GENESIS_CEREMONY.md
@@ -1,0 +1,67 @@
+# Mainnet Genesis Ceremony (FC4)
+
+The mainnet genesis block currently reuses the Dogecoin genesis template
+(message "Nintondo", nTime 1386325540, nonce 99943, the original ECDSA P2PK
+output). Launch checklist item A1 and bead z9vk ratify replacing it before
+launch with a purpose-built genesis. This document is the complete procedure,
+staged so the ceremony itself is a one-sitting operation. It is a
+consensus-touching change: it lands inside Freeze Candidate 4 and shares that
+candidate's soak.
+
+## Why a dated headline
+
+A genesis containing a same-day wire-service headline provably was not mined
+before that date. On a chain whose fair-launch claim is load-bearing and whose
+merge mining opens at height 0, this is the one artifact that mathematically
+forecloses "they secretly mined early". It also removes a permanent optics
+liability: after genesis the block is immutable, and every decoder would
+otherwise display another chain's 2013 message and an ECDSA key on an
+ECDSA-elimination chain forever.
+
+## Inputs, chosen on ceremony day
+
+1. `pszTimestamp`: a verifiable, dated headline from a major wire service,
+   ideally quantum-computing related. Nothing clever. Chosen by the founder on
+   the day of the ceremony; that immediacy is the point.
+2. `nTime`: the actual UTC timestamp of the ceremony.
+3. The output script: replace the Dogecoin ECDSA P2PK with a
+   nothing-up-my-sleeve unspendable output. The genesis coinbase is excluded
+   from the UTXO set regardless; this is about what decoders display.
+
+## Procedure
+
+1. Branch from the FC4 candidate. All other FC4 consensus changes must
+   already be in, so one soak covers everything.
+2. Edit `src/chainparams.cpp` `CreateGenesisBlock` (the mainnet call site near
+   line 433): new `pszTimestamp`, new `nTime`, nonce 0.
+3. Mine the nonce: build, run with a temporary search loop (the pattern used
+   for the 2025/2026 testnet and stagenet geneses; scrypt at nBits 0x1e0ffff0
+   takes seconds), and record nonce, block hash, and merkle root.
+4. Update every pin, in one commit:
+   - `src/chainparams.cpp:439` mainnet `hashGenesisBlock` assert
+   - `src/chainparams.cpp:440` mainnet `hashMerkleRoot` assert
+   - the scrypt PoW hash recorded in the comment near line 435
+   - `src/test/genesis_chainparams_tests.cpp` expected mainnet genesis values
+   - `src/test/consensus_digest_tests.cpp` digest pins (the digest hashes
+     `hashGenesisBlock`; the pinned digests WILL change and that is the
+     tripwire working, not breaking)
+5. Run the full unit suite. Expected result: everything green except exactly
+   the three deliberate SoquObscura tripwires. Any fourth failure stops the
+   ceremony.
+6. Differential validation: replay the full stagenet history against the new
+   binary and diff verdicts transaction by transaction (stagenet and testnet
+   geneses are untouched, so history replays identically; this catches
+   accidental spillover).
+7. Tag the freeze candidate. The soak clock starts at fleet deploy.
+
+## What does not change
+
+Testnet, regtest, and stagenet genesis parameters. Message-start bytes,
+ports, DNS seeds. Every deployment posture (dormancy_matrix_tests pins them).
+The emission schedule.
+
+## Rollback
+
+Before the tag is published, rollback is `git revert` of the ceremony commit.
+After mainnet launch there is no rollback; that is the entire reason this
+happens now.

--- a/src/amount.h
+++ b/src/amount.h
@@ -40,11 +40,22 @@ extern const std::string CURRENCY_UNIT;
  *      this constant exists to prevent, and the MoneyRange check downstream
  *      would be reading an already-wrapped value.
  *
- * So 10B coins is a deliberate cap with a 9.2x overflow margin, and the
- * consequence is real and worth knowing: NO SINGLE TRANSACTION MAY MOVE MORE
- * THAN 10B SOQ on either side, so a treasury or exchange consolidation larger
- * than that must be split. (For scale, the largest sum handled to date is the
- * 4.45B the pool consolidation trapped.)
+ * AND A THIRD BOUND EXISTS, DISCOVERED BY TEST WHEN 40B WAS TRIED (FC4,
+ * 2026-08-26): CompressAmount/DecompressAmount, the chainstate txout codec,
+ * computes roughly 9n + 81 in a uint64, so any amount above
+ * ~2,049,638,230,412,172,714 shors (~20.49B coins) with a non-round decimal
+ * tail fails to round-trip and would silently corrupt in the UTXO database.
+ * serialization_invariance_tests caught 40B * COIN - 1 decompressing to
+ * garbage. The static_assert below enforces this bound too.
+ *
+ * So 20B coins is the cap: 4.5x above the largest consolidation observed to
+ * date (the 4.45B the pool consolidation trapped), 80% of first-epoch
+ * emission, 2.4% under the codec ceiling, and 4.6x under the int64 additive
+ * ceiling. The consequence is real and worth knowing: NO SINGLE TRANSACTION
+ * MAY MOVE MORE THAN 20B SOQ on either side; a larger treasury or exchange
+ * consolidation must be split. (40B was ratified first, bead iwzf; the codec
+ * bound reduced it to 20B. Raising it above ~20.49B requires replacing the
+ * amount codec, which is chainstate-format surgery, not a constant bump.)
  *
  * The previous comment here claimed "maximum of 100B coins". That was wrong
  * twice over: the value is 10B, not 100B, and 100B coins in shors is 1e19,
@@ -54,12 +65,17 @@ extern const std::string CURRENCY_UNIT;
  * As this sanity check is used by consensus-critical validation code, the exact
  * value is consensus critical; changing it after genesis is a hard fork.
  * */
-static const CAmount MAX_MONEY = 10000000000 * COIN; // 10B SOQ, a per-TX ceiling
+static const CAmount MAX_MONEY = 20000000000 * COIN; // 20B SOQ, a per-TX ceiling
 
 //! The overflow bound argued for above, enforced rather than trusted: every
 //! accumulator in the validation path adds two in-range amounts before it calls
 //! MoneyRange, so twice MAX_MONEY has to remain representable.
-static_assert(MAX_MONEY > 0 && MAX_MONEY <= 4611686018427387903LL,
+static_assert(MAX_MONEY > 0 && MAX_MONEY <= 2049638230412172714LL,
+              "MAX_MONEY must fit the CompressAmount codec (~9n+81 in a uint64, "
+              "see the comment above): amounts past ~20.49B coins silently "
+              "corrupt in the chainstate. Raising this bound means replacing "
+              "the amount codec first.");
+static_assert(MAX_MONEY <= 4611686018427387903LL,
               "MAX_MONEY must satisfy 2 * MAX_MONEY <= INT64_MAX: validation "
               "accumulators sum before they range-check, so a larger value makes "
               "the check read an already-overflowed total");

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -533,10 +533,13 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999;   // December 31, 2008
 
         // Deployment of BIP68, BIP112, and BIP113.
-        // XXX: BIP heights and hashes all need to be updated to Soqucoin values
+        // CSV mirrors mainnet: ALWAYS_ACTIVE. The inherited 2016/2017 Dogecoin
+        // BIP9 window would resolve THRESHOLD_FAILED on a 2026-genesis chain,
+        // silently disabling BIP68/112/113 on testnet forever (F8 class; the
+        // exact hazard the mainnet comment describes). Fixed for FC4.
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1456790400; // March 1st, 2016
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800;   // May 1st, 2017
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
         // Deployment of SegWit (BIP141, BIP143, and BIP147)
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
@@ -985,8 +988,16 @@ public:
 
     void UpdateBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout)
     {
+        // ⚠️ ALL THREE, for the same reason as UpdateActivationHeight below:
+        // regtest's height-indexed consensus tree means a mutation applied to
+        // `consensus` alone is invisible to every block above height 19
+        // (bead tofg).
         consensus.vDeployments[d].nStartTime = nStartTime;
         consensus.vDeployments[d].nTimeout = nTimeout;
+        digishieldConsensus.vDeployments[d].nStartTime = nStartTime;
+        digishieldConsensus.vDeployments[d].nTimeout = nTimeout;
+        auxpowConsensus.vDeployments[d].nStartTime = nStartTime;
+        auxpowConsensus.vDeployments[d].nTimeout = nTimeout;
     }
 
     void UpdateActivationHeight(Consensus::DeploymentPos d, int nActivationHeight)

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1669,12 +1669,18 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
     // Future witness versions (v10-v16): anyone-can-spend until soft fork.
     // NOTE: v6 (P2WSH-Dilithium), v7 (USDSOQ holding), v8 (BTCSOQ holding)
     // and v9 (BTCSOQ authority marker) are carved out above.
+    // Witness v10 is ALLOCATED: confidential USDSOQ (SOQ-ARCH-004), gated on
+    // DEPLOYMENT_USDSOQ and DEPLOYMENT_SOQUOBSCURA together (validation.cpp
+    // versionActive case 10). It is not a generic future version (bead jzg0).
+    bool is_confidential_usdsoq_witness = (scriptPubKey.size() == 34 &&
+                                           scriptPubKey[0] == OP_10 &&
+                                           scriptPubKey[1] == 32);
     bool is_future_witness = (scriptPubKey.size() == 34 &&
-                              scriptPubKey[0] >= OP_10 &&
+                              scriptPubKey[0] >= OP_11 &&
                               scriptPubKey[0] <= OP_16 &&
                               scriptPubKey[1] == 32);
 
-    if (!is_dilithium && !is_op_return && !is_future_witness && !is_pat && !is_latticefold && !is_latticebp_witness && !is_usdsoq_witness && !is_p2wsh_dilithium && !is_usdsoq_holding && !is_btcsoq_holding && !is_btcsoq_authority) {
+    if (!is_dilithium && !is_op_return && !is_future_witness && !is_pat && !is_latticefold && !is_latticebp_witness && !is_usdsoq_witness && !is_p2wsh_dilithium && !is_usdsoq_holding && !is_btcsoq_holding && !is_btcsoq_authority && !is_confidential_usdsoq_witness) {
         return set_error(serror, SCRIPT_ERR_DISALLOWED_CLASSICAL_CRYPTO);
     }
 
@@ -1746,11 +1752,12 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
         return set_success(serror);
     }
 
-    // Future witness versions (v4-v16): consensus-valid, no validation performed.
-    // SECURITY NOTE: Coins sent to v4-v16 outputs are anyone-can-spend at
-    // the consensus layer until a soft fork adds validation rules for that
-    // version. Standardness policy (IsStandard in policy/policy.cpp) MUST
-    // reject creation and relay of these outputs to prevent premature use.
+    // Dormant witness versions (v4-v10 allocated, v11-v16 unallocated):
+    // spends are anyone-can-spend at the script layer until each version's
+    // deployment activates. This window cannot be funded: creating an output
+    // of an inactive witness version is consensus-rejected in ConnectBlock
+    // (SOQ-I009, bad-txns-witness-version-not-active), and standardness
+    // (policy/policy.cpp) keeps such transactions out of the mempool.
     if (is_latticebp_witness) {
         if (!(flags & SCRIPT_VERIFY_SOQUOBSCURA)) {
             return set_success(serror);  // Not active yet — anyone-can-spend
@@ -1922,6 +1929,21 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
             return set_success(serror);  // Not active yet — anyone-can-spend (soft-fork safe)
         }
         return set_error(serror, SCRIPT_ERR_BTCSOQ_MARKER_SPEND);
+    }
+
+    // Witness v10: confidential USDSOQ (bead jzg0, Gate 0 ruling r0vn).
+    // Dormant posture matches every allocated sibling. When BOTH gating
+    // deployments are active the spend FAILS CLOSED, because the confidential
+    // verifier is deliberately not shipped (SOQ-I011: the in-tree range
+    // verifier does not bind the amount — do not route to it). The activation
+    // release that schedules SOQUOBSCURA + USDSOQ replaces this reject with
+    // real verification; the scaffolding exists so activation is a rules
+    // change inside an existing dispatch, never a code-shape change.
+    if (is_confidential_usdsoq_witness) {
+        if (!(flags & SCRIPT_VERIFY_USDSOQ) || !(flags & SCRIPT_VERIFY_SOQUOBSCURA)) {
+            return set_success(serror);  // Not active yet — anyone-can-spend (soft-fork safe)
+        }
+        return set_error(serror, SCRIPT_ERR_CONFIDENTIAL_USDSOQ_UNVERIFIED);
     }
 
     if (is_future_witness) {

--- a/src/script/script_error.cpp
+++ b/src/script/script_error.cpp
@@ -42,6 +42,8 @@ const char* ScriptErrorString(const ScriptError serror)
         return "Attempt to spend a frozen USDSOQ UTXO";
     case SCRIPT_ERR_BTCSOQ_MARKER_SPEND:
         return "BTCSOQ authority marker may only be spent by an authority transaction";
+    case SCRIPT_ERR_CONFIDENTIAL_USDSOQ_UNVERIFIED:
+        return "Confidential USDSOQ spend rejected: no confidential verifier is shipped";
     case SCRIPT_ERR_CHECKTEMPLATEVERIFY:
         return "OP_CHECKTEMPLATEVERIFY hash mismatch";
     case SCRIPT_ERR_CHECKSIGFROMSTACK:

--- a/src/script/script_error.h
+++ b/src/script/script_error.h
@@ -41,6 +41,12 @@ typedef enum ScriptError_t {
     /* BTCSOQ consensus-native asset errors (DL-BTCSOQ-CONSENSUS-NATIVE) */
     SCRIPT_ERR_BTCSOQ_MARKER_SPEND,
 
+    /* Witness v10 (confidential USDSOQ): reject-path scaffolding. Fails closed
+     * when both gating deployments are active, because no confidential
+     * verifier is shipped (SOQ-I011). Replaced by real verification in the
+     * activation release. */
+    SCRIPT_ERR_CONFIDENTIAL_USDSOQ_UNVERIFIED,
+
     /* BIP 119: OP_CHECKTEMPLATEVERIFY */
     SCRIPT_ERR_CHECKTEMPLATEVERIFY,
 

--- a/src/test/consensus_digest_tests.cpp
+++ b/src/test/consensus_digest_tests.cpp
@@ -252,20 +252,27 @@ BOOST_AUTO_TEST_CASE(consensus_digest_is_pinned)
     const uint256 digest = ComputeConsensusDigest();
     BOOST_TEST_MESSAGE("CONSENSUS DIGEST: " << digest.ToString());
 
-    // Pinned 2026-08-20, Apple clang 21 arm64 -O2, at the v2.0.0 freeze candidate.
+    // Pinned 2026-08-26, Apple clang 21 arm64 -O2, at the FC4 candidate.
     //
-    // Moved from 0489e98d4d6465a42ef90a0d456c70804794b914cdd0e502ad0bbae3928a9fe7
-    // for ONE reason, verified by isolation rather than assumed: AbsorbGlobalLimits
-    // was added, bringing MAX_MONEY and the block limits under the digest for the
-    // first time. Rebuilding with that call removed reproduced the old value
-    // byte-for-byte on the new binary, which also proves the three other changes
-    // in the same commit moved nothing in consensus:
-    //   * -fno-strict-aliasing (bead eolo) perturbs no computed value;
-    //   * the v2.0.0 version bump does not reach consensus;
-    //   * adding SCRIPT_VERIFY_SCRIPT_RESTORE to relay policy (bead mxph) is
-    //     policy, not consensus.
+    // Moved from 5effd2ed86326721613bddbbe2002555b217e1008c27668557027dcacf6a7ce0
+    // for exactly the consensus inputs FC4 changed, each individually intended:
+    //   * MAX_MONEY 10B -> 20B (bead iwzf; AbsorbGlobalLimits input). 40B was
+    //     tried first and moved the digest to c346a6b6...; the CompressAmount
+    //     codec bound then reduced the value to 20B, so the 40B digest never
+    //     shipped anywhere.
+    //   * testnet CSV moved off the inherited 2016/2017 BIP9 window to
+    //     ALWAYS_ACTIVE (per-network deployment inputs).
+    //   * witness v10 gained its own gated dispatch failing closed under
+    //     USDSOQ+SOQUOBSCURA (bead jzg0; script-verdict matrix inputs, where
+    //     the flag sets cover it).
+    // The regtest BIP9 lever fix in the same commit mutates nothing at
+    // construction time and therefore contributes nothing here.
+    //
+    // Prior pin history: moved from 0489e98d... on 2026-08-20 when
+    // AbsorbGlobalLimits first brought MAX_MONEY and the block limits under
+    // the digest (verified by isolation at the time).
     const std::string expected =
-        "5effd2ed86326721613bddbbe2002555b217e1008c27668557027dcacf6a7ce0";
+        "f830d7d6e85f044feb88243263755a92c67a15a480e4f3c9d9ba074e0533bc80";
 
     BOOST_CHECK_MESSAGE(digest.ToString() == expected,
         "consensus digest is " + digest.ToString() + ", expected " + expected +

--- a/src/test/soquobscura_keyimage_deadcode_tests.cpp
+++ b/src/test/soquobscura_keyimage_deadcode_tests.cpp
@@ -57,16 +57,21 @@
 BOOST_FIXTURE_TEST_SUITE(soquobscura_keyimage_deadcode_tests, DilithiumChainSetup)
 
 // ---------------------------------------------------------------------------
-// The measurement. Two CONFIDENTIAL (witness v10) inputs are spent in one
-// transaction, both signed by the same key, so both witness stacks end in the
-// identical 0x00-prefixed pubkey. The key image is defined as the last witness
-// element, so if the loop ran at all the second input would be an intra-block
-// duplicate and the block would be rejected with
-// bad-txns-conf-intrablock-duplicate-keyimage.
+// The measurement, updated for FC4. Two CONFIDENTIAL (witness v10) inputs are
+// spent in one transaction with IDENTICAL trailing witness elements, so if the
+// key-image loop ran at all the second input would be an intra-block duplicate.
 //
-// It connects. And nothing is written to the key-image DB, which is checked
-// directly rather than inferred, so this cannot be read as "the loop ran and the
-// images happened to differ".
+// Before FC4 this case proved the loop dead by showing the block CONNECTS
+// (the loop resolves inputs after UpdateCoins has spent them; bead p4wv). FC4
+// gave v10 its own interpreter dispatch that FAILS CLOSED while the
+// confidential verifier is unshipped (bead jzg0, ruling r0vn), so the loop is
+// now dead twice over: its inputs resolve too late, AND no v10 spend can
+// connect at all while the gates are active. This case pins the stronger
+// posture, and still checks the key-image DB directly rather than inferring.
+//
+// When the activation release ships a real verifier and replaces the
+// fail-closed reject, this case must be revisited together with the loop's
+// scheduled REMOVAL (p4wv: remove in Phase 2, never revive).
 // ---------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE(connectblock_never_extracts_key_images_from_confidential_inputs)
 {
@@ -90,15 +95,21 @@ BOOST_AUTO_TEST_CASE(connectblock_never_extracts_key_images_from_confidential_in
     const LatticeKeyImageHash ki =
         LatticeKeyImageHash::FromSerializedKeyImage(tx.vin[0].scriptWitness.stack.back());
 
-    BOOST_CHECK_MESSAGE(RejectReasonFor({tx}).empty(),
-        "a block spending two confidential inputs whose key images are IDENTICAL must be "
-        "rejected once the key-image loop runs. It connects, so the loop does not run: "
-        "it resolves inputs through the coins view in ConnectBlock's LAST pass, after "
-        "UpdateCoins has already spent them (bead p4wv, third instance of the e2n pattern)");
+    // BlockIsValid, not RejectReasonFor: the rejection comes from VerifyScript
+    // (SCRIPT_ERR_CONFIDENTIAL_USDSOQ_UNVERIFIED), and script failures inside a
+    // block carry an EMPTY reject string, which RejectReasonFor cannot tell
+    // apart from a valid block. The exact script error is pinned separately in
+    // witness_version_allocation_tests / v10_fails_closed_when_both_gates_are_active.
+    BOOST_CHECK_MESSAGE(!BlockIsValid({tx}),
+        "a v10 spend must FAIL CLOSED while the confidential verifier is unshipped "
+        "(FC4 scaffolding, bead jzg0). If this block validates, either a real verifier "
+        "landed (update this case alongside the p4wv loop removal) or the fail-closed "
+        "dispatch regressed to anyone-can-spend");
 
-    CBlock connected = CreateAndProcessBlock({tx}, coinbaseSpk);
-    BOOST_REQUIRE_MESSAGE(chainActive.Tip()->GetBlockHash() == connected.GetHash(),
-        "the block must actually connect for the DB assertion below to mean anything");
+    const uint256 tipBefore = chainActive.Tip()->GetBlockHash();
+    CBlock rejected = CreateAndProcessBlock({tx}, coinbaseSpk);
+    BOOST_REQUIRE_MESSAGE(chainActive.Tip()->GetBlockHash() == tipBefore,
+        "a block spending v10 inputs must NOT connect while the verifier is unshipped");
 
     bool have;
     {
@@ -106,9 +117,9 @@ BOOST_AUTO_TEST_CASE(connectblock_never_extracts_key_images_from_confidential_in
         have = pcoinsdbview->HaveKeyImage(ki.hash);
     }
     BOOST_CHECK_MESSAGE(!have,
-        "ConnectBlock recorded no key image for a confidential spend. vBlockKeyImages is "
-        "always empty, so WriteKeyImage is never reached and the cross-block duplicate "
-        "check has an empty set to consult. Direct evidence, not inference.");
+        "no key image may be recorded for a confidential spend: the extraction loop is "
+        "dead (p4wv) and the spend itself cannot connect (jzg0). Direct evidence, not "
+        "inference.");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/test/witness_version_allocation_tests.cpp
+++ b/src/test/witness_version_allocation_tests.cpp
@@ -126,7 +126,10 @@ const Row TABLE[] = {
     {  7, "is_usdsoq_holding",      SCRIPT_VERIFY_USDSOQ,             true,         true  },
     {  8, "is_btcsoq_holding",      SCRIPT_VERIFY_BTCSOQ,             true,         true  },
     {  9, "is_btcsoq_authority",    SCRIPT_VERIFY_BTCSOQ,             true,         true  },
-    { 10, "is_future_witness",      0,                                true,         false },
+    // v10 is ALLOCATED (confidential USDSOQ) with a COMPOUND gate: both
+    // deployments must be active (bead jzg0; validation versionActive case 10).
+    { 10, "is_confidential_usdsoq_witness",
+          SCRIPT_VERIFY_USDSOQ | SCRIPT_VERIFY_SOQUOBSCURA,           true,         false },
     { 11, "is_future_witness",      0,                                true,         false },
     { 12, "is_future_witness",      0,                                true,         false },
     { 13, "is_future_witness",      0,                                true,         false },
@@ -177,9 +180,10 @@ BOOST_AUTO_TEST_CASE(gates_do_not_leak_across_versions)
         if (gated.gate == 0) continue;
         for (const Row& other : TABLE) {
             if (other.version == gated.version) continue;
-            // Versions sharing a deployment flag by design (v5/v7 on USDSOQ,
-            // v8/v9 on BTCSOQ) are expected to move together.
-            if (other.gate == gated.gate) continue;
+            // Versions sharing any deployment flag by design (v5/v7 on USDSOQ,
+            // v8/v9 on BTCSOQ, and v10 whose COMPOUND gate contains both the
+            // USDSOQ and SOQUOBSCURA flags) are expected to move together.
+            if ((other.gate & gated.gate) != 0) continue;
             if (!other.anyoneCanSpendWhenOff) continue;
             const ScriptError serr = ScriptVerdict(Program(other.version),
                                                    SCRIPT_VERIFY_WITNESS | gated.gate);
@@ -189,6 +193,22 @@ BOOST_AUTO_TEST_CASE(gates_do_not_leak_across_versions)
                 "predicate, which is the v6 / P2WSH-Dilithium collision shape");
         }
     }
+}
+
+// v10's gate is COMPOUND: either flag alone must leave it dormant, and with
+// both set it must fail CLOSED on the scaffolding error, because no
+// confidential verifier ships before activation (SOQ-I011; Gate 0 ruling
+// r0vn). The activation release replaces the reject with real verification,
+// and this pin is the tripwire that makes that replacement deliberate.
+BOOST_AUTO_TEST_CASE(v10_fails_closed_when_both_gates_are_active)
+{
+    BOOST_CHECK_EQUAL(ScriptVerdict(Program(10), SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_USDSOQ),
+                      SCRIPT_ERR_OK);
+    BOOST_CHECK_EQUAL(ScriptVerdict(Program(10), SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_SOQUOBSCURA),
+                      SCRIPT_ERR_OK);
+    BOOST_CHECK_EQUAL(ScriptVerdict(Program(10),
+                          SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_USDSOQ | SCRIPT_VERIFY_SOQUOBSCURA),
+                      SCRIPT_ERR_CONFIDENTIAL_USDSOQ_UNVERIFIED);
 }
 
 // Shapes outside the allocated forms must fail CLOSED at the script layer, not
@@ -322,9 +342,10 @@ BOOST_AUTO_TEST_CASE(free_witness_versions_are_v11_through_v16)
     const std::vector<int> expected = {11, 12, 13, 14, 15, 16};
     BOOST_CHECK_MESSAGE(free_ == expected,
         "the free witness-version range has moved. v10 is TAKEN (confidential USDSOQ, Tier A) "
-        "even though interpreter.cpp still treats it as a generic future version, which is the "
-        "half-allocation tracked on bead jzg0. Derive this list from the code before allocating "
-        "anything, never from a design document");
+        "in every layer: transaction.h, validation.cpp versionActive, and since FC4 the "
+        "interpreter's own is_confidential_usdsoq_witness dispatch (bead jzg0 closed the "
+        "half-allocation). Derive this list from the code before allocating anything, never "
+        "from a design document");
 }
 
 // ⚠️ WITNESS v0 IS RELAY-STANDARD AND NOT SPENDABLE AS ITS NAME IMPLIES.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -691,7 +691,11 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
         if (heightActive(Consensus::DEPLOYMENT_P2WSH_DILITHIUM)) activeWitnessVersions |= WitnessVersionBit(6);
         // BTCSOQ governs both the v8 holding form and the v9 authority marker.
         if (heightActive(Consensus::DEPLOYMENT_BTCSOQ))        activeWitnessVersions |= WitnessVersionBit(8) | WitnessVersionBit(9);
-        // v10-v16 are unallocated: never standard until one is assigned a deployment.
+        // v10 is ALLOCATED (confidential USDSOQ, gated on SOQUOBSCURA + USDSOQ
+        // together) but deliberately stays out of this mask: its Solver form and
+        // verifier ship with the activation release, and nothing is standard
+        // that Solver cannot name. v11-v16 are unallocated: never standard
+        // until one is assigned a deployment.
     }
 
     // Rather not work on nonstandard transactions (unless -testnet/-regtest)


### PR DESCRIPTION
Freeze Candidate 4 consensus package. Every consensus-touching item from the pre-freeze scan rides this one candidate so a single soak covers all of it, with the genesis ceremony (doc/GENESIS_CEREMONY.md) as the final staged step before the tag.

What changed and why:

1. MAX_MONEY capped at 20B SOQ. Ratified at 40B first; applying 40B made serialization_invariance_tests catch a third, undocumented bound: the chainstate amount codec (CompressAmount) overflows a uint64 for non-round amounts above roughly 20.49B coins, so a 40B cap would let legitimate UTXOs silently corrupt in the database. 20B satisfies the codec bound, the int64 additive bound, and operational needs (4.5x the largest consolidation ever observed). Both bounds are now static_asserted.
2. Witness v10 gets its own gated interpreter dispatch. Previously half-allocated: governed as confidential USDSOQ by transaction.h and validation.cpp while the interpreter treated it as a generic future version, anyone-can-spend even after activation. It now matches its siblings while dormant and fails closed on a dedicated script error when both gating deployments are active, since no confidential verifier ships (SOQ-I011). Pinned by an exact-error test and by the reworked keyimage deadcode case.
3. Testnet CSV moves off the inherited 2016/2017 BIP9 window (which resolves THRESHOLD_FAILED on a 2026-genesis chain) to ALWAYS_ACTIVE, matching mainnet. The regtest BIP9 lever now writes all three consensus structs.
4. The consensus digest is deliberately re-pinned, with the three moved inputs identified in the pin comment.
5. The genesis ceremony procedure is staged as a document so the re-mine itself is a one-sitting operation on ceremony day.

Verification: full unit suite at the final pin is 722 cases, 718 passing, exactly the 3 deliberate SoquObscura tripwires failing, 1 disabled legacy case skipped, 5,914,159 assertions with exactly 3 failing. Differential validation against stagenet history remains a pre-tag gate per the freeze-sequencing plan.
