### PR TITLE
consensus: stop routing v4 to an unsound verifier, and make the freeze tripwire measure consensus crypto

### DIFF
--- a/contrib/f4-digest-sweep.sh
+++ b/contrib/f4-digest-sweep.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# F4 cross-build digest sweep — bead v7xm fork-risk class F4, bead 71z6.
+#
+# WHAT THIS IS FOR. consensus_digest_tests computes one SHA256 over everything
+# the consensus rules are made of, and executes the code that derives it rather
+# than only reading constants back. Its second job is to be diffed ACROSS BUILDS:
+# an nh6m-class defect is invisible to functional tests because each build is
+# internally self-consistent, so the only way to see it is to compare a build
+# against another build.
+#
+# nh6m was not hypothetical. A strict-aliasing violation in AES-CTR nonce setup
+# made the seed-derived statement matrix depend on the optimisation level: gcc
+# -O2 and -Os derived a DIFFERENT matrix and rejected every honest proof. That is
+# a chain split from a compiler flag.
+#
+# ⛔ THIS SWEEP WAS NOT MEANINGFUL FOR THE SCRIPT PATH UNTIL 2026-08-27. Before
+# bead 71z6 the digest absorbed only witness-program dispatch and bailed on shape
+# checks before running any consensus cryptography, so identical digests across
+# builds proved far less than they appeared to. Re-run it now that
+# AbsorbOpcodeVerdicts executes PAT and the custom opcodes.
+#
+# USAGE
+#   bash contrib/f4-digest-sweep.sh                 # default levels
+#   bash contrib/f4-digest-sweep.sh -O0 -O2 -O3     # explicit levels
+#   SOQ_CONFIGURE_EXTRA="..." bash contrib/f4-digest-sweep.sh   # non-brew host
+#
+# Each level gets a CLEAN EXPORT of HEAD via `git archive`, built in its own
+# directory. Not a VPATH build: autotools refuses an out-of-tree build against an
+# already-configured source tree ("source directory already configured; run make
+# distclean there first"), and running distclean in the working tree would
+# destroy the developer's build. A fresh export per level is also what makes the
+# levels genuinely independent of each other.
+#
+# ⚠️ Only committed content is swept, because that is what `git archive` exports.
+# Commit before sweeping, or the sweep measures a different tree than the one in
+# front of you.
+#
+# PASS: every level prints the same digest.
+# FAIL: any difference is an nh6m-class defect and a launch blocker. Do not
+#       "just re-pin". Bisect which absorbed input diverged.
+
+set -u
+
+SRC="$(cd "$(dirname "$0")/.." && pwd)"
+LEVELS=("$@")
+if [ ${#LEVELS[@]} -eq 0 ]; then
+    LEVELS=(-O0 -O1 -O2 -O3 -Os)
+fi
+
+# Build directories live beside the source, never under /tmp: macOS clears /tmp
+# and a half-cleared build directory produces confusing failures.
+WORK="${SRC}/../soqucoin-f4-sweep"
+mkdir -p "$WORK"
+
+echo "=== F4 cross-build consensus digest sweep ==="
+echo "source: $SRC"
+echo "commit: $(git -C "$SRC" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+echo "levels: ${LEVELS[*]}"
+if [ -n "$(git -C "$SRC" status --porcelain 2>/dev/null)" ]; then
+    echo "⚠️  working tree is DIRTY — the sweep exports HEAD, not your edits"
+fi
+echo
+
+declare -a RESULTS
+FAILED=0
+NPROC="$(sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4)"
+
+for lvl in "${LEVELS[@]}"; do
+    bd="${WORK}/build${lvl}"
+    echo "--- ${lvl} : exporting and building in ${bd} ---"
+
+    # No deletion anywhere in this script. A stale directory is moved aside so a
+    # previous run's artifacts can never be mistaken for this run's evidence,
+    # and nothing is ever destroyed.
+    if [ -e "$bd" ]; then
+        mv "$bd" "${bd}.prev.$$" || { echo "    could not move stale dir aside"; FAILED=1; continue; }
+        echo "    (stale build moved to ${bd}.prev.$$)"
+    fi
+    mkdir -p "$bd"
+
+    (
+        cd "$SRC" || exit 1
+        git archive HEAD | tar -x -C "$bd" || exit 1
+        cd "$bd" || exit 1
+        ./autogen.sh >autogen.log 2>&1 || {
+            echo "    autogen FAILED, see ${bd}/autogen.log"; exit 1; }
+        # ⚠️ A fresh export does not inherit the working tree's configure
+        # environment, so boost and the homebrew include/lib paths must be given
+        # explicitly or configure dies on "Need at least boost 1.60.0". These
+        # mirror the options recorded in the working tree's config.status.
+        # Override with SOQ_CONFIGURE_EXTRA if your host differs.
+        BREW_PREFIX="$(brew --prefix 2>/dev/null || echo /opt/homebrew)"
+        EXTRA="${SOQ_CONFIGURE_EXTRA:---with-incompatible-bdb --with-boost=${BREW_PREFIX}/opt/boost --without-gui}"
+        # shellcheck disable=SC2086
+        ./configure $EXTRA \
+            CXXFLAGS="${lvl} -g" CFLAGS="${lvl} -g" \
+            LDFLAGS="-L${BREW_PREFIX}/lib" CPPFLAGS="-I${BREW_PREFIX}/include" \
+            >configure.log 2>&1 || {
+            echo "    configure FAILED, see ${bd}/configure.log"; exit 1; }
+        make -j"${NPROC}" -C src test/test_soqucoin >build.log 2>&1 || {
+            echo "    build FAILED, see ${bd}/build.log"; exit 1; }
+    ) || { RESULTS+=("${lvl} BUILD-FAILED"); FAILED=1; continue; }
+
+    # A PASSING digest test prints nothing, so ask for the value directly: the
+    # suite prints the computed digest on failure, and on success it equals the
+    # pin. Read the pin from the exported source so a stale working-tree edit
+    # cannot contaminate the comparison.
+    out="$("${bd}/src/test/test_soqucoin" --run_test=consensus_digest_tests 2>&1)"
+    if echo "$out" | grep -q "No errors detected"; then
+        dg="$(grep -A2 'const std::string expected' \
+              "${bd}/src/test/consensus_digest_tests.cpp" \
+              | grep -oE '[0-9a-f]{64}' | head -1)"
+    else
+        dg="$(echo "$out" | grep -oE 'digest is [0-9a-f]{64}' | grep -oE '[0-9a-f]{64}' | head -1)"
+    fi
+    if [ -z "$dg" ]; then
+        echo "    could not extract a digest from the test output"
+        RESULTS+=("${lvl} NO-DIGEST"); FAILED=1; continue
+    fi
+    echo "    ${lvl} -> ${dg}"
+    RESULTS+=("${lvl} ${dg}")
+done
+
+echo
+echo "=== RESULT ==="
+printf '%s\n' "${RESULTS[@]}"
+echo
+
+# ⛔ A FAILED BUILD IS NOT A PASS. The first version of this script counted
+# unique result strings, and "BUILD-FAILED" is itself a single unique value, so a
+# sweep in which EVERY level failed to build printed PASS. That is precisely the
+# defect class this sweep exists to catch — an instrument reporting green while
+# measuring nothing — so it is now guarded explicitly rather than implicitly.
+if [ "$FAILED" != "0" ]; then
+    echo "⛔ INCONCLUSIVE: at least one level did not produce a digest, so no"
+    echo "   comparison was made. This is NOT a pass. Logs are under ${WORK}."
+    exit 2
+fi
+if [ "${#RESULTS[@]}" -lt 2 ]; then
+    echo "⛔ INCONCLUSIVE: fewer than two levels produced a digest, so there was"
+    echo "   nothing to compare. This is NOT a pass."
+    exit 2
+fi
+
+uniq_count=$(printf '%s\n' "${RESULTS[@]}" | awk '{print $2}' | sort -u | wc -l | tr -d ' ')
+if [ "$uniq_count" = "1" ]; then
+    echo "PASS: one digest across all ${#RESULTS[@]} levels. Evidence of build-independence."
+else
+    echo "⛔ FAIL: digests differ across optimisation levels."
+    echo "   This is an nh6m-class defect and a LAUNCH BLOCKER."
+    echo "   Bisect the absorbed inputs; do not re-pin the constant."
+    exit 1
+fi

--- a/doc/DEPLOYMENT_PRECONDITIONS.md
+++ b/doc/DEPLOYMENT_PRECONDITIONS.md
@@ -1,0 +1,252 @@
+# Per-deployment activation preconditions
+
+**Status:** working document. Bead `x7hb` asked for exactly this and said why:
+
+> the freeze needs to ship alongside a written per-deployment precondition list —
+> what must be true before THIS deployment may be activated — rather than the
+> current situation where that constraint is restated in five separate beads and
+> depends on whoever is holding the pen remembering it.
+
+**What this is.** One row per consensus deployment: its state in the genesis
+binary, what it gates, and the conditions that must ALL be true before anyone
+sets an activation height for it. It is the checklist a reviewer, an auditor or a
+future maintainer reads instead of reconstructing the answer from beads.
+
+**What this is not.** It is not a schedule. No deployment here has a date, and
+the absence of one is deliberate.
+
+---
+
+## The rules that apply to every deployment
+
+These come from bead `9iu` (the flag-day runbook) and from the fund-loss path
+closed by commit `b4b8fddab`. They are preconditions in their own right: a
+feature that satisfies its own row and violates one of these is **not** ready.
+
+1. **Activation is by scheduled HEIGHT, not BIP9 signalling.** Soqucoin is
+   merge-mined and AuxPoW occupies the version high bits, so there is no
+   signalling constituency. Activation is `DeploymentActiveAtHeight` in
+   `ConnectBlock`, mirrored in the mempool.
+
+2. **Every consensus node must run a binary that knows the height BEFORE that
+   block arrives.** That means all `soqucoind` instances — broadcast, services,
+   relayers — and every merge-mining pool node. A node on an older binary does
+   not enforce the new rule and forks off at the activation block. Set the height
+   far enough ahead to guarantee 100% fleet coverage plus buffer.
+
+3. **One feature at a time, and only after its audit scope clears.** Never
+   batch-activate. `NOT_SCHEDULED` stays until the relevant Halborn Phase 2 scope
+   signs off on that specific feature.
+
+4. **Relay policy must move in lockstep with consensus, never ahead of it.** A
+   gated witness version is anyone-can-spend until its deployment activates. If
+   relay policy also calls it standard, the pair is not a safe failure, it is a
+   fund-loss path: the output relays, confirms, and then anybody may spend it.
+   That shipped for v5–v9 and was closed by replacing the carve-out list with an
+   activation mask that defaults to zero. **Precondition: the standardness mask
+   for this version derives from the same deployment state `ConnectBlock`
+   enforces.** Do not hand-add a version to a carve-out list.
+
+5. **Post-activation verification is part of the activation, not follow-up.**
+   After the height passes: confirm every node agrees on tip, and confirm the
+   feature actually engages — for example that a newly created output of that
+   type is no longer anyone-can-spend.
+
+6. **A rollback posture must be written down BEFORE the height is set.** A
+   soft-fork cannot be cleanly un-activated without coordination.
+
+7. **⛔ Adding a verifier where one did not exist is a RELAXATION.** Several rows
+   below ship a dispatch that fails closed. Replacing that reject with real
+   verification makes previously invalid spends valid, so it is only safe inside
+   a coordinated flag-day upgrade — which is why the scaffolding must be present
+   in the genesis binary (Gate 0 ruling, bead `r0vn`). Never satisfy a row by
+   deleting the dispatch.
+
+---
+
+## Active from genesis
+
+These are live on mainnet at block 0. Their preconditions are **launch**
+preconditions, not activation preconditions.
+
+### `DEPLOYMENT_CSV`, `DEPLOYMENT_SEGWIT` — `ALWAYS_ACTIVE`
+Historical Bitcoin deployments. Nothing outstanding.
+
+⚠️ **SegWit being active from genesis is load-bearing for everything else.** If
+it were not, every witness-dispatched feature (USDSOQ v5/v7, SoquObscura v4/v10,
+P2WSH-Dilithium, v6) would never execute even once height-activated. Confirm the
+launch binary carries the `g7c` fix (`7117c22f9`).
+
+### `DEPLOYMENT_CHECKPATAGG` (bit 3) — `ALWAYS_ACTIVE`
+PAT, the Practical **Attestation** Technique. Dilithium aggregation via
+`OP_CHECKPATAGG` and witness v2.
+
+**This is the only Soqucoin-specific consensus cryptography live at launch, so it
+carries the launch risk the others defer.**
+
+- ✅ Covered by Halborn Phase 1 (the L1/PQ engagement, 30 findings, all
+  remediated). Scope included the PAT batch-verification primitive.
+- ✅ Its verdicts are now inside the consensus digest, with valid proofs at
+  n=1..4 executed through the opcode and a tampered proof required to reject
+  (bead `71z6`). Before 2026-08-27 the digest reached no PAT cryptography at all.
+- ☐ **Cross-build evidence.** Run `contrib/f4-digest-sweep.sh` and record that
+  every optimisation level produces one digest. This is the F4 check, and it was
+  not meaningful for the script path until the coverage fix landed.
+- ☐ **Naming fix owed before the audit.** `consensus.h:36` mislabels PAT as
+  *Aggregation* where the technique is *Attestation* (bead `uv58`). ⚠️ PAT
+  verifies no signatures **by design** — two separate false P1 escalations have
+  been filed against it by readers who did not check the design intent first.
+  Read the patent and the headers before reporting anything here as a defect.
+
+---
+
+## Withdrawn — not to be activated
+
+### `DEPLOYMENT_LATTICEFOLD` (bit 28) — `nStartTime=0 / nTimeout=0`
+Terminal `THRESHOLD_FAILED`. `OP_CHECKFOLDPROOF` and witness v3.
+
+Withdrawn from launch consensus because the verifier reads its statement fields
+from the untrusted proof blob and every algebraic check is homogeneous in the
+witness, so an all-zero witness carrying a recomputed Fiat-Shamir seed verifies.
+A proof with no valid Dilithium signature therefore passes.
+
+**Preconditions to ever reactivate — all three, not any:**
+1. A real prover exists. There has never been one.
+2. The statement is anchored to a commitment fixed **outside** the proof.
+3. Re-audit. Halborn finding 7.3 was remediated and signed off SOLVED, and the
+   zero-witness class **survived that remediation** (bead `quwp`) because the fix
+   was scoped to external binding. A sign-off on one class is not a sign-off on
+   the defect.
+
+⛔ While inactive, witness v3 must stay relay-nonstandard via the BIP141 s4
+future-witness rejection. Do **not** add `OP_3` to the v5–v9 carve-outs.
+
+Guard: `latticefold_tests.cpp::mainnet_latticefold_deployment_never_active`.
+
+---
+
+## Dormant with machinery — activation candidates
+
+All of these are `nStartTime=0 / nTimeout=0` and `nActivationHeight =
+NOT_SCHEDULED` on **all four networks**.
+
+### `DEPLOYMENT_SOQUOBSCURA` (bit 5)
+Confidential transactions. Gates witness v4 (confidential SOQ) and, compounded
+with `DEPLOYMENT_USDSOQ`, witness v10 (confidential USDSOQ).
+
+Both dispatches currently **fail closed** when active, because no confidential
+verifier ships. v10 has done so since FC4; v4 joined it in
+`consensus: stop routing the v4 range proof to an unsound verifier`.
+
+**Preconditions:**
+1. ☐ **A verifier that binds the amount.** The in-tree `LatticeRangeProofV2` does
+   not: Check 4 compares a prover-supplied value against a homogeneous relation,
+   so `(0,0,0)` with an honest seed passes. Seeding the generators from
+   `consensus.latticeBPSeed` is **necessary but not sufficient** (bead `uv34`,
+   SOQ-I011). The replacement is the extracted LaZer subset.
+2. ☐ **All 18 degenerate-witness vectors reject.** Three mutation classes across
+   six honest bases; two of the three are **non-zero**, so a reject-if-all-zeros
+   patch cannot satisfy them. ⛔ The deliberate failures in
+   `soquobscura_degenerate_witness_tests.cpp` must never be patched at the symptom.
+3. ☐ **Halborn Phase 2 clearance** for the confidential layer. Per bead `uv58` the
+   audit cannot start until the layer is code-complete and wired: "Halborn gets
+   the FINISHED layer."
+4. ☐ **If the flag-2 pack aggregate is in scope: the portable LaBRADOR port**
+   (bead `bx46`). `validation.cpp:4987` puts `VerifyBlockAggregate` on the
+   `ConnectBlock` path and the archive requires AVX-512 by ratified decision D1.
+   6 of 8 fleet nodes have none, and a node without it rejects the block — no DoS
+   score, correctly, but it still stalls. **A hardware feature must not become a
+   de facto consensus requirement.**
+5. ☐ **Amount privacy must be true before it is claimed.** A v4/v10 output still
+   carries its amount in cleartext `nValue` (bead `sh2u`). Public copy has been
+   corrected to say "research direction, not yet available"; do not re-claim
+   amount privacy on activation unless this is actually fixed.
+
+Guard: `witness_version_allocation_tests::soquobscura_must_stay_dormant_on_every_network`.
+
+### `DEPLOYMENT_USDSOQ` (bit 6)
+Stablecoin authority opcodes, witness v5 (authority) and v7 (holdings).
+
+**Preconditions:**
+1. ☐ Halborn Phase 2 clearance for the USDSOQ layer.
+2. ☐ Per-asset value conservation enforced in `ConnectBlock` **and** mirrored in
+   the mempool. Policy-equals-consensus on both the input and output side; the
+   output side was the `b4b8fddab` fix.
+3. ☐ The authority registry and rotation path reviewed as part of that scope.
+4. ⛔ Activating USDSOQ alone does **not** enable confidential USDSOQ. Witness v10
+   is compound-gated on USDSOQ **and** SOQUOBSCURA, and fails closed when both are
+   active. Activating both without satisfying the SoquObscura row above turns a
+   fail-closed reject into a live confidential path with no verifier.
+
+### `DEPLOYMENT_BTCSOQ` (bit 14)
+Bitcoin-backed consensus asset, witness v8 (holding) and v9 (authority).
+
+**Preconditions:**
+1. ☐ The v8/v9 history sweep gate (bead `uen6.2`) run against the target network.
+2. ☐ Reorg and release hardening cluster closed (bead `1g6`) — notably that
+   `attemptRelease` re-verifies the deposit before paying.
+3. ☐ Bridge-side validator signatures actually verified. `mint_from_deposit`
+   currently counts set membership and never checks the signature bytes, and the
+   field is 64-byte Ed25519-shaped, which cannot carry ML-DSA-44 (bead `23q1`).
+   ⛔ This violates the standing rule: ML-DSA-44 only in the bridge signing path.
+4. ☐ Halborn Phase 2 clearance for the BTCSOQ layer.
+
+### `DEPLOYMENT_CTV` (bit 7), `DEPLOYMENT_APO` (bit 8), `DEPLOYMENT_CSFS` (bit 9)
+BIP 119 `OP_CHECKTEMPLATEVERIFY`, BIP 118 `SIGHASH_ANYPREVOUT`, BIP 348
+`OP_CHECKSIGFROMSTACK`. Covenants, eltoo Lightning, oracle and bridge attestation.
+
+**Preconditions:**
+1. ☐ Halborn Phase 2 covenant scope cleared. Groundwork exists in
+   `DL-COVENANT-ADVERSARIAL-AUDIT.md` and `DL-COVENANT-POST-AUDIT-HARDENING.md`.
+2. ☐ APO specifically: the hashtype gate must be pinned
+   (`apo_hashtype_gate_tests.cpp`), since ANYPREVOUT changes what a signature
+   commits to.
+3. ☐ These three are commonly activated together for eLTOO. That is still three
+   separate decisions under rule 3 above.
+
+### `DEPLOYMENT_P2WSH_DILITHIUM` (bit 10)
+Witness v6: P2WSH with Dilithium. Covenant script execution and L2SOQ Lightning.
+
+**Preconditions:**
+1. ☐ **An audit that is not currently scheduled.** This is called out explicitly
+   in `b4b8fddab` as an additional block beyond the deployment being inactive.
+2. ☐ ⛔ The witness-version allocation must be re-derived from `interpreter.cpp`
+   before any adjacent version is allocated. A v6 collision with P2WSH-Dilithium
+   was green in CI once already and forced a reallocation to v10. Never derive
+   the free list from a document.
+
+### `DEPLOYMENT_V6_CONTROLFLOW` (bit 13)
+`IF`/`CLTV`/`CSV`/`DROP`/`SHA256`/`EQUAL` inside v6 `EvalScript`, for the eLTOO
+ratchet and HTLCs.
+
+**Preconditions:**
+1. ☐ Cannot precede `DEPLOYMENT_P2WSH_DILITHIUM`: it extends v6 script execution,
+   so activating it first has no meaning.
+2. ☐ Halborn Phase 2 clearance for the restored control-flow surface.
+
+### `DEPLOYMENT_DILITHIUM_KEYHASH` (bit 12)
+`OP_CHECKDILITHIUMKEYHASH`: key-committed Dilithium verification, eLTOO 2-of-2.
+
+**Preconditions:**
+1. ☐ Halborn Phase 2 clearance.
+2. ☐ Committed-keyhash tests green (`dilithium_keyhash_committed_tests.cpp`).
+
+### `DEPLOYMENT_UTXO_COST` (bit 11)
+SOQ-ARCH-003, consensus-enforced minimum UTXO value.
+
+**Preconditions:**
+1. ☐ Confirm it remains a **tightening**. A tightening can be added later as a
+   soft fork, which is why bead `x7hb` places it outside the freeze scope.
+2. ☐ The 0-value v4 dust and utxo-cost exemption (seam-audit F8/R1) must be
+   settled first, or activating this rejects outputs the confidential design
+   depends on.
+
+---
+
+## Maintaining this document
+
+- A new deployment is not complete until it has a row here.
+- A precondition is discharged by **evidence**, not by assertion. Link the commit,
+  the test, or the audit finding.
+- When a row's conditions are all met, that is the input to the activation
+  decision. It is not the decision.

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -412,113 +412,53 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
                     } else if (opcode == OP_SOQUOBSCURA_RANGEPROOF) {
 #ifndef BUILD_BITCOIN_INTERNAL
                         // =========================================================
-                        // SOQ-P003: Lattice-BP++ Range Proof Verification
-                        // Post-quantum confidential transaction amount hiding
-                        // using Ring-LWE commitments over Dilithium's cyclotomic
-                        // ring R_q = Z_q[X]/(X^256 + 1), q = 8380417.
+                        // SOQ-P003 / SOQ-I011: SoquObscura range proof.
+                        // REJECT-PATH SCAFFOLDING — no confidential verifier ships.
                         //
-                        // Stack layout:
-                        //   top:    proof_blob (serialized LatticeRangeProof)
+                        // Stack layout the activation release will consume:
+                        //   top:    proof_blob (serialized range proof)
                         //   top-1:  pubkey_hash (32 bytes, identity binding)
                         //   top-2:  commitment (serialized LatticeCommitment)
                         //
-                        // Fiat-Shamir binding: challenge = SHA256(domain ||
-                        //   sighash || pubkey_hash || bit_commitments)
+                        // -- Do NOT route this path to latticebp::LatticeRangeProofV2 --
+                        // That verifier does not bind the amount. Check 4 compares a
+                        // PROVER-SUPPLIED t_reconstruction against
+                        // z_response*A + z_randomness*S; both sides are
+                        // prover-controlled and the relation is HOMOGENEOUS, so
+                        // (z, z_r, t) = (0, 0, 0) carrying an honestly recomputed
+                        // Fiat-Shamir seed satisfies every check. Seeding the
+                        // generators from consensus.latticeBPSeed is NECESSARY BUT
+                        // NOT SUFFICIENT, because the relation remains homogeneous
+                        // with real generators. Bead: uv34 (SOQ-I011). The forgery
+                        // class is pinned by the 18 degenerate vectors on the
+                        // vendored corpus, two of whose three mutations are NON-ZERO,
+                        // so a reject-if-all-zeros patch cannot satisfy it either.
+                        //
+                        // Posture mirrors witness v10, whose dispatch already carries
+                        // this rule and fails closed with
+                        // SCRIPT_ERR_CONFIDENTIAL_USDSOQ_UNVERIFIED. The activation
+                        // release replaces this reject with real verification INSIDE
+                        // this existing dispatch, so activation is a rules change and
+                        // never a code-shape change (Gate 0 scaffolding ruling, bead
+                        // r0vn).
                         // =========================================================
 
-                        // Consensus gating: not active until soft-fork
+                        // Consensus gating: not active until soft-fork. The dormant
+                        // posture is unchanged — to a node today the opcode does not
+                        // exist. DEPLOYMENT_SOQUOBSCURA is nStartTime=0/nTimeout=0 and
+                        // NOT_SCHEDULED on all four networks, so this is the branch
+                        // every network takes, and the reject below is unreachable in
+                        // production. Guarded by
+                        // witness_version_allocation_tests::
+                        // soquobscura_must_stay_dormant_on_every_network.
                         if (!(flags & SCRIPT_VERIFY_SOQUOBSCURA)) {
                             return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
                         }
 
-                        // Minimum stack: proof_blob + pubkey_hash + commitment = 3
-                        if (stack.size() < 3) {
-                            return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
-                        }
-
-                        const valtype& vchRangeProof = stacktop(-1);
-                        const valtype& vchPubkeyHashRP = stacktop(-2);
-                        const valtype& vchCommitment = stacktop(-3);
-
-                        // Validate pubkey_hash is exactly 32 bytes
-                        if (vchPubkeyHashRP.size() != 32) {
-                            return set_error(serror, SCRIPT_ERR_SOQUOBSCURA_RANGEPROOF_FAILED);
-                        }
-
-                        // Validate commitment matches expected serialized size
-                        if (vchCommitment.size() != latticebp::LatticeCommitment::SIZE) {
-                            return set_error(serror, SCRIPT_ERR_SOQUOBSCURA_RANGEPROOF_FAILED);
-                        }
-
-                        // Validate proof size within bounds
-                        if (vchRangeProof.empty() || vchRangeProof.size() > 16384) {
-                            return set_error(serror, SCRIPT_ERR_SOQUOBSCURA_RANGEPROOF_FAILED);
-                        }
-
-                        try {
-                            // Deserialize the range proof from raw bytes
-                            std::vector<uint8_t> proofBytes(vchRangeProof.begin(), vchRangeProof.end());
-                            latticebp::LatticeRangeProofV2 proof;
-                            if (!latticebp::LatticeRangeProofV2::deserialize(proofBytes, proof)) {
-                                return set_error(serror, SCRIPT_ERR_SOQUOBSCURA_RANGEPROOF_FAILED);
-                            }
-
-                            // Reconstruct commitment from serialized witness data
-                            std::vector<uint8_t> commitBytes(vchCommitment.begin(), vchCommitment.end());
-                            latticebp::LatticeCommitment commitment =
-                                latticebp::LatticeCommitment::deserialize(commitBytes);
-
-                            // Build sighash and pubkey_hash arrays for Fiat-Shamir binding
-                            std::array<uint8_t, 32> sighash_arr;
-                            {
-                                CHashWriter ss(SER_GETHASH, 0);
-                                ss << std::string("LatticeBP-RangeProof");
-                                ss.write((const char*)vchPubkeyHashRP.data(), 32);
-                                uint256 h = ss.GetHash();
-                                memcpy(sighash_arr.data(), h.begin(), 32);
-                            }
-
-                            std::array<uint8_t, 32> pubkey_hash_arr;
-                            memcpy(pubkey_hash_arr.data(), vchPubkeyHashRP.data(), 32);
-
-                            // ⛔⛔ SOQ-I011: THIS VERIFIER DOES NOT BIND THE AMOUNT.
-                            // Default-constructed, so commit_params.A and .S are all-zero
-                            // (RingElement's default ctor zero-fills). Check 4 in
-                            // LatticeRangeProofV2::verify compares the prover-supplied
-                            // t_reconstruction against z_response*A + z_randomness*S, which
-                            // with zero generators collapses to "t_reconstruction == 0"
-                            // regardless of the responses. Any proof blob carrying a zero t
-                            // and a correct Fiat-Shamir seed verifies, and the seed is
-                            // computable from public data alone.
-                            //
-                            // Root cause: consensus.latticeBPSeed exists in chainparams for
-                            // exactly this and is read NOWHERE. LatticeCommitment::
-                            // PublicParams::generate() has no consensus caller. Seeding it
-                            // here is necessary but NOT sufficient: Check 4 is homogeneous
-                            // even with real generators, so (z, z_r, t) = (0, 0, 0) passes.
-                            // See soquobscura_degenerate_witness_tests.cpp, whose three
-                            // failures are deliberate, and the tripwire
-                            // witness_version_allocation_tests::
-                            // soquobscura_must_stay_dormant_on_every_network.
-                            //
-                            // Harmless today: DEPLOYMENT_SOQUOBSCURA is NOT_SCHEDULED on all
-                            // four networks and creating a v4/v10 output is consensus-
-                            // rejected (SOQ-ARCH-001 / SOQ-I009), so this code is
-                            // unreachable. Do NOT schedule an activation height.
-                            latticebp::RangeProofParams rp_params;
-                            if (!proof.verify(commitment, rp_params,
-                                              sighash_arr, pubkey_hash_arr)) {
-                                return set_error(serror, SCRIPT_ERR_SOQUOBSCURA_RANGEPROOF_FAILED);
-                            }
-                        } catch (const std::exception& e) {
-                            return set_error(serror, SCRIPT_ERR_SOQUOBSCURA_RANGEPROOF_FAILED);
-                        }
-
-                        // Pop all 3 items and push true
-                        popstack(stack);
-                        popstack(stack);
-                        popstack(stack);
-                        stack.push_back(valtype(1, 1)); // true
+                        // Active, and no verifier ships: FAIL CLOSED. There is
+                        // deliberately no accept path and no stack push here.
+                        return set_error(serror,
+                                         SCRIPT_ERR_SOQUOBSCURA_RANGEPROOF_UNVERIFIED);
 #else
                         // Consensus shared lib: latticebp verification not available.
                         // This opcode is a future soft-fork — reject in shared lib context.

--- a/src/script/script_error.cpp
+++ b/src/script/script_error.cpp
@@ -44,6 +44,8 @@ const char* ScriptErrorString(const ScriptError serror)
         return "BTCSOQ authority marker may only be spent by an authority transaction";
     case SCRIPT_ERR_CONFIDENTIAL_USDSOQ_UNVERIFIED:
         return "Confidential USDSOQ spend rejected: no confidential verifier is shipped";
+    case SCRIPT_ERR_SOQUOBSCURA_RANGEPROOF_UNVERIFIED:
+        return "SoquObscura range proof rejected: no confidential verifier is shipped";
     case SCRIPT_ERR_CHECKTEMPLATEVERIFY:
         return "OP_CHECKTEMPLATEVERIFY hash mismatch";
     case SCRIPT_ERR_CHECKSIGFROMSTACK:

--- a/src/script/script_error.h
+++ b/src/script/script_error.h
@@ -106,6 +106,19 @@ typedef enum ScriptError_t {
     SCRIPT_ERR_OP_CODESEPARATOR,
     SCRIPT_ERR_SIG_FINDANDDELETE,
 
+    /* OP_SOQUOBSCURA_RANGEPROOF (witness v4, confidential SOQ): reject-path
+     * scaffolding, the sibling of SCRIPT_ERR_CONFIDENTIAL_USDSOQ_UNVERIFIED.
+     * Fails closed when DEPLOYMENT_SOQUOBSCURA is active, because no
+     * confidential verifier is shipped — the in-tree LatticeRangeProofV2 does
+     * not bind the amount (SOQ-I011), so that path deliberately does not route
+     * to it. Replaced by real verification in the activation release.
+     *
+     * ⛔ APPENDED AT THE END ON PURPOSE. consensus_digest_tests hashes the
+     * NUMERIC ScriptError value (d.I64((int64_t)serr)), so inserting a value
+     * mid-enum renumbers every error after it and moves the consensus digest for
+     * a reason unrelated to any rule change. New errors go here. */
+    SCRIPT_ERR_SOQUOBSCURA_RANGEPROOF_UNVERIFIED,
+
     SCRIPT_ERR_ERROR_COUNT
 } ScriptError;
 

--- a/src/test/consensus_digest_tests.cpp
+++ b/src/test/consensus_digest_tests.cpp
@@ -37,10 +37,12 @@
 #include "amount.h"
 #include "consensus/consensus.h"
 #include "consensus/params.h"
+#include "crypto/pat/logarithmic.h"
 #include "crypto/sha256.h"
 #include "primitives/block.h"
 #include "script/interpreter.h"
 #include "script/script.h"
+#include "script/script_error.h"
 #include "soqucoin.h"
 #include "streams.h"
 #include "uint256.h"
@@ -174,6 +176,249 @@ void AbsorbScriptVerdicts(DigestBuilder& d)
     }
 }
 
+//! A deterministic byte vector. ⛔ NEVER use GetRandHashVec() or anything else
+//! random in this file: the digest has to be reproducible across builds forever,
+//! which is the entire point of the instrument.
+std::vector<unsigned char> FixedVec(size_t n, unsigned char seed)
+{
+    std::vector<unsigned char> v(n);
+    for (size_t i = 0; i < n; ++i) v[i] = (unsigned char)((seed + i * 31u) & 0xff);
+    return v;
+}
+
+//! A VALID PAT full-mode script, built from fixed material.
+//!
+//! This is the one place the digest reaches real consensus cryptography, and it
+//! matters more than the rest of this file put together: PAT is the only one of
+//! these features ACTIVE FROM GENESIS on mainnet (SCRIPT_VERIFY_PAT), and its
+//! proof construction is hash-tree arithmetic — exactly where an nh6m-class
+//! codegen difference expresses itself.
+//!
+//! Stack layout, per interpreter.cpp's OP_CHECKPATAGG handler:
+//!   <sigs...> <pks...> <msgs...> <count_le32> <proof> <agg_pk> <msg_root>
+//!
+//! The 32-byte "sigs" are not Dilithium signatures and are not meant to be. PAT
+//! verifies no signatures by design; it proves an aggregation relation over the
+//! supplied material. Fixed vectors are therefore a faithful input, and the
+//! upstream PAT tests use random ones of exactly this shape.
+bool BuildValidPatScript(uint32_t n, CScript& out)
+{
+    std::vector<std::vector<unsigned char> > sigs, pks, msgs;
+    for (uint32_t i = 0; i < n; ++i) {
+        sigs.push_back(FixedVec(32, (unsigned char)(0x10 + i)));
+        pks.push_back(FixedVec(32, (unsigned char)(0x40 + i)));
+        msgs.push_back(FixedVec(32, (unsigned char)(0x70 + i)));
+    }
+
+    std::vector<unsigned char> proof_data;
+    if (!pat::CreateLogarithmicProof(sigs, pks, msgs, proof_data)) return false;
+
+    pat::LogarithmicProof proof;
+    if (!pat::ParseLogarithmicProof(proof_data, proof)) return false;
+
+    const std::vector<unsigned char> agg_pk(proof.pk_agg.begin(), proof.pk_agg.end());
+    const std::vector<unsigned char> msg_root(proof.msg_root.begin(), proof.msg_root.end());
+
+    out = CScript();
+    for (uint32_t i = 0; i < n; ++i) out << sigs[i];
+    for (uint32_t i = 0; i < n; ++i) out << pks[i];
+    for (uint32_t i = 0; i < n; ++i) out << msgs[i];
+    std::vector<unsigned char> count(4);
+    for (int i = 0; i < 4; ++i) count[i] = (unsigned char)((n >> (8 * i)) & 0xff);
+    out << count;
+    out << proof_data << agg_pk << msg_root;
+    out << OP_CHECKPATAGG;
+    return true;
+}
+
+//! ★★★ Custom-opcode and real-crypto verdicts. Bead 71z6.
+//!
+//! WHY THIS EXISTS. Until 2026-08-27 the script half of this digest absorbed
+//! only witness-program dispatch: AbsorbScriptVerdicts builds an
+//! `OP_N <program>` scriptPubKey and hands it a TWO-item, four-byte witness
+//! stack. Every witness-dispatched feature demands more than that and returns a
+//! shape error before reaching its verification math — PAT, for instance,
+//! requires witness->stack.size() >= 4 (interpreter.cpp:1644) and otherwise
+//! returns SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH. So the digest exercised the
+//! dispatch and NOT ONE LINE of consensus cryptography, while its own header
+//! claimed the interpreter was included because that is 'where a codegen
+//! difference could actually express itself'.
+//!
+//! That was demonstrated rather than argued: the v4 dispatch was changed from
+//! calling an unsound verifier to failing closed, a new ScriptError was added,
+//! and this digest did not move.
+//!
+//! Nothing else covered the gap. Functional tests run on ONE build, so an
+//! nh6m-class defect is invisible to them by construction. Differential
+//! validation replays stagenet history through a SINGLE binary, so it compares
+//! against history rather than against another build. This was the only
+//! cross-build instrument, and it stopped at shape checks.
+//!
+//! ⛔ RULES FOR EXTENDING THIS FUNCTION:
+//!   * Deterministic inputs only. No randomness, no clock, no host state.
+//!   * Absorb (ok, serr) for BOTH the gated-off and gated-on flag state, so a
+//!     change to gating moves the digest as well as a change to verification.
+//!   * Adding anything here MOVES THE DIGEST. Re-pin deliberately and say what
+//!     was added in the commit message.
+//!   * New ScriptError values go at the END of the enum. This function absorbs
+//!     the NUMERIC value, so inserting mid-enum renumbers every later error and
+//!     moves the digest for no behavioural reason.
+void AbsorbOpcodeVerdicts(DigestBuilder& d)
+{
+    BaseSignatureChecker checker;
+
+    // -- PAT, the genesis-active path, with material that reaches the crypto --
+    // Absorbed for several aggregation widths because the proof is a hash tree
+    // and the tree shape changes with n.
+    for (uint32_t n : {uint32_t(1), uint32_t(2), uint32_t(3), uint32_t(4)}) {
+        CScript patScript;
+        const bool built = BuildValidPatScript(n, patScript);
+        d.I64(built ? 1 : 0);
+        d.I64(n);
+        if (!built) continue;
+
+        // The proof bytes themselves are consensus-visible output of the PAT
+        // construction, so absorb the script directly as well as the verdict.
+        // If a codegen difference changes the hash tree, this catches it even if
+        // the verdict happens to stay the same.
+        d.U64(patScript.size());
+        d.Bytes((const unsigned char*)patScript.data(), patScript.size());
+
+        for (unsigned int flags : {(unsigned int)0, (unsigned int)SCRIPT_VERIFY_PAT}) {
+            std::vector<std::vector<unsigned char> > stack;
+            ScriptError serr = SCRIPT_ERR_OK;
+            const bool ok = EvalScript(stack, patScript, flags, checker,
+                                       SIGVERSION_BASE, &serr);
+            d.I64(flags);
+            d.I64(ok ? 1 : 0);
+            d.I64((int64_t)serr);
+            d.U64(stack.size());
+            for (const std::vector<unsigned char>& item : stack) {
+                d.U64(item.size());
+                if (!item.empty()) d.Bytes(item.data(), item.size());
+            }
+        }
+    }
+
+    // -- A tampered PAT proof must be rejected, and the REASON is absorbed --
+    // A codegen difference that broke the aggregation check would most likely
+    // show up as this flipping to accept.
+    {
+        CScript patScript;
+        if (BuildValidPatScript(3, patScript)) {
+            // Rebuild with one witness pk replaced, header left honest.
+            std::vector<std::vector<unsigned char> > sigs, pks, msgs;
+            for (uint32_t i = 0; i < 3; ++i) {
+                sigs.push_back(FixedVec(32, (unsigned char)(0x10 + i)));
+                pks.push_back(FixedVec(32, (unsigned char)(0x40 + i)));
+                msgs.push_back(FixedVec(32, (unsigned char)(0x70 + i)));
+            }
+            std::vector<unsigned char> proof_data;
+            if (pat::CreateLogarithmicProof(sigs, pks, msgs, proof_data)) {
+                pat::LogarithmicProof proof;
+                if (pat::ParseLogarithmicProof(proof_data, proof)) {
+                    const std::vector<unsigned char> agg_pk(proof.pk_agg.begin(), proof.pk_agg.end());
+                    const std::vector<unsigned char> msg_root(proof.msg_root.begin(), proof.msg_root.end());
+                    pks[1] = FixedVec(32, 0xEE);  // tamper
+
+                    CScript bad;
+                    for (uint32_t i = 0; i < 3; ++i) bad << sigs[i];
+                    for (uint32_t i = 0; i < 3; ++i) bad << pks[i];
+                    for (uint32_t i = 0; i < 3; ++i) bad << msgs[i];
+                    std::vector<unsigned char> count(4, 0); count[0] = 3;
+                    bad << count << proof_data << agg_pk << msg_root;
+                    bad << OP_CHECKPATAGG;
+
+                    std::vector<std::vector<unsigned char> > stack;
+                    ScriptError serr = SCRIPT_ERR_OK;
+                    const bool ok = EvalScript(stack, bad, SCRIPT_VERIFY_PAT, checker,
+                                               SIGVERSION_BASE, &serr);
+                    d.I64(ok ? 1 : 0);
+                    d.I64((int64_t)serr);
+                }
+            }
+        }
+    }
+
+    // -- Every other custom opcode, in both gate states --
+    //
+    // These carry well-SHAPED but deliberately invalid payloads. That is not a
+    // weakness: nh6m lived in seed-derived statement-matrix construction, i.e.
+    // in deserialisation and derivation, which runs before any accept decision.
+    // Exercising the parse-and-derive path with fixed bytes is what catches that
+    // class. Where a payload cannot be made valid deterministically without a
+    // prover, the recorded verdict is a reject, and a codegen change that moves
+    // WHICH reject fires still moves the digest.
+    struct OpCase {
+        const char* name;
+        opcodetype op;
+        unsigned int gate;
+        int stack_items;
+        size_t item_size;
+    };
+    const OpCase opCases[] = {
+        { "checkpatagg_malformed",  OP_CHECKPATAGG,           SCRIPT_VERIFY_PAT,          4,   32 },
+        { "checkfoldproof",         OP_CHECKFOLDPROOF,        SCRIPT_VERIFY_LATTICEFOLD,  4, 1280 },
+        { "soquobscura_rangeproof", OP_SOQUOBSCURA_RANGEPROOF, SCRIPT_VERIFY_SOQUOBSCURA, 3,  256 },
+        { "usdsoq_mint",            OP_USDSOQ_MINT,           SCRIPT_VERIFY_USDSOQ,       4,   64 },
+        { "usdsoq_burn",            OP_USDSOQ_BURN,           SCRIPT_VERIFY_USDSOQ,       4,   64 },
+        { "usdsoq_freeze",          OP_USDSOQ_FREEZE,         SCRIPT_VERIFY_USDSOQ,       4,   64 },
+        { "usdsoq_rotate",          OP_USDSOQ_ROTATE,         SCRIPT_VERIFY_USDSOQ,       4,   64 },
+        { "checkdilithiumkeyhash",  OP_CHECKDILITHIUMKEYHASH, SCRIPT_VERIFY_DILITHIUM_KEYHASH, 3, 64 },
+    };
+
+    for (const OpCase& c : opCases) {
+        d.Str(c.name);
+        for (unsigned int flags : {(unsigned int)0, c.gate}) {
+            CScript script = CScript() << c.op;
+            std::vector<std::vector<unsigned char> > stack;
+            for (int i = 0; i < c.stack_items; ++i) {
+                stack.push_back(FixedVec(c.item_size, (unsigned char)(0x20 + i)));
+            }
+            ScriptError serr = SCRIPT_ERR_OK;
+            const bool ok = EvalScript(stack, script, flags, checker,
+                                       SIGVERSION_BASE, &serr);
+            d.I64(flags);
+            d.I64(ok ? 1 : 0);
+            d.I64((int64_t)serr);
+        }
+    }
+
+    // -- Satoshi Restoration arithmetic guards --
+    // Pure integer arithmetic with fixed operands: the cheapest possible probe
+    // for an arithmetic codegen difference, and it exercises the division and
+    // modulo guards that carry their own script errors.
+    {
+        struct ArithCase { const char* name; int64_t a; int64_t b; opcodetype op; };
+        const ArithCase arith[] = {
+            { "div_normal",   1000,  7, OP_DIV },
+            { "div_by_zero",  1000,  0, OP_DIV },
+            { "mod_normal",   1000,  7, OP_MOD },
+            { "mod_by_zero",  1000,  0, OP_MOD },
+            { "div_negative", -1000, 7, OP_DIV },
+            { "mod_negative", -1000, 7, OP_MOD },
+            { "mul_large",    1 << 30, 1 << 20, OP_MUL },
+            { "lshift",       1,      31, OP_LSHIFT },
+            { "rshift",       1 << 30, 15, OP_RSHIFT },
+        };
+        for (const ArithCase& a : arith) {
+            d.Str(a.name);
+            CScript script = CScript() << CScriptNum(a.a) << CScriptNum(a.b) << a.op;
+            std::vector<std::vector<unsigned char> > stack;
+            ScriptError serr = SCRIPT_ERR_OK;
+            const bool ok = EvalScript(stack, script, SCRIPT_VERIFY_SCRIPT_RESTORE,
+                                       checker, SIGVERSION_BASE, &serr);
+            d.I64(ok ? 1 : 0);
+            d.I64((int64_t)serr);
+            d.U64(stack.size());
+            for (const std::vector<unsigned char>& item : stack) {
+                d.U64(item.size());
+                if (!item.empty()) d.Bytes(item.data(), item.size());
+            }
+        }
+    }
+}
+
 //! Network-independent consensus constants. These live in headers rather than
 //! chainparams, so nothing above would notice them changing — and MAX_MONEY in
 //! particular is consensus-critical (MoneyRange gates every value check) and was
@@ -231,6 +476,7 @@ uint256 ComputeConsensusDigest()
     }
 
     AbsorbScriptVerdicts(d);
+    AbsorbOpcodeVerdicts(d);
 
     SelectParams(CBaseChainParams::MAIN);
     return d.Finalize();
@@ -271,12 +517,113 @@ BOOST_AUTO_TEST_CASE(consensus_digest_is_pinned)
     // Prior pin history: moved from 0489e98d... on 2026-08-20 when
     // AbsorbGlobalLimits first brought MAX_MONEY and the block limits under
     // the digest (verified by isolation at the time).
+    //
+    // Moved from f830d7d6... on 2026-08-27 when AbsorbOpcodeVerdicts was added
+    // (bead 71z6). This was a COVERAGE change, not a rule change: no consensus
+    // rule moved, the digest simply started measuring things it had never
+    // measured. Before this, the script half of the digest absorbed only
+    // witness-program DISPATCH — AbsorbScriptVerdicts hands every witness
+    // version a two-item, four-byte witness stack, and every feature bails on
+    // its shape check before reaching any verification math (PAT requires
+    // >= 4 items, interpreter.cpp:1644). So the digest exercised no consensus
+    // cryptography at all, while claiming the interpreter was included because
+    // that is where a codegen difference expresses itself.
+    //
+    // Proven, not assumed: changing the v4 dispatch from calling an unsound
+    // verifier to failing closed, plus adding a ScriptError, did NOT move the
+    // old digest. The new function is guarded by
+    // opcode_coverage_actually_reaches_pat_crypto below, so the coverage cannot
+    // silently regress to shape-rejection again.
     const std::string expected =
-        "f830d7d6e85f044feb88243263755a92c67a15a480e4f3c9d9ba074e0533bc80";
+        "df60b54de75e72cf1cd7387cb0b1bc01191c1bccd0a1e7644927aa423750401b";
 
     BOOST_CHECK_MESSAGE(digest.ToString() == expected,
         "consensus digest is " + digest.ToString() + ", expected " + expected +
         ". Identify which consensus input moved before updating the constant.");
+}
+
+// ---------------------------------------------------------------------------
+// ★★★ THE COVERAGE GUARD. Bead 71z6.
+//
+// A digest can be green, stable and cross-build identical while measuring
+// nothing that matters — which is exactly the state this file was in until
+// 2026-08-27. Pinning the constant does not detect that; only asserting that the
+// instrument reaches real cryptography does.
+//
+// This test therefore makes two claims about AbsorbOpcodeVerdicts' inputs:
+//   1. A VALID PAT proof can be built from fixed material, so the digest is not
+//      silently absorbing a construction failure.
+//   2. That proof is ACCEPTED with SCRIPT_VERIFY_PAT set — meaning execution got
+//      past every shape check and through the aggregation arithmetic — and a
+//      tampered one is REJECTED, meaning the check is load-bearing rather than
+//      vacuous.
+//
+// PAT is the case that matters most: it is the only one of these features active
+// from genesis on mainnet, and its proof is hash-tree arithmetic, the same shape
+// of code as the nh6m defect.
+//
+// ⛔ If this fails, do not re-pin the digest. The digest has stopped measuring
+// consensus cryptography and the pin is meaningless until it does again.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(opcode_coverage_actually_reaches_pat_crypto)
+{
+    BaseSignatureChecker checker;
+
+    for (uint32_t n : {uint32_t(1), uint32_t(2), uint32_t(3), uint32_t(4)}) {
+        CScript patScript;
+        BOOST_REQUIRE_MESSAGE(BuildValidPatScript(n, patScript),
+            "could not build a valid PAT proof at n=" + std::to_string(n) +
+            "; AbsorbOpcodeVerdicts is absorbing a construction failure, so the "
+            "digest is not measuring PAT at all");
+
+        std::vector<std::vector<unsigned char> > stack;
+        ScriptError serr = SCRIPT_ERR_OK;
+        const bool ok = EvalScript(stack, patScript, SCRIPT_VERIFY_PAT, checker,
+                                   SIGVERSION_BASE, &serr);
+        BOOST_CHECK_MESSAGE(ok,
+            "a VALID PAT proof at n=" + std::to_string(n) + " was rejected with "
+            "error " + std::to_string((int)serr) + ". Either PAT is broken, or the "
+            "digest's PAT input stopped being valid and is now recording a shape "
+            "rejection instead of the aggregation arithmetic — which is the exact "
+            "blindness bead 71z6 fixed.");
+    }
+
+    // The check must be load-bearing: tamper one witness pk, leave the header
+    // honest, and require rejection. A verifier that accepts this is measuring
+    // nothing, and a digest over it would be stable and worthless.
+    {
+        std::vector<std::vector<unsigned char> > sigs, pks, msgs;
+        for (uint32_t i = 0; i < 3; ++i) {
+            sigs.push_back(FixedVec(32, (unsigned char)(0x10 + i)));
+            pks.push_back(FixedVec(32, (unsigned char)(0x40 + i)));
+            msgs.push_back(FixedVec(32, (unsigned char)(0x70 + i)));
+        }
+        std::vector<unsigned char> proof_data;
+        BOOST_REQUIRE(pat::CreateLogarithmicProof(sigs, pks, msgs, proof_data));
+        pat::LogarithmicProof proof;
+        BOOST_REQUIRE(pat::ParseLogarithmicProof(proof_data, proof));
+        const std::vector<unsigned char> agg_pk(proof.pk_agg.begin(), proof.pk_agg.end());
+        const std::vector<unsigned char> msg_root(proof.msg_root.begin(), proof.msg_root.end());
+
+        pks[1] = FixedVec(32, 0xEE);
+
+        CScript bad;
+        for (uint32_t i = 0; i < 3; ++i) bad << sigs[i];
+        for (uint32_t i = 0; i < 3; ++i) bad << pks[i];
+        for (uint32_t i = 0; i < 3; ++i) bad << msgs[i];
+        std::vector<unsigned char> count(4, 0); count[0] = 3;
+        bad << count << proof_data << agg_pk << msg_root;
+                    bad << OP_CHECKPATAGG;
+
+        std::vector<std::vector<unsigned char> > stack;
+        ScriptError serr = SCRIPT_ERR_OK;
+        const bool ok = EvalScript(stack, bad, SCRIPT_VERIFY_PAT, checker,
+                                   SIGVERSION_BASE, &serr);
+        BOOST_CHECK_MESSAGE(!ok,
+            "a TAMPERED PAT proof was accepted. The aggregation check is not "
+            "load-bearing, so absorbing its verdict into the consensus digest "
+            "measures nothing.");
+    }
 }
 
 // Determinism within a single build. A digest that varies run to run would mean

--- a/src/test/soquobscura_degenerate_witness_tests.cpp
+++ b/src/test/soquobscura_degenerate_witness_tests.cpp
@@ -30,10 +30,42 @@
 // position, since every input to that hash is public.
 //
 // If a test here fails, do not "fix the test".
+//
+// =============================================================================
+// ⛔ 2026-08-27: WHAT CHANGED, AND WHY THREE ASSERTIONS NOW READ "ACCEPTED"
+//
+// These three cases used to assert REJECTION and therefore failed on purpose,
+// as a tripwire for the unsound verifier. That made the only CI job which runs
+// `make check` permanently red, so a genuine regression during the v2.2.0 freeze
+// soak was indistinguishable from the status quo (bead 1zc1). Marking them as
+// expected-failures was considered and rejected: it manages the symptom.
+//
+// The root cause was fixed instead. LatticeRangeProofV2 cannot be repaired in
+// place — every algebraic check on its accept path is HOMOGENEOUS in the
+// prover-supplied values, so seeding the generators from consensus.latticeBPSeed
+// is necessary but not sufficient (bead uv34 / SOQ-I011). So the v4 consensus
+// dispatch no longer calls it: interpreter.cpp fails closed with
+// SCRIPT_ERR_SOQUOBSCURA_RANGEPROOF_UNVERIFIED, mirroring what witness v10
+// already did. The real verifier arrives in the activation release, inside the
+// same dispatch, per the Gate 0 scaffolding ruling (bead r0vn).
+//
+// So the three cases below no longer describe a live exposure. They are
+// CHARACTERISATION TESTS: they document, by execution, the defect that justified
+// removing the class from consensus, and they will notice if anyone changes it.
+// The property that protects the chain is asserted at the BOTTOM of this file,
+// by driving the proven forgery through the real interpreter and requiring a
+// fail-closed reject.
+//
+// ⛔ Do not "tidy" the three ACCEPTED assertions into REJECTED ones. A green
+// result there without a re-derived soundness argument means a partial patch,
+// which is precisely the LatticeFold+ mistake (L2 above) repeating.
 // =============================================================================
 
 #include "crypto/latticebp/commitment.h"
 #include "crypto/latticebp/range_proof.h"
+#include "script/interpreter.h"
+#include "script/script.h"
+#include "script/script_error.h"
 #include "test/test_bitcoin.h"
 
 #include <array>
@@ -113,7 +145,7 @@ BOOST_AUTO_TEST_CASE(honest_proof_verifies)
 // zero and this proof is accepted while proving nothing about the committed
 // value.
 // ---------------------------------------------------------------------------
-BOOST_AUTO_TEST_CASE(all_zero_witness_with_correct_seed_must_reject)
+BOOST_AUTO_TEST_CASE(documented_unsoundness_all_zero_witness_is_accepted)
 {
     Fixture f;
     LatticeRangeProofV2 p;
@@ -125,11 +157,19 @@ BOOST_AUTO_TEST_CASE(all_zero_witness_with_correct_seed_must_reject)
     for (size_t k = 0; k < LatticeParams::K; k++) ZeroRing(p.t_reconstruction[k]);
     // version and challenge_seed deliberately UNTOUCHED — see L2 at the top.
 
-    BOOST_CHECK_MESSAGE(!f.Verify(p),
-        "ZERO-WITNESS FORGERY: the verifier accepted an all-zero witness carrying a "
-        "correct Fiat-Shamir seed. Every algebraic check on the accept path is "
-        "homogeneous in the prover-supplied values, so the proof establishes nothing "
-        "about the committed value. This is the LatticeFold+ break class.");
+    // ⛔ THE ASSERTION IS DELIBERATELY "ACCEPTED". Read the header before
+    // touching it. This records a PROVEN DEFECT in a class that consensus no
+    // longer calls; it does not endorse the behaviour. If this ever starts
+    // rejecting, someone has changed LatticeRangeProofV2 — and a partial patch
+    // here is worse than none, so re-derive soundness rather than flipping the
+    // assertion back.
+    BOOST_CHECK_MESSAGE(f.Verify(p),
+        "LatticeRangeProofV2 no longer accepts the all-zero witness. That is not "
+        "automatically good news: the accept path is homogeneous in the "
+        "prover-supplied values, so a change that rejects THIS input while leaving "
+        "homogeneity intact fixes nothing (the scaled-witness case below is the "
+        "non-zero member that catches such a patch). Do not wire this class back "
+        "into consensus on the strength of this test flipping.");
 }
 
 // ---------------------------------------------------------------------------
@@ -149,7 +189,7 @@ BOOST_AUTO_TEST_CASE(all_zero_witness_with_correct_seed_must_reject)
 // DOMAIN_SEP || sighash || pubkey_hash || commitment, every term of which the
 // attacker knows. Nothing secret is used to build this blob.
 // ---------------------------------------------------------------------------
-BOOST_AUTO_TEST_CASE(wire_reachable_zero_witness_must_reject)
+BOOST_AUTO_TEST_CASE(documented_unsoundness_wire_reachable_zero_witness_is_accepted)
 {
     Fixture f;
     LatticeRangeProofV2 honest;
@@ -171,11 +211,15 @@ BOOST_AUTO_TEST_CASE(wire_reachable_zero_witness_must_reject)
         "the all-zero blob did not even deserialize; if this fails the wire path "
         "is not reachable and the severity of the in-memory finding drops");
 
-    BOOST_CHECK_MESSAGE(!f.Verify(forged),
-        "WIRE-REACHABLE ZERO-WITNESS FORGERY: a blob an attacker can construct from "
-        "public data alone deserialized and then VERIFIED. The range proof therefore "
-        "establishes nothing about the committed value, and the forgery needs no "
-        "secret, no grinding and no in-memory access.");
+    // ⛔ DELIBERATELY ASSERTS "ACCEPTED" — see the note on the previous case.
+    // This is the finding that justified removing the class from the consensus
+    // path: a blob an attacker builds from public data alone deserializes and
+    // verifies, needing no secret, no grinding and no in-memory access. The
+    // consensus posture is asserted separately, at the bottom of this file.
+    BOOST_CHECK_MESSAGE(f.Verify(forged),
+        "The wire-reachable all-zero blob is no longer accepted by "
+        "LatticeRangeProofV2. Re-derive soundness before concluding anything from "
+        "that: see the note on documented_unsoundness_all_zero_witness_is_accepted.");
 }
 
 // ---------------------------------------------------------------------------
@@ -317,7 +361,7 @@ BOOST_AUTO_TEST_CASE(zero_version_must_reject)
 //   - if it PASSES, the exploitable homogeneity is narrower than the comment above
 //     assumes, and THAT is worth knowing before anyone designs a fix around it.
 // ---------------------------------------------------------------------------
-BOOST_AUTO_TEST_CASE(scaled_witness_with_correct_seed_must_reject)
+BOOST_AUTO_TEST_CASE(documented_unsoundness_scaled_witness_is_accepted)
 {
     Fixture f;
     LatticeRangeProofV2 p;
@@ -340,12 +384,110 @@ BOOST_AUTO_TEST_CASE(scaled_witness_with_correct_seed_must_reject)
     for (size_t k = 0; k < LatticeParams::K; k++) scale(p.t_reconstruction[k]);
     // version and challenge_seed deliberately UNTOUCHED.
 
-    BOOST_CHECK_MESSAGE(!f.Verify(p),
-        "SCALED-WITNESS FORGERY: the verifier accepted a witness whose every value was "
-        "multiplied by a constant, with the honest Fiat-Shamir seed. This is a NON-ZERO "
-        "member of the same homogeneity break class, which means no 'reject if all "
-        "zeros' patch can legitimately make this battery green — the accept path itself "
-        "has to stop being homogeneous.");
+    // ⛔ DELIBERATELY ASSERTS "ACCEPTED". This is the most important of the three,
+    // because it is a NON-ZERO member of the break class: no "reject if all zeros"
+    // patch can satisfy it. The accept path itself has to stop being homogeneous.
+    BOOST_CHECK_MESSAGE(f.Verify(p),
+        "The scaled witness is no longer accepted. If the other two documented cases "
+        "still accept, this is a partial patch and the class is NOT fixed.");
+}
+
+// ===========================================================================
+// THE CONSENSUS POSTURE. This is the part that protects the chain, and it is
+// what the three cases above are evidence FOR.
+//
+// The v4 dispatch used to call LatticeRangeProofV2::verify(). It no longer does:
+// it fails closed. So the forgeries documented above are unreachable through the
+// consensus entry point regardless of the state of that class. These two tests
+// drive the real interpreter rather than the crypto object, which is the only
+// place the distinction is observable.
+// ===========================================================================
+
+namespace {
+
+//! The exact blob from documented_unsoundness_wire_reachable_zero_witness_is_accepted:
+//! version + honest Fiat-Shamir seed + an all-zero witness. Built from public
+//! data only, and accepted by LatticeRangeProofV2. If the consensus path ever
+//! routes back to that verifier, THIS is what gets through.
+std::vector<uint8_t> ForgedZeroWitnessBlob(const Fixture& f)
+{
+    LatticeRangeProofV2 honest;
+    BOOST_REQUIRE(f.Prove(honest));
+
+    const size_t elem_size = LatticeParams::N * 8;
+    const size_t expected_size = 1 + 32 + elem_size * 2 + LatticeParams::K * elem_size;
+
+    std::vector<uint8_t> blob(expected_size, 0x00);
+    blob[0] = static_cast<uint8_t>(RangeProofParams::PROOF_VERSION);
+    memcpy(blob.data() + 1, honest.challenge_seed.data(), 32);
+    return blob;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// ★★★ THE REGRESSION GUARD. Push the proven forgery through the real script
+// interpreter with SCRIPT_VERIFY_SOQUOBSCURA SET — the activated posture — and
+// require that it is REJECTED, with the fail-closed error rather than any
+// verification error.
+//
+// Asserting the specific error matters. SCRIPT_ERR_SOQUOBSCURA_RANGEPROOF_FAILED
+// would mean a verifier ran and said no, which is exactly the situation we are
+// getting out of. UNVERIFIED means no verifier ran at all.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(consensus_v4_path_fails_closed_on_the_proven_forgery)
+{
+    Fixture f;
+    const std::vector<uint8_t> forged = ForgedZeroWitnessBlob(f);
+
+    // Sanity: the class really does accept this. If it stops, the test below is
+    // still correct but stops being a forgery test, and we want to know.
+    {
+        LatticeRangeProofV2 parsed;
+        BOOST_REQUIRE(LatticeRangeProofV2::deserialize(forged, parsed));
+        BOOST_CHECK_MESSAGE(f.Verify(parsed),
+            "the reference forgery is no longer accepted by LatticeRangeProofV2; "
+            "see documented_unsoundness_all_zero_witness_is_accepted");
+    }
+
+    CScript script = CScript() << OP_SOQUOBSCURA_RANGEPROOF;
+    std::vector<std::vector<unsigned char> > stack;
+    stack.push_back(f.commitment.serialize());                                  // top-2
+    stack.push_back(std::vector<unsigned char>(f.pubkey_hash.begin(),
+                                              f.pubkey_hash.end()));            // top-1
+    stack.push_back(forged);                                                    // top
+
+    ScriptError serror = SCRIPT_ERR_OK;
+    BaseSignatureChecker checker;
+    const bool ok = EvalScript(stack, script, SCRIPT_VERIFY_SOQUOBSCURA, checker,
+                               SIGVERSION_BASE, &serror);
+
+    BOOST_CHECK_MESSAGE(!ok,
+        "CONSENSUS ACCEPTED THE ZERO-WITNESS FORGERY. The v4 dispatch has been "
+        "re-routed to a verifier. Revert that.");
+    BOOST_CHECK_EQUAL(serror, SCRIPT_ERR_SOQUOBSCURA_RANGEPROOF_UNVERIFIED);
+}
+
+// ---------------------------------------------------------------------------
+// The dormant posture, which is what every network actually runs today:
+// DEPLOYMENT_SOQUOBSCURA is nStartTime=0/nTimeout=0 and NOT_SCHEDULED on all
+// four networks, so the flag is never set and the opcode does not exist.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(consensus_v4_opcode_does_not_exist_while_dormant)
+{
+    Fixture f;
+    CScript script = CScript() << OP_SOQUOBSCURA_RANGEPROOF;
+    std::vector<std::vector<unsigned char> > stack;
+    stack.push_back(f.commitment.serialize());
+    stack.push_back(std::vector<unsigned char>(f.pubkey_hash.begin(),
+                                               f.pubkey_hash.end()));
+    stack.push_back(ForgedZeroWitnessBlob(f));
+
+    ScriptError serror = SCRIPT_ERR_OK;
+    BaseSignatureChecker checker;
+    BOOST_CHECK(!EvalScript(stack, script, 0 /* no SOQUOBSCURA */, checker,
+                            SIGVERSION_BASE, &serror));
+    BOOST_CHECK_EQUAL(serror, SCRIPT_ERR_BAD_OPCODE);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Three commits, one thread: the permanently red CI had a root cause, fixing it exposed a blind spot in the freeze tripwire, and closing that needed an artifact the freeze plan had already asked for.

Suite: **724 cases, 0 failures.** Was 718 pass / 3 deliberate failures / 1 skipped.

## 1. `consensus:` stop routing the v4 range proof to an unsound verifier

The v4 dispatch called `LatticeRangeProofV2::verify()`. That verifier does not bind the amount and cannot be repaired in place: Check 4 compares a prover-supplied `t_reconstruction` against `z_response*A + z_randomness*S`, both sides prover-controlled and the relation **homogeneous**, so `(0,0,0)` with an honestly recomputed Fiat-Shamir seed satisfies every check. Seeding the generators from `consensus.latticeBPSeed` is necessary but not sufficient (SOQ-I011).

Witness v10 already had the right posture and said so in its own dispatch — fail closed, do not route to the in-tree verifier, let the activation release substitute real verification inside the existing dispatch. **v4 was the one path that still routed.** It now matches.

**No behaviour changes on any network.** `DEPLOYMENT_SOQUOBSCURA` is `nStartTime=0/nTimeout=0` and `NOT_SCHEDULED` on all four networks, so `SCRIPT_VERIFY_SOQUOBSCURA` is never set and the new reject is unreachable in production; every network takes the unchanged `BAD_OPCODE` branch.

The three degenerate-witness cases asserted rejection and therefore failed on purpose, which left the only job that runs `make check` red on every merge since 2026-08-20 — PRs #44 through #48, including the whole FC4 package and the MAX_MONEY change, merged with no regression signal from it. Marking them expected-failures was considered and rejected as managing the symptom. They are now characterisation tests recording the defect that justified removing the class, and **two new tests assert the property that actually protects the chain**: the proven zero-witness forgery is driven through the real interpreter with the flag set and must be rejected with the fail-closed error rather than any verification error.

`LatticeRangeProofV2` is not deleted here — `capi.cpp` and a wallet RPC still reference it, so removal belongs with the commit-1 cleanup that also retires `block_accumulator`. Nothing in consensus reaches it.

## 2. `test:` make the consensus digest measure consensus cryptography

Found while doing (1), and it is the more serious item.

The script half of the digest absorbed only witness-program **dispatch**. `AbsorbScriptVerdicts` hands every witness version a two-item, four-byte witness stack, and every feature bails on its shape check first — PAT requires ≥4 items and otherwise returns `SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH`. So the one instrument designed to catch a cross-build divergence **ran no consensus cryptography at all**, while its header claimed the interpreter was included because that is where a codegen difference expresses itself.

Demonstrated, not argued: commit (1) changed a script verdict and added a `ScriptError`, and the digest did not move.

Nothing else covered it. Functional tests run on one build, so an nh6m-class defect is invisible to them by construction — that is why this file exists. Differential validation replays stagenet history through a **single** binary, comparing against history rather than another build.

`AbsorbOpcodeVerdicts` adds PAT proofs from fixed material at n=1..4 executed through `OP_CHECKPATAGG` (absorbing the proof bytes as well as the verdict), a tampered proof so the accept is load-bearing, the other custom opcodes in both gate states, and the arithmetic guards. `opcode_coverage_actually_reaches_pat_crypto` is the guard that keeps it honest: a digest can be green, stable and cross-build identical while measuring nothing, and pinning the constant cannot detect that.

Digest re-pinned `f830d7d6` → `df60b54d`. **Coverage change, not a rule change.**

### Near-miss worth reading

My first PAT builder omitted `out << OP_CHECKPATAGG`, so the script was a run of pushes ending truthy and `EvalScript` returned true for every input including tampered ones. That reads exactly like a forgery in a genesis-active opcode, and this repo has already had two false PAT P1 escalations. I probed the full tamper matrix — n=1..4 × every index × pk/msg/sig, 30 cases — against the upstream test's expectations, which exposed the builder bug. With the opcode appended, **all 30 tamper cases reject. PAT binds every witness element correctly and there is no defect in PAT.**

## 3. `doc:` per-deployment activation preconditions, and the F4 sweep

`doc/DEPLOYMENT_PRECONDITIONS.md` is what bead `x7hb` asked for: the activation constraints were "restated in five separate beads and depend on whoever is holding the pen remembering it". One row per deployment — genesis-binary state, what it gates, what must hold before a height is set — behind seven cross-cutting rules.

Three things it pins that were written nowhere: relay policy must never call a gated witness version standard ahead of consensus and the mask must **derive** from the deployment state `ConnectBlock` enforces; adding a verifier where none exists is a **relaxation**, so fail-closed dispatches must stay in the genesis binary and must never be "satisfied" by deletion; and `CHECKPATAGG` is the only Soqucoin-specific consensus cryptography live at launch.

`contrib/f4-digest-sweep.sh` is the cross-build comparison. Two bugs in my own first draft, both fixed, one of them the exact class this PR is about: **it reported PASS when every level failed to build**, because the verdict counted unique strings and `BUILD-FAILED` is itself one unique value. It now exits 2 as INCONCLUSIVE, verified by running it against a nonsense optimisation level. The script deletes nothing; stale build directories are moved aside.

## Status and what is not done

- ⏳ **The F4 sweep has not yet produced a result.** A run over `-O0` and `-O2` is in progress. Until it produces one digest across levels, build-independence is asserted rather than measured, so bead `71z6` stays open on that item.
- Not done, deliberately: deleting `LatticeRangeProofV2`, which belongs with commit-1 cleanup.

Beads: `1zc1` (root cause fixed), `71z6` (raised to P0, coverage fixed, sweep pending), `x7hb` (deliverable landed), `uv34`, `r0vn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
