### PR TITLE
doc: MAX_MONEY rationale, and genesis headline procedure

### DIFF
--- a/doc/GENESIS_CEREMONY.md
+++ b/doc/GENESIS_CEREMONY.md
@@ -64,12 +64,11 @@ in preference order:
 
 1. **Ceremony-day headline.** Gap of zero. This is what the section above means
    by immediacy, and it remains the strongest option.
-2. **21 September 2026.** Founder's birthday, and a private meaning that is
-   invisible to any reader, which is the good kind. Costs a gap equal to the
-   distance from 21 Sep to the ceremony. ⚠️ Cannot be selected before that date
-   arrives; check the majors on the day and keep anything usable. A Reuters, AP
-   or Bloomberg quantum story carries more weight with exchange and federal
-   readers than a trade outlet.
+2. **21 September 2026.** A preferred alternate date. On the proof axis it is
+   strictly better than the fallback below, because the gap to the ceremony is
+   shorter. ⚠️ Cannot be selected before that date arrives; check the majors on
+   the day and keep anything usable. A Reuters, AP or Bloomberg quantum story
+   carries more weight with exchange and federal readers than a trade outlet.
 3. **The pre-vetted fallback below.** Use only if neither of the above produced
    something usable.
 

--- a/doc/GENESIS_CEREMONY.md
+++ b/doc/GENESIS_CEREMONY.md
@@ -20,13 +20,110 @@ ECDSA-elimination chain forever.
 
 ## Inputs, chosen on ceremony day
 
-1. `pszTimestamp`: a verifiable, dated headline from a major wire service,
-   ideally quantum-computing related. Nothing clever. Chosen by the founder on
-   the day of the ceremony; that immediacy is the point.
+1. `pszTimestamp`: a verifiable, dated headline, ideally quantum-computing
+   related. Nothing clever. See **Choosing the headline** below, which records
+   the byte budget, the date ladder and a pre-vetted fallback.
 2. `nTime`: the actual UTC timestamp of the ceremony.
 3. The output script: replace the Dogecoin ECDSA P2PK with a
    nothing-up-my-sleeve unspendable output. The genesis coinbase is excluded
    from the UTXO set regardless; this is about what decoders display.
+
+## Choosing the headline
+
+### The byte budget is 91 characters. This is consensus, not style.
+
+`validation.cpp:558` rejects any coinbase whose `scriptSig` is under 2 or over
+**100 bytes**. `CreateGenesisBlock` (chainparams.cpp:61) builds:
+
+```
+CScript() << 486604799 << CScriptNum(4) << <message bytes>
+```
+
+which costs 5 bytes for `486604799` (4 data + 1 opcode), 2 for `CScriptNum(4)`
+(1 data + 1 opcode), and the message push: `1 + N` while `N <= 75`, or `2 + N`
+from 76 up, where `OP_PUSHDATA1` adds a length byte. So:
+
+| message length | scriptSig | verdict |
+|---|---|---|
+| N <= 75 | N + 8 | fits |
+| 76 <= N <= 91 | N + 9 | fits |
+| N >= 92 | N + 9 > 100 | **consensus-invalid** |
+
+**Maximum message: 91 characters.** For calibration, Bitcoin's genesis message
+is 69 characters, a 77-byte scriptSig.
+
+⛔ Count it before the ceremony. An over-length `pszTimestamp` does not fail
+loudly at mine time; it produces a block the network will reject.
+
+### The date ladder
+
+The headline's job is to prove the block was not mined before its date. A
+headline older than the ceremony leaves a gap of exactly that age in which a
+"they mined early" claim cannot be foreclosed by this artifact alone. So,
+in preference order:
+
+1. **Ceremony-day headline.** Gap of zero. This is what the section above means
+   by immediacy, and it remains the strongest option.
+2. **21 September 2026.** Founder's birthday, and a private meaning that is
+   invisible to any reader, which is the good kind. Costs a gap equal to the
+   distance from 21 Sep to the ceremony. ⚠️ Cannot be selected before that date
+   arrives; check the majors on the day and keep anything usable. A Reuters, AP
+   or Bloomberg quantum story carries more weight with exchange and federal
+   readers than a trade outlet.
+3. **The pre-vetted fallback below.** Use only if neither of the above produced
+   something usable.
+
+Any option other than (1) **should be paired with the Bitcoin anchor**, which
+closes the gap cryptographically rather than journalistically.
+
+### Pre-vetted fallback, locked 2026-08-27
+
+Verified to exist, correctly dated, on-theme, and within budget:
+
+```
+CoinDesk 27/Aug/2026 Bitcoin researchers propose quantum fix
+```
+
+60 characters, 68-byte scriptSig, 32 characters spare.
+
+Source: <https://www.coindesk.com/tech/2026/08/27/bitcoin-researchers-propose-quantum-fix-that-would-not-crowd-out-transactions>
+The full headline ("... that would not crowd out transactions") is 98 characters
+with the date prefix and does **not** fit; the trim above is deliberate and ends
+on the load-bearing verb. The article covers SHRINCS, a hash-based post-quantum
+signature proposal for Bitcoin by Blockstream researchers Jonas Nick and Mikhail
+Kudinov, described as the first concrete post-quantum signature design specific
+to Bitcoin.
+
+Why it is on-theme without needing to say anything: it is dated evidence that in
+August 2026 Bitcoin was still *proposing* its first concrete post-quantum
+signature, in the genesis block of a chain that ships ML-DSA-44 live from height
+zero. Same structure as Bitcoin quoting a bank-bailout headline in the block that
+replaced the banks.
+
+⛔ **Do not editorialise around it afterwards.** Bitcoin has the harder problem:
+retrofitting post-quantum signatures without breaking fifteen years of UTXOs and
+capacity. SHRINCS starts at 324 bytes against Schnorr's 64; ML-DSA-44 is 2,420.
+Soqucoin did not beat anyone on signature size, it had a clean slate and designed
+around the cost from block 0. The line states a dated fact. Overclaiming in
+commentary is what would cheapen it.
+
+### Optional: the Bitcoin block anchor
+
+A recent Bitcoin block hash is a stronger timestamp than a newspaper. It is
+verifiable forever from any node, does not depend on a publisher's archive, and
+cannot be produced before that block existed. Kaspa uses this approach. Appending
+one closes the premine gap to zero even when the headline is older:
+
+```
+CoinDesk 27/Aug/2026 Bitcoin researchers propose quantum fix BTC 921456 9f3ac1d2
+```
+
+80 characters, 89-byte scriptSig, 11 spare. Substitute the real height and a
+short hash slice taken on the morning of the ceremony.
+
+⚠️ Take the slice from a part of the hash that is not the leading zeros, which
+carry no information. Record the full hash in the ceremony log so the prefix can
+be checked later.
 
 ## Procedure
 

--- a/doc/MAX_MONEY_RATIONALE.md
+++ b/doc/MAX_MONEY_RATIONALE.md
@@ -5,15 +5,14 @@
 > fleet topology and infrastructure detail. This one carries neither, and it is useful
 > to a reviewer reading `amount.h`, so it lives here instead.
 
-**Question asked (Casey, 2026-08-27):** is 20B truly the best number for Soqucoin, would
-comparable top-10 chains do the same given similar emissions tokenomics, why do we have
-MAX_MONEY at all, and is it related to the new emission schedule?
+**Scope.** This document records why `MAX_MONEY` is set to 20B, how that compares with
+other major chains, and how the constant relates to the emission schedule. It exists
+because the name invites a wrong reading, and because the value is fixed by constraints
+that are not visible from the constant alone.
 
-**Short answer:** the question contains a premise worth correcting before the comparison
-means anything. **On Soqucoin, MAX_MONEY is not a supply cap and structurally cannot be
-one.** It is a per-transaction ceiling. Soqucoin has **no supply cap at all** — that is a
-deliberate, already-ratified property of the emission schedule, and it is a separate
-decision from this constant.
+**Summary.** **On Soqucoin, `MAX_MONEY` is not a supply cap and structurally cannot be
+one.** It is a per-transaction ceiling. Soqucoin has **no supply cap at all**, which is a
+deliberate and separately ratified property of the emission schedule.
 
 Once that is straight, 20B is not really a choice. It is the largest round number under a
 hard structural bound, and the only way past it is replacing the chainstate amount codec.
@@ -145,8 +144,8 @@ constant is not the supply cap.
 
 ## 6. ⚠️ The question underneath the question
 
-Comparing against Bitcoin, Kaspa and Polkadot suggests what is really being asked is not
-about `MAX_MONEY` but about **whether Soqucoin should have a supply cap at all.**
+The comparison above raises a second and much larger question, which is not about
+`MAX_MONEY` at all: **whether Soqucoin should have a supply cap.**
 
 That is a separate decision, already ratified, and it is a **hard fork to change after
 genesis**:

--- a/doc/MAX_MONEY_RATIONALE.md
+++ b/doc/MAX_MONEY_RATIONALE.md
@@ -158,11 +158,25 @@ genesis**:
   is the strongest contrary datapoint available.
 - Kaspa and Bitcoin are capped. Dogecoin and Ethereum are not.
 
-There is no consensus in the industry, and both models are defensible. But if the cap
-question is genuinely open, **it must be settled before genesis**, and it should be argued on
-monetary-policy grounds — miner-security-budget, exchange and listing perception, holder
-expectations — not on the basis of this constant. Raising it here would be arguing the wrong
-variable.
+There is no consensus in the industry, and both models are defensible.
+
+**⛔ CORRECTION, added after checking rather than assuming: that question is NOT open. It was
+decided deliberately, and it was decided with this comparison already in hand.**
+
+Bead `c61` weighed the 47B Moderate model against a Full 99B alternative, explicitly including
+the tail rate as a parameter (the ratified outcome is `nInitialSubsidy` 100,000,
+`nSubsidyHalvingInterval` 250,000, four halvings, **2,500 tail**). It was decided against
+written peer-comparison analyses, with a named stakeholder group, and locked on
+**2026-06-28** — three and a half months *after* Polkadot adopted its hard cap on
+**2026-03-14**.
+
+So the strongest apparently-contrary datapoint in the table above pre-dates the decision and
+was available to it. Uncapped-with-a-tail is a chosen monetary policy here, not an oversight,
+and changing it is a hard fork after genesis.
+
+The narrow claim this document does make stands on its own: `MAX_MONEY` is the wrong variable
+to move if anyone ever wants to revisit supply policy. It is a per-transaction ceiling forced
+by the amount codec, and it has nothing to say about total supply.
 
 ---
 

--- a/doc/MAX_MONEY_RATIONALE.md
+++ b/doc/MAX_MONEY_RATIONALE.md
@@ -1,0 +1,179 @@
+# MAX_MONEY at 20B: why, and how it compares
+
+> Companion to the reasoning block in `src/amount.h`. Kept OUT of `doc/design/` on
+> purpose: `**/DL-*` is gitignored in this public repo because those documents carry
+> fleet topology and infrastructure detail. This one carries neither, and it is useful
+> to a reviewer reading `amount.h`, so it lives here instead.
+
+**Question asked (Casey, 2026-08-27):** is 20B truly the best number for Soqucoin, would
+comparable top-10 chains do the same given similar emissions tokenomics, why do we have
+MAX_MONEY at all, and is it related to the new emission schedule?
+
+**Short answer:** the question contains a premise worth correcting before the comparison
+means anything. **On Soqucoin, MAX_MONEY is not a supply cap and structurally cannot be
+one.** It is a per-transaction ceiling. Soqucoin has **no supply cap at all** — that is a
+deliberate, already-ratified property of the emission schedule, and it is a separate
+decision from this constant.
+
+Once that is straight, 20B is not really a choice. It is the largest round number under a
+hard structural bound, and the only way past it is replacing the chainstate amount codec.
+
+---
+
+## 1. Why the constant exists at all
+
+It is an artifact of **amount representation**, not of tokenomics.
+
+Bitcoin-derived chains store amounts as `int64` satoshis (`typedef int64_t CAmount`).
+Validation accumulators **add before they range-check** — `validation.cpp:1947` does
+`nValueIn += ...` and only then calls `MoneyRange`. So a sum of two in-range values must not
+overflow, or the check downstream is reading an already-wrapped number. `MAX_MONEY` is the
+bound that makes that safe.
+
+Chains that use big integers have no equivalent constant and no equivalent problem:
+
+| Chain | Amount type | Has a MAX_MONEY-style constant? |
+|---|---|---|
+| Bitcoin, Dogecoin, Litecoin, **Soqucoin** | `int64` | **Yes** — required by the representation |
+| Ethereum | `uint256` | No |
+| Polkadot | `u128` | No |
+
+So "what would a top-10 chain do here" only has an answer for the `int64` family. For ETH
+and Polkadot the question does not arise.
+
+---
+
+## 2. Why it cannot be our supply cap
+
+Three independent reasons, all in `src/amount.h`:
+
+1. **The supply is unbounded.** After four halvings the schedule enters a perpetual tail of
+   2,500 SOQ per block, roughly 1.31B SOQ a year, forever. No constant bounds a supply that
+   grows without limit.
+2. **Even the head supply does not fit.** `2 * MAX_MONEY <= INT64_MAX` caps the constant at
+   ~46.1B coins. Head supply is **46.875B** — already past that line. Setting MAX_MONEY "to
+   cover the supply" would reintroduce the exact signed-overflow bug it exists to prevent.
+3. **The chainstate codec binds tighter still.** `CompressAmount`/`DecompressAmount` computes
+   roughly `9n + 81` in a `uint64`, so any amount above **~20.49B coins** with a non-round
+   decimal tail fails to round-trip and **silently corrupts in the UTXO database**. This was
+   found by test during FC4 when 40B was tried: `serialization_invariance_tests` caught
+   `40B * COIN - 1` decompressing to garbage. Both bounds are now `static_assert`ed.
+
+So the ceiling is **20.49B, hard**. 20B is the largest round number beneath it, with 2.4%
+headroom.
+
+---
+
+## 3. Is it related to the emission schedule?
+
+**Only as a consequence, not as a design input.** The emission schedule (locked 2026-06-28,
+bead `c61`, `DL-EMISSION-47B-LOCK`) is:
+
+- `nInitialSubsidy` 100,000 SOQ on mainnet, halved four times at `nSubsidyHalvingInterval`
+- head supply ~46.875B = 25B + 12.5B + 6.25B + 3.125B
+- then a **perpetual tail of 2,500 SOQ/block**, ~1.31B/yr, described in the code as keeping
+  SOQ "a living currency, not hard-capped"
+
+The emission is what makes MAX_MONEY *unable* to be a supply cap. It did not set its value —
+the codec did.
+
+---
+
+## 4. The comparison
+
+⚠️ Two different things are being compared, so the table separates them.
+
+| Chain | Supply cap | Emission today | Per-tx `MAX_MONEY` | Constant vs supply |
+|---|---|---|---|---|
+| **Bitcoin** | 21M | halving, tail → 0 | 21M | **=100%** (they coincide) |
+| **Dogecoin** | **None** | fixed +5B/yr (~3.4%) | **10B** | **~6.4%** of ~155.3B |
+| **Kaspa** | ~28.7B (29B in code) | annual halving, ~95% mined, →0 late 2026 | n/a (not this codebase family) | — |
+| **Polkadot** | **2.1B, adopted 2026-03-14** | cut 53.6% (120M → 56.88M DOT/yr), ~3.11% | none (`u128`) | — |
+| **Ethereum** | None | issuance/burn net variable | none (`uint256`) | — |
+| **Soqucoin** | **None** | 47B head + 2,500/block tail (~1.31B/yr) | **20B** | **~42.7%** of 46.875B |
+
+### The precedent that actually governs
+
+**Dogecoin is the direct one — Soqucoin is based on that codebase.** Dogecoin Core carries:
+
+```c
+static const CAmount MAX_MONEY = 10000000000 * COIN;
+```
+
+with the comment, verbatim: *"Note that this constant is **not** the total money supply …
+but rather a sanity check."*
+
+Dogecoin has run for a decade with a per-transaction ceiling of 10B against a circulating
+supply now around **155.3B** — a ceiling at roughly **6.4%** of supply, on a top-10 chain, at
+scale, without it being a problem.
+
+Soqucoin's 20B against a 46.875B head supply is **~42.7%** of supply: proportionally about
+**6.7× more generous** than the chain we inherited the mechanism from.
+
+> Historical note: Soqucoin's old comment claimed "maximum of 100B coins". That was inherited
+> from Dogecoin's own comment, which conflates two numbers — 100B was Dogecoin's *original*
+> 2013 cap (removed in Feb 2014), and 10B is the *transaction* maximum. The value here was
+> never 100B, and 100B coins in shors is 1e19, which does not fit in an `int64` at all.
+
+---
+
+## 5. So is 20B the best number?
+
+**For what it actually is — a per-transaction ceiling — yes, and the choice is close to
+forced.**
+
+- Anything above **20.49B** silently corrupts the UTXO set. That is not a tuning knob.
+- 20B is the largest round number under it, keeping 2.4% margin rather than sitting on the
+  boundary.
+- **4.5×** the largest consolidation ever observed on this chain (the 4.45B pool
+  consolidation).
+- **80%** of first-epoch emission (25B).
+- **4.6×** under the `int64` additive ceiling.
+- Proportionally far more generous than Dogecoin's decade-proven equivalent.
+
+**The one real consequence, and it should be stated plainly in operator docs:** no single
+transaction may move more than 20B SOQ on either side. A larger treasury move or exchange
+consolidation must be split across transactions. Given the largest real consolidation to date
+was 4.45B, that is a 4.5× margin — but it is a genuine operational constraint, not a
+theoretical one.
+
+**Going higher is not a constant bump.** It requires replacing the amount codec, which is
+chainstate-format surgery. And there is no tokenomics reason to want to, because this
+constant is not the supply cap.
+
+---
+
+## 6. ⚠️ The question underneath the question
+
+Comparing against Bitcoin, Kaspa and Polkadot suggests what is really being asked is not
+about `MAX_MONEY` but about **whether Soqucoin should have a supply cap at all.**
+
+That is a separate decision, already ratified, and it is a **hard fork to change after
+genesis**:
+
+- Soqucoin is currently **uncapped** by design — perpetual 2,500 SOQ/block, "a living
+  currency, not hard-capped". Same philosophy as Dogecoin and Ethereum.
+- **Polkadot moved the other way on 2026-03-14**, adopting a 2.1B hard cap and cutting
+  emissions 53.6%. That is a top-10 chain abandoning perpetual inflation *this year*, and it
+  is the strongest contrary datapoint available.
+- Kaspa and Bitcoin are capped. Dogecoin and Ethereum are not.
+
+There is no consensus in the industry, and both models are defensible. But if the cap
+question is genuinely open, **it must be settled before genesis**, and it should be argued on
+monetary-policy grounds — miner-security-budget, exchange and listing perception, holder
+expectations — not on the basis of this constant. Raising it here would be arguing the wrong
+variable.
+
+---
+
+## Sources
+
+External figures retrieved 2026-08-27. In-repo figures measured from `src/amount.h`,
+`src/soqucoin.cpp` and `src/chainparams.cpp` at commit `28bbcf8d0`.
+
+- Dogecoin Core `src/amount.h` — https://raw.githubusercontent.com/dogecoin/dogecoin/master/src/amount.h
+- Dogecoin supply — https://www.kucoin.com/blog/en-how-many-dogecoins-are-there-in-2026-a-deep-dive-into-doge-supply
+- Dogecoin cap history — https://dogecoin.com/dogepedia/faq/putting-a-cap-on-dogecoin/
+- Kaspa tokenomics — https://wiki.kaspa.org/en/tokenomics
+- Polkadot hard cap — https://phemex.com/blogs/polkadot-halving-tokenomics-explained
+- Polkadot 2.1B cap — https://www.nasdaq.com/articles/polkadots-21-billion-hard-cap-explained-put-away-your-calculators


### PR DESCRIPTION
Documentation only. No code, no consensus behaviour, no digest movement.

## `doc/MAX_MONEY_RATIONALE.md`

Records why `MAX_MONEY` is 20B, how it compares with other major chains, and how the constant relates to the emission schedule. It exists because the name invites a wrong reading and the value is fixed by constraints not visible from the constant alone.

**`MAX_MONEY` is a per-transaction ceiling, not a supply cap, and structurally cannot be one.** Soqucoin has no supply cap: the emission carries a perpetual 2,500 SOQ/block tail.

The constant is an artefact of **amount representation, not tokenomics**. `int64` satoshis, combined with validation accumulators that add before they range-check (`validation.cpp:1947`), require `2 * MAX_MONEY <= INT64_MAX`. Chains using big integers have no equivalent: Ethereum is `uint256`, Polkadot is `u128`. Only the `int64` family offers a comparison at all.

**Dogecoin is the governing precedent, being the codebase this one derives from.** Dogecoin Core sets `MAX_MONEY = 10000000000 * COIN` with the comment *"Note that this constant is **not** the total money supply … but rather a sanity check"*, and has operated for a decade with that ceiling against a supply now near 155.3B — roughly **6.4%** of supply. Soqucoin's 20B against a 46.875B head supply is **~42.7%**, proportionally about **6.7× more generous**.

Three bounds fix the value, two of them `static_assert`ed:

| Bound | Limit | Source |
|---|---|---|
| Supply is unbounded (perpetual tail) | no constant suffices | emission schedule |
| Accumulators sum before range-checking | ~46.1B | `2 * MAX_MONEY <= INT64_MAX` |
| Chainstate amount codec | **~20.49B** | `CompressAmount` ≈ `9n + 81` in a `uint64` |

Above ~20.49B, amounts silently corrupt in the UTXO database. 20B is the largest round number beneath that with margin rather than sitting on the boundary. Raising it is not a constant bump; it requires replacing the chainstate amount codec.

The document also records the provenance of the former "maximum of 100B coins" comment: it derives from Dogecoin's own comment, which conflates that chain's original 2013 cap (removed February 2014) with its transaction maximum.

A closing section notes that the supply-cap question is **settled, not open** — bead `c61` weighed the 47B model against a 99B alternative with the tail rate as an explicit parameter and was ratified on 2026-06-28, three and a half months after Polkadot adopted its 2.1B cap. That is recorded so the comparison table is not later mistaken for an argument to reopen it.

## `doc/GENESIS_CEREMONY.md` — "Choosing the headline"

The procedure previously left the genesis `pszTimestamp` to be chosen on the day with no further guidance. Three things were missing.

**The message budget is 91 characters, and it is consensus rather than style.** `validation.cpp:558` rejects any coinbase `scriptSig` outside 2–100 bytes. `CreateGenesisBlock` consumes 5 bytes for the `486604799` push, 2 for `CScriptNum(4)`, and 1–2 for the message push once `OP_PUSHDATA1` engages at 76. **An over-length `pszTimestamp` does not fail at mine time** — it mines successfully and produces a block the network rejects. The derivation is recorded as a table, with Bitcoin's 69-character message as calibration.

**A date ladder.** The headline proves the block was not mined before its date, so a headline older than the ceremony leaves a gap equal to its age. Recorded in preference order: ceremony-day (gap of zero), 21 September 2026, then a pre-vetted fallback. Any choice other than ceremony-day should carry the Bitcoin block anchor.

**A pre-vetted fallback**, verified to exist, be correctly dated, be on-theme and fit within budget:

```
CoinDesk 27/Aug/2026 Bitcoin researchers propose quantum fix
```

60 characters, 68-byte scriptSig. [Source](https://www.coindesk.com/tech/2026/08/27/bitcoin-researchers-propose-quantum-fix-that-would-not-crowd-out-transactions) — Blockstream's SHRINCS, described as the first concrete post-quantum signature proposal designed specifically for Bitcoin. The full headline is 98 characters and does not fit; the trim is deliberate.

The section also documents the optional **Bitcoin block anchor**: a block hash is verifiable from any node, does not depend on a publisher's archive, and closes the premine gap to zero even when the headline is older.

It carries an explicit instruction against editorialising around the block. Bitcoin faces the harder problem of retrofitting post-quantum signatures without breaking fifteen years of UTXOs and capacity; SHRINCS is 324 bytes against Schnorr's 64, where ML-DSA-44 is 2,420. Soqucoin had a clean slate and designed around that cost from block 0. The line states a dated fact.

## Revision

A later commit removes personal framing and personal data from both documents, per the project rule that no personnel names appear in commits, PRs, docs or beads. A date of birth in particular is an identity-verification factor and does not belong in a public repository.

⚠️ Note for the merge: commit `630a2f50e`'s **message** still contains a personnel name. If clean history matters more than merge convenience, #52 carries identical content with clean commit messages and this can be closed unmerged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
