### PR TITLE
consensus: inert genesis-migration allocation rule, height-parameterized

### DIFF
--- a/doc/GENESIS_CEREMONY.md
+++ b/doc/GENESIS_CEREMONY.md
@@ -150,6 +150,26 @@ be checked later.
    accidental spillover).
 7. Tag the freeze candidate. The soak clock starts at fleet deploy.
 
+## The migration allocation constants stay null at this ceremony
+
+The freeze candidate carries an inert consensus rule for a one-shot coinbase
+allocation at a parameterized height (`hashMigrationOutputs`,
+`nMigrationTotal`, `nMigrationHeight` in `consensus/params.h`; enforcement in
+`ConnectBlock`). **This ceremony sets none of them.** They ship null/0/0 on
+every network, which the migration_rule_tests suite pins as byte-for-byte
+unchanged validation, and the consensus digest absorbs them so any later
+arming is a visible digest move.
+
+If an allocation event is ever scheduled, it happens as its own pin-setting
+release at a pre-announced future height, with its own procedure: the
+committed output vector is produced by a deterministic tool run on two
+independent RPC providers whose commitment hashes must match, published in
+full before the constants are set, compiled in beside a build-time assertion
+that the vector hashes to `hashMigrationOutputs` and sums to
+`nMigrationTotal`, and soaked like any other consensus release. Nothing about
+this launch depends on that event, and skipping it forever changes nothing
+here.
+
 ## What does not change
 
 Testnet, regtest, and stagenet genesis parameters. Message-start bytes,

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -113,6 +113,7 @@ testScripts = [
     'latticefold_basic.py',
     'pat_basic.py',
     'maxreorgdepth.py',
+    'genesis-migration.py',
     'getauxblock.py',
     'wallet.py',
     'wallet-accounts.py',

--- a/qa/rpc-tests/genesis-migration.py
+++ b/qa/rpc-tests/genesis-migration.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Soqucoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Genesis-migration one-shot allocation rule, end to end through a real node
+# (DL-GENESIS-MIGRATION-IMPLEMENTATION section A; the full 10-case tamper
+# matrix lives in src/test/migration_rule_tests.cpp, driven through
+# ConnectBlock with named reject strings).
+#
+# This test covers what the unit suite cannot: the -migrationoutputs /
+# -migrationheight / -migrationtotal regtest arming path through init, the
+# production miner emitting the committed outputs at exactly the armed height,
+# and the window being one block wide on a live chain.
+#
+
+import struct
+from decimal import Decimal
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+MIGRATION_HEIGHT = 5
+
+# Witness v1 (OP_1 <32 bytes>) — the shape real sq1 allocations have.
+def v1_script(seed):
+    return bytes([0x51, 0x20]) + bytes([seed] * 32)
+
+# Values sit above the SOQ-ARCH-003 utxo-cost floor (6,500 sat/byte, active
+# from height 0 on regtest), as every real allocation does (dust floor 1 SOQ).
+ALLOCATIONS = [
+    (10 * 100000000, v1_script(0xA1)),
+    (20 * 100000000, v1_script(0xA2)),
+    (50000000, v1_script(0xA3)),
+]
+
+# Standard CTxOut vector serialization, hand-rolled rather than imported from
+# test_framework.mininode (which drags in asyncore, removed in Python 3.12).
+def ser_compact_size(n):
+    assert n < 253  # all this test ever needs
+    return struct.pack("B", n)
+
+def migration_outputs_hex():
+    r = ser_compact_size(len(ALLOCATIONS))
+    for (value, script) in ALLOCATIONS:
+        r += struct.pack("<q", value) + ser_compact_size(len(script)) + script
+    return bytes_to_hex_str(r)
+
+class GenesisMigrationTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self):
+        self.is_network_split = False
+        self.nodes = [start_node(0, self.options.tmpdir,
+                                 ["-debug", "-txindex=1",
+                                  "-migrationoutputs=%s" % migration_outputs_hex(),
+                                  "-migrationheight=%d" % MIGRATION_HEIGHT])]
+
+    def coinbase_vout(self, height):
+        block_hash = self.nodes[0].getblockhash(height)
+        block = self.nodes[0].getblock(block_hash)
+        return self.nodes[0].getrawtransaction(block['tx'][0], 1)['vout']
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # Below the armed height the rule is inert: plain coinbases.
+        node.generate(MIGRATION_HEIGHT - 1)
+        assert_equal(node.getblockcount(), MIGRATION_HEIGHT - 1)
+        for height in range(1, MIGRATION_HEIGHT):
+            vout = self.coinbase_vout(height)
+            for out in vout[1:]:
+                assert_equal(out['value'], Decimal(0))  # only the witness commitment trails
+
+        # The migration block: the production miner must emit the committed
+        # outputs as vout[1..N], in committed order, and the network accepts it.
+        node.generate(1)
+        assert_equal(node.getblockcount(), MIGRATION_HEIGHT)
+        vout = self.coinbase_vout(MIGRATION_HEIGHT)
+        assert len(vout) >= 1 + len(ALLOCATIONS), "migration block coinbase is missing committed outputs"
+        for i, (value, script) in enumerate(ALLOCATIONS):
+            got = vout[1 + i]
+            assert_equal(got['value'], Decimal(value) / Decimal(100000000))
+            assert_equal(got['scriptPubKey']['hex'], bytes_to_hex_str(script))
+
+        # The window is one block wide: the very next coinbase is plain again.
+        node.generate(1)
+        assert_equal(node.getblockcount(), MIGRATION_HEIGHT + 1)
+        vout = self.coinbase_vout(MIGRATION_HEIGHT + 1)
+        for out in vout[1:]:
+            assert_equal(out['value'], Decimal(0))
+
+        # And the chain keeps extending normally past the window.
+        node.generate(3)
+        assert_equal(node.getblockcount(), MIGRATION_HEIGHT + 4)
+
+        print("Genesis-migration functional test passed")
+
+if __name__ == '__main__':
+    GenesisMigrationTest().main()

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -119,6 +119,7 @@ BITCOIN_TESTS =\
   test/pat_tests.cpp \
   test/pat_script_tests.cpp \
   test/merkle_tests.cpp \
+  test/migration_rule_tests.cpp \
   test/miner_tests.cpp \
   test/net_tests.cpp \
   test/netbase_tests.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -439,6 +439,14 @@ public:
         assert(consensus.hashGenesisBlock == uint256S("0x1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691"));
         assert(genesis.hashMerkleRoot == uint256S("0x5b2a3f53f605d62c53e62932dac6925e3d74afa5a4b459745c36d42d0ed26a69"));
 
+        // Genesis-migration allocation constants (DL-GENESIS-MIGRATION-IMPLEMENTATION §A1).
+        // Deliberately NOT set here: hashMigrationOutputs stays null, nMigrationTotal 0,
+        // nMigrationHeight 0, so the rule is inert. If a migration window is ever run,
+        // the ceremony sets all three beside these genesis pins (with vMigrationOutputs
+        // compiled in and asserted against the hash) at a scheduled post-genesis height,
+        // per doc/GENESIS_CEREMONY.md. Struct defaults propagate into digishieldConsensus
+        // and auxpowConsensus via the copies above.
+
         // SOQ-H3: Lattice-BP++ consensus seed — derived from genesis hash
         consensus.latticeBPSeed = ComputeSoquObscuraSeed(
             consensus.hashGenesisBlock,
@@ -1020,6 +1028,24 @@ public:
         consensus.nMaxReorgDepth = nMaxReorgDepth;
         digishieldConsensus.nMaxReorgDepth = nMaxReorgDepth;
     }
+
+    void UpdateMigrationParams(const uint256& hashOutputs, CAmount nTotal, int nHeight,
+                               const std::vector<CTxOut>& vOutputs)
+    {
+        // ⚠️ ALL THREE structs, for the same height-indexed-tree reason as
+        // UpdateActivationHeight above (bead tofg): a migration height above 19
+        // resolves to auxpowConsensus, not `consensus`.
+        consensus.hashMigrationOutputs = hashOutputs;
+        consensus.nMigrationTotal = nTotal;
+        consensus.nMigrationHeight = nHeight;
+        digishieldConsensus.hashMigrationOutputs = hashOutputs;
+        digishieldConsensus.nMigrationTotal = nTotal;
+        digishieldConsensus.nMigrationHeight = nHeight;
+        auxpowConsensus.hashMigrationOutputs = hashOutputs;
+        auxpowConsensus.nMigrationTotal = nTotal;
+        auxpowConsensus.nMigrationHeight = nHeight;
+        vMigrationOutputs = vOutputs;
+    }
 };
 static CRegTestParams regTestParams;
 
@@ -1423,4 +1449,10 @@ void UpdateRegtestActivationHeight(Consensus::DeploymentPos d, int nActivationHe
 void UpdateRegtestMaxReorgDepth(int nMaxReorgDepth)
 {
     regTestParams.UpdateMaxReorgDepth(nMaxReorgDepth);
+}
+
+void UpdateRegtestMigrationParams(const uint256& hashOutputs, CAmount nTotal, int nHeight,
+                                  const std::vector<CTxOut>& vOutputs)
+{
+    regTestParams.UpdateMigrationParams(hashOutputs, nTotal, nHeight, vOutputs);
 }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -83,6 +83,12 @@ public:
     const CCheckpointData& Checkpoints() const { return checkpointData; }
     const ChainTxData& TxData() const { return chainTxData; }
     const std::string& Bech32HRP() const { return bech32HRP; }
+    /** Genesis-migration committed allocation outputs, in committed order — the
+     *  preimage of Consensus::Params::hashMigrationOutputs. Used only by the block
+     *  template builder (miner.cpp); validation consults the hash alone. Empty on
+     *  every network until the genesis ceremony compiles the ceremony vector in
+     *  beside the constants (regtest injects it via -migrationoutputs). */
+    const std::vector<CTxOut>& MigrationOutputs() const { return vMigrationOutputs; }
 
 protected:
     CChainParams() {}
@@ -104,6 +110,7 @@ protected:
     bool fMineBlocksOnDemand;
     CCheckpointData checkpointData;
     ChainTxData chainTxData;
+    std::vector<CTxOut> vMigrationOutputs;
 };
 
 /**
@@ -150,5 +157,17 @@ void UpdateRegtestActivationHeight(Consensus::DeploymentPos d, int nActivationHe
  * for functional tests. Regtest only.
  */
 void UpdateRegtestMaxReorgDepth(int nMaxReorgDepth);
+
+/**
+ * Arms the genesis-migration allocation rule on regtest
+ * (DL-GENESIS-MIGRATION-IMPLEMENTATION §A1). Sets the three consensus constants
+ * exactly as given — hash, total and height are taken independently so tests can
+ * arm deliberately inconsistent values (tamper case 10) — and installs vOutputs
+ * as the miner's committed vector. Regtest only; it mutates the regtest
+ * singleton, so a test that arms the rule MUST disarm it (null hash, 0, 0, {})
+ * before it returns.
+ */
+void UpdateRegtestMigrationParams(const uint256& hashOutputs, CAmount nTotal, int nHeight,
+                                  const std::vector<CTxOut>& vOutputs);
 
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -7,6 +7,7 @@
 #ifndef BITCOIN_CONSENSUS_PARAMS_H
 #define BITCOIN_CONSENSUS_PARAMS_H
 
+#include "amount.h"
 #include "uint256.h"
 #include <array>
 #include <limits>
@@ -205,6 +206,22 @@ struct Params {
      *  Different per-network: mainnet, stagenet, regtest each get unique A.
      *  MUST match between soqucoind and soq-privacy-signer for proof verification. */
     std::array<uint8_t, 32> latticeBPSeed = {};
+
+    /** Genesis-migration one-shot allocation (DL-GENESIS-MIGRATION-IMPLEMENTATION §A).
+     *  At exactly nHeight == nMigrationHeight (non-zero, hash set), the coinbase must
+     *  carry the committed allocation outputs as vout[1..N] (a trailing segwit
+     *  witness-commitment output is excluded from the committed range): their standard
+     *  vector serialization must double-SHA256 to hashMigrationOutputs, their values
+     *  must sum to exactly nMigrationTotal, and the permitted block reward becomes
+     *  subsidy + fees + nMigrationTotal with vout[0] (the miner) still bounded by
+     *  subsidy + fees. With the defaults below the rule is INERT: validation is
+     *  byte-for-byte unchanged on every network. Mainnet values are set only at the
+     *  genesis ceremony (doc/GENESIS_CEREMONY.md), the same trust model as the genesis
+     *  fields. Regtest arms via the -migrationoutputs/-migrationtotal/-migrationheight
+     *  test-only args. */
+    uint256 hashMigrationOutputs;   // null = inert
+    CAmount nMigrationTotal = 0;    // exact sum of the committed outputs, in sats
+    int nMigrationHeight = 0;       // 0 = inert; the one height the rule applies at
 };
 
 /**

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -20,6 +20,7 @@
 #include "consensus/usdsoq.h"
 #include "crypto/scrypt.h" // for scrypt_detect_sse2
 #include "fs.h"
+#include "hash.h"
 #include "httprpc.h"
 #include "httpserver.h"
 #include "key.h"
@@ -32,6 +33,7 @@
 #include "rpc/server.h"
 #include "scheduler.h"
 #include "script/sigcache.h"
+#include "streams.h"
 #include "script/standard.h"
 #include "timedata.h"
 #include "torcontrol.h"
@@ -446,6 +448,9 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-limitdescendantcount=<n>", strprintf("Do not accept transactions if any ancestor would have <n> or more in-mempool descendants (default: %u)", DEFAULT_DESCENDANT_LIMIT));
         strUsage += HelpMessageOpt("-limitdescendantsize=<n>", strprintf("Do not accept transactions if any ancestor would have more than <n> kilobytes of in-mempool descendants (default: %u).", DEFAULT_DESCENDANT_SIZE_LIMIT));
         strUsage += HelpMessageOpt("-bip9params=deployment:start:end", "Use given start/end times for specified BIP9 deployment (regtest-only)");
+        strUsage += HelpMessageOpt("-migrationoutputs=<hex>", "Arm the genesis-migration allocation rule with this hex-serialized CTxOut vector (regtest-only; requires -migrationheight)");
+        strUsage += HelpMessageOpt("-migrationheight=<n>", "Height at which the genesis-migration allocation rule applies (regtest-only; requires -migrationoutputs)");
+        strUsage += HelpMessageOpt("-migrationtotal=<n>", "Override the armed nMigrationTotal in sats (regtest-only; default: the sum of -migrationoutputs, override exists to test the mismatch reject)");
     }
     std::string debugCategories = "addrman, alert, bench, cmpctblock, coindb, db, http, libevent, lock, mempool, mempoolrej, net, proxy, prune, rand, reindex, rpc, selectcoins, tor, zmq"; // Don't translate these and qt below
     if (mode == HMM_BITCOIN_QT)
@@ -1177,6 +1182,55 @@ bool AppInitParameterInteraction()
         }
         UpdateRegtestMaxReorgDepth((int)nDepth);
         LogPrintf("Setting regtest finality horizon (nMaxReorgDepth) to %d\n", (int)nDepth);
+    }
+
+    if (IsArgSet("-migrationoutputs") || IsArgSet("-migrationheight") || IsArgSet("-migrationtotal")) {
+        // Arm the genesis-migration allocation rule for testing
+        // (DL-GENESIS-MIGRATION-IMPLEMENTATION §A1). Regtest only — on real
+        // networks the constants are consensus, set at the genesis ceremony.
+        if (!chainparams.MineBlocksOnDemand()) {
+            return InitError("Genesis-migration parameters may only be overridden on regtest.");
+        }
+        if (!IsArgSet("-migrationoutputs") || !IsArgSet("-migrationheight")) {
+            return InitError("-migrationoutputs and -migrationheight must be set together.");
+        }
+        const std::string strOutputs = GetArg("-migrationoutputs", "");
+        if (!IsHex(strOutputs) || strOutputs.empty()) {
+            return InitError("Invalid -migrationoutputs (expected a hex-serialized CTxOut vector)");
+        }
+        std::vector<CTxOut> vOutputs;
+        try {
+            std::vector<unsigned char> raw = ParseHex(strOutputs);
+            CDataStream ss(raw, SER_NETWORK, PROTOCOL_VERSION);
+            ss >> vOutputs;
+            if (!ss.empty()) throw std::ios_base::failure("trailing bytes");
+        } catch (const std::exception& e) {
+            return InitError(strprintf("Invalid -migrationoutputs (%s)", e.what()));
+        }
+        if (vOutputs.empty()) {
+            return InitError("Invalid -migrationoutputs (the committed vector must be non-empty)");
+        }
+        int64_t nMigrationHeight;
+        if (!ParseInt64(GetArg("-migrationheight", ""), &nMigrationHeight) || nMigrationHeight <= 0) {
+            return InitError("Invalid -migrationheight (expected a positive integer)");
+        }
+        CAmount nMigrationTotal = 0;
+        for (const CTxOut& out : vOutputs) {
+            nMigrationTotal += out.nValue;
+        }
+        if (IsArgSet("-migrationtotal")) {
+            int64_t nOverride;
+            if (!ParseInt64(GetArg("-migrationtotal", ""), &nOverride) || nOverride < 0) {
+                return InitError("Invalid -migrationtotal (expected a non-negative integer)");
+            }
+            nMigrationTotal = nOverride;
+        }
+        CHashWriter hasher(SER_GETHASH, PROTOCOL_VERSION);
+        hasher << vOutputs;
+        const uint256 hashOutputs = hasher.GetHash();
+        UpdateRegtestMigrationParams(hashOutputs, nMigrationTotal, (int)nMigrationHeight, vOutputs);
+        LogPrintf("Arming regtest genesis-migration rule: height=%d total=%d outputs=%u hash=%s\n",
+                  (int)nMigrationHeight, nMigrationTotal, (unsigned)vOutputs.size(), hashOutputs.ToString());
     }
     return true;
 }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -202,6 +202,19 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     coinbaseTx.vout[0].nValue = nFees + GetSoqucoinBlockSubsidy(nHeight, consensus, pindexPrev->GetBlockHash());
     coinbaseTx.vin[0].scriptSig = CScript() << nHeight << OP_0;
 
+    // Genesis-migration one-shot allocation (DL-GENESIS-MIGRATION-IMPLEMENTATION §A3):
+    // at the armed height, append the committed outputs after the miner output. The
+    // consensus rule in ConnectBlock binds every miner regardless — this template
+    // insertion is a convenience, not a trust assumption — and GenerateCoinbaseCommitment
+    // below appends the witness commitment AFTER them, which validation excludes from
+    // the committed range. TestBlockValidity at the end of this function fails loudly
+    // if the compiled-in vector does not match the armed constants.
+    if (consensus.nMigrationHeight != 0 && nHeight == consensus.nMigrationHeight &&
+        !consensus.hashMigrationOutputs.IsNull()) {
+        const std::vector<CTxOut>& vMigration = chainparams.MigrationOutputs();
+        coinbaseTx.vout.insert(coinbaseTx.vout.end(), vMigration.begin(), vMigration.end());
+    }
+
     // SOQUCOIN: Force Dilithium-only coinbase outputs (witness v1)
     if (nHeight >= consensus.dilithiumOnlyHeight && (scriptPubKeyIn.size() != 34 || scriptPubKeyIn[0] != OP_1 || scriptPubKeyIn[1] != 32)) {
         LogPrintf("%s: Coinbase must pay to Dilithium witness v1 address (OP_1 <32-byte-hash>)\n", __func__);

--- a/src/test/consensus_digest_tests.cpp
+++ b/src/test/consensus_digest_tests.cpp
@@ -114,6 +114,13 @@ void AbsorbConsensus(DigestBuilder& d, const Consensus::Params& c)
     d.I64(c.fDigishieldDifficultyCalculation ? 1 : 0);
     d.I64(c.fSimplifiedRewards ? 1 : 0);
 
+    // Genesis-migration allocation constants (DL-GENESIS-MIGRATION-IMPLEMENTATION
+    // §A1). Null/0/0 today on every network — absorbed so that ARMING them at the
+    // ceremony is a digest move, exactly like touching a genesis field.
+    d.Hash(c.hashMigrationOutputs);
+    d.I64(c.nMigrationTotal);
+    d.I64(c.nMigrationHeight);
+
     // The derived privacy seed. THIS is the field whose class of defect F4 exists
     // for: it is computed at startup by HKDF over the genesis hash, so it is both
     // public and code-derived, and the nh6m bug made exactly that kind of value
@@ -498,7 +505,7 @@ BOOST_AUTO_TEST_CASE(consensus_digest_is_pinned)
     const uint256 digest = ComputeConsensusDigest();
     BOOST_TEST_MESSAGE("CONSENSUS DIGEST: " << digest.ToString());
 
-    // Pinned 2026-08-26, Apple clang 21 arm64 -O2, at the FC4 candidate.
+    // Pinned 2026-08-29, Apple clang 21 arm64 -O2, at the FC4 candidate.
     //
     // Moved from 5effd2ed86326721613bddbbe2002555b217e1008c27668557027dcacf6a7ce0
     // for exactly the consensus inputs FC4 changed, each individually intended:
@@ -534,8 +541,18 @@ BOOST_AUTO_TEST_CASE(consensus_digest_is_pinned)
     // old digest. The new function is guarded by
     // opcode_coverage_actually_reaches_pat_crypto below, so the coverage cannot
     // silently regress to shape-rejection again.
+    //
+    // Moved from df60b54d... on 2026-08-29 when AbsorbConsensus gained the three
+    // genesis-migration allocation constants (hashMigrationOutputs,
+    // nMigrationTotal, nMigrationHeight — DL-GENESIS-MIGRATION-IMPLEMENTATION
+    // §A1, bead gm-consensus-rule-bxws). A COVERAGE change again, not a rule
+    // change: the constants are null/0/0 on every network, so the absorbed
+    // values are the inert defaults — but arming them at a ceremony must move
+    // the digest exactly like touching a genesis field, so they are absorbed
+    // from the day they exist. The F4 sweep is re-run against the FC4 tag
+    // (bead 71z6), which covers this move on the fleet toolchain.
     const std::string expected =
-        "df60b54de75e72cf1cd7387cb0b1bc01191c1bccd0a1e7644927aa423750401b";
+        "43eb9d6bc5907f9d7ba13aba375c63ada6ef3d915f1941e6c754a35f971b5a24";
 
     BOOST_CHECK_MESSAGE(digest.ToString() == expected,
         "consensus digest is " + digest.ToString() + ", expected " + expected +

--- a/src/test/migration_rule_tests.cpp
+++ b/src/test/migration_rule_tests.cpp
@@ -1,0 +1,394 @@
+// Copyright (c) 2026 Soqucoin Labs Inc.
+// Distributed under the MIT software license.
+//
+// migration_rule_tests.cpp — tamper matrix for the genesis-migration one-shot
+// allocation rule (DL-GENESIS-MIGRATION-IMPLEMENTATION §A, bead
+// gm-consensus-rule-bxws).
+//
+// The rule: at exactly nHeight == nMigrationHeight (non-zero, hash set), the
+// coinbase must carry the committed allocation outputs as vout[1..N] in
+// committed order (a trailing segwit witness-commitment output is excluded
+// from the committed range); their standard vector serialization must
+// double-SHA256 to hashMigrationOutputs, their values must sum to exactly
+// nMigrationTotal, and the miner's vout[0] stays bounded by subsidy + fees
+// while the permitted coinbase total becomes subsidy + fees + nMigrationTotal.
+// With null/0/0 constants the rule is INERT — behavior byte-for-byte unchanged.
+//
+// r0vn acceptance criterion: every reject case drives a failing block through
+// ConnectBlock (via TestBlockValidity, which runs ConnectBlock in fJustCheck
+// mode) and observes the EXACT reject string, never just an unmoved tip.
+//
+// ⚠️ These tests arm the rule by mutating the regtest singleton
+// (UpdateRegtestMigrationParams). Every arming goes through the RAII guard
+// below so the singleton is always restored to the inert null/0/0/{} state,
+// even on assertion failure — a leaked arming would poison every later suite.
+//
+// Fixture shape borrowed from authority_skip_gate_tests.cpp.
+
+#include "chainparams.h"
+#include "consensus/validation.h"
+#include "hash.h"
+#include "miner.h"
+#include "pow.h"
+#include "primitives/transaction.h"
+#include "script/script.h"
+#include "uint256.h"
+#include "validation.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+//! OP_1 <32-byte hash> — the witness-v1 shape the miner's Dilithium-only
+//! coinbase check requires, and the shape real sq1 allocations will have.
+static CScript V1Spk(unsigned char seed)
+{
+    return CScript() << OP_1 << std::vector<unsigned char>(32, seed);
+}
+
+static uint256 HashOutputs(const std::vector<CTxOut>& vOutputs)
+{
+    CHashWriter hasher(SER_GETHASH, PROTOCOL_VERSION);
+    hasher << vOutputs;
+    return hasher.GetHash();
+}
+
+static CAmount SumOutputs(const std::vector<CTxOut>& vOutputs)
+{
+    CAmount total = 0;
+    for (const CTxOut& out : vOutputs) total += out.nValue;
+    return total;
+}
+
+//! Arms the regtest migration rule for one scope and ALWAYS disarms on exit.
+struct MigrationArming {
+    MigrationArming(const uint256& hashOutputs, CAmount nTotal, int nHeight,
+                    const std::vector<CTxOut>& vOutputs)
+    {
+        UpdateRegtestMigrationParams(hashOutputs, nTotal, nHeight, vOutputs);
+    }
+    ~MigrationArming()
+    {
+        UpdateRegtestMigrationParams(uint256(), 0, 0, std::vector<CTxOut>());
+    }
+};
+
+} // namespace
+
+struct MigrationChainSetup : public TestingSetup {
+    CScript minerSpk;
+    std::vector<CTxOut> committed; // the canonical 3-output allocation fixture
+
+    MigrationChainSetup() : TestingSetup(CBaseChainParams::REGTEST)
+    {
+        minerSpk = V1Spk(0x01);
+        // Values sit above the SOQ-ARCH-003 utxo-cost floor (6,500 sat/byte —
+        // active from height 0 on regtest), as every real allocation does: the
+        // snapshot tool's dust floor is 1 pSOQ = 1 SOQ = 10^8 sats, comfortably
+        // over the ~2.8e5-sat minimum for a v1 output.
+        committed.push_back(CTxOut(10 * COIN, V1Spk(0xA1)));
+        committed.push_back(CTxOut(20 * COIN, V1Spk(0xA2)));
+        committed.push_back(CTxOut(COIN / 2, V1Spk(0xA3)));
+        // Past the regtest params-tree boundaries (digishield at 10, auxpow at
+        // 20), so armed heights resolve through auxpowConsensus — the struct a
+        // singleton mutation historically missed (bead tofg).
+        for (int i = 0; i < 30; i++) {
+            MineHonestBlock();
+        }
+    }
+
+    //! Template straight from the production miner — this is also the §A3 test
+    //! surface: at the armed height the template must already carry the
+    //! committed outputs.
+    CBlock BuildTemplateBlock()
+    {
+        std::unique_ptr<CBlockTemplate> tmpl = BlockAssembler(Params()).CreateNewBlock(minerSpk, true);
+        BOOST_REQUIRE(tmpl != nullptr);
+        return tmpl->block;
+    }
+
+    //! Runs ConnectBlock (fJustCheck) on the block as-is; returns the reject
+    //! string, or "" if it validated. PoW and merkle are skipped so tampered,
+    //! unsolved blocks can be driven straight at the rule. The migration
+    //! rejects asserted below all carry their own named strings, so "" is
+    //! unambiguous here (see authority_skip_gate_tests.cpp on the empty-string
+    //! caveat for script-layer rules).
+    std::string RejectReasonFor(const CBlock& block)
+    {
+        CValidationState st;
+        LOCK(cs_main);
+        if (TestBlockValidity(st, Params(), block, chainActive.Tip(), false, false)) return std::string();
+        return st.GetRejectReason();
+    }
+
+    //! Solve and submit; returns whether the tip advanced to this block.
+    bool MineBlock(CBlock& block)
+    {
+        const CChainParams& cp = Params();
+        unsigned int extraNonce = 0;
+        {
+            LOCK(cs_main);
+            IncrementExtraNonce(&block, chainActive.Tip(), extraNonce);
+        }
+        while (!CheckProofOfWork(block.GetPoWHash(), block.nBits, cp.GetConsensus(0)))
+            ++block.nNonce;
+        std::shared_ptr<const CBlock> shared = std::make_shared<const CBlock>(block);
+        bool fNewBlock = false;
+        ProcessNewBlock(cp, shared, true, &fNewBlock);
+        LOCK(cs_main);
+        return chainActive.Tip()->GetBlockHash() == block.GetHash();
+    }
+
+    void MineHonestBlock()
+    {
+        CBlock block = BuildTemplateBlock();
+        BOOST_REQUIRE(MineBlock(block));
+    }
+
+    int TipHeight()
+    {
+        LOCK(cs_main);
+        return chainActive.Height();
+    }
+
+    //! Replace the coinbase vout vector, keeping everything else (witness
+    //! commitment output positions are the caller's business — the committed
+    //! range excludes only a TRAILING commitment output).
+    static CBlock WithCoinbaseVout(const CBlock& block, const std::vector<CTxOut>& vout)
+    {
+        CBlock tampered = block;
+        CMutableTransaction coinbaseMut(*tampered.vtx[0]);
+        coinbaseMut.vout = vout;
+        tampered.vtx[0] = MakeTransactionRef(std::move(coinbaseMut));
+        return tampered;
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(migration_rule_tests, MigrationChainSetup)
+
+// The inert guarantee, stated as a test: with null constants (the state every
+// real network ships in), the template carries no allocation and validates.
+BOOST_AUTO_TEST_CASE(inert_by_default)
+{
+    CBlock block = BuildTemplateBlock();
+    // miner output + witness commitment only — nothing appended
+    BOOST_CHECK_EQUAL(block.vtx[0]->vout.size(), 2U);
+    BOOST_CHECK_EQUAL(RejectReasonFor(block), "");
+}
+
+// §A3 + §A2 honest path: at the armed height the production template carries
+// miner + committed outputs (+ trailing commitment), in committed order, and
+// the block both validates and connects.
+BOOST_AUTO_TEST_CASE(honest_migration_block_accepted)
+{
+    const int H = TipHeight() + 1;
+    MigrationArming arm(HashOutputs(committed), SumOutputs(committed), H, committed);
+
+    CBlock block = BuildTemplateBlock();
+    const CTransaction& coinbase = *block.vtx[0];
+    BOOST_REQUIRE_EQUAL(coinbase.vout.size(), 2U + committed.size());
+    for (size_t i = 0; i < committed.size(); i++) {
+        BOOST_CHECK(coinbase.vout[1 + i] == committed[i]);
+    }
+    BOOST_CHECK_EQUAL(RejectReasonFor(block), "");
+    BOOST_CHECK(MineBlock(block));
+    BOOST_CHECK_EQUAL(TipHeight(), H);
+}
+
+// Tamper 1: one committed output missing.
+BOOST_AUTO_TEST_CASE(tamper_missing_output)
+{
+    const int H = TipHeight() + 1;
+    MigrationArming arm(HashOutputs(committed), SumOutputs(committed), H, committed);
+    CBlock block = BuildTemplateBlock();
+    std::vector<CTxOut> vout = block.vtx[0]->vout;
+    vout.erase(vout.begin() + 2); // drop the second committed output
+    BOOST_CHECK_EQUAL(RejectReasonFor(WithCoinbaseVout(block, vout)), "bad-cb-migration-outputs");
+}
+
+// Tamper 2: one committed amount altered (by a single sat, both directions).
+BOOST_AUTO_TEST_CASE(tamper_altered_amount)
+{
+    const int H = TipHeight() + 1;
+    MigrationArming arm(HashOutputs(committed), SumOutputs(committed), H, committed);
+    CBlock block = BuildTemplateBlock();
+    for (const CAmount delta : {CAmount(1), CAmount(-1)}) {
+        std::vector<CTxOut> vout = block.vtx[0]->vout;
+        vout[1].nValue += delta;
+        BOOST_CHECK_EQUAL(RejectReasonFor(WithCoinbaseVout(block, vout)), "bad-cb-migration-outputs");
+    }
+}
+
+// Tamper 3: committed outputs reordered (same set, same sum).
+BOOST_AUTO_TEST_CASE(tamper_reordered_outputs)
+{
+    const int H = TipHeight() + 1;
+    MigrationArming arm(HashOutputs(committed), SumOutputs(committed), H, committed);
+    CBlock block = BuildTemplateBlock();
+    std::vector<CTxOut> vout = block.vtx[0]->vout;
+    std::swap(vout[1], vout[2]);
+    BOOST_CHECK_EQUAL(RejectReasonFor(WithCoinbaseVout(block, vout)), "bad-cb-migration-outputs");
+}
+
+// Tamper 4: an extra output inserted inside the committed range. A zero-value
+// OP_RETURN is the sharpest probe: unspendable outputs are exempt from the
+// utxo-cost floor and zero value is invisible to every amount check, so ONLY
+// the committed-vector hash can catch it.
+BOOST_AUTO_TEST_CASE(tamper_extra_output_inside_range)
+{
+    const int H = TipHeight() + 1;
+    MigrationArming arm(HashOutputs(committed), SumOutputs(committed), H, committed);
+    CBlock block = BuildTemplateBlock();
+    std::vector<CTxOut> vout = block.vtx[0]->vout;
+    vout.insert(vout.begin() + 2, CTxOut(0, CScript() << OP_RETURN << std::vector<unsigned char>{0xEE}));
+    BOOST_CHECK_EQUAL(RejectReasonFor(WithCoinbaseVout(block, vout)), "bad-cb-migration-outputs");
+}
+
+// Tamper 5 (amended for nMigrationHeight): the committed outputs at any height
+// other than the armed one are just unlicensed coinbase inflation, and the
+// pre-existing subsidy check rejects them. Driven at both H-1 and H+1.
+BOOST_AUTO_TEST_CASE(tamper_outputs_at_wrong_height)
+{
+    const int H = TipHeight() + 2; // arm one block in the future
+    MigrationArming arm(HashOutputs(committed), SumOutputs(committed), H, committed);
+
+    // H-1: rule inert at this height, so a coinbase carrying the committed
+    // outputs simply pays too much.
+    {
+        CBlock block = BuildTemplateBlock();
+        std::vector<CTxOut> vout = block.vtx[0]->vout;
+        vout.insert(vout.begin() + 1, committed.begin(), committed.end());
+        BOOST_CHECK_EQUAL(RejectReasonFor(WithCoinbaseVout(block, vout)), "bad-cb-amount");
+    }
+
+    // Advance honestly through H-1 and H (the migration block itself).
+    MineHonestBlock();
+    BOOST_REQUIRE_EQUAL(TipHeight(), H - 1);
+    {
+        CBlock block = BuildTemplateBlock();
+        BOOST_CHECK_EQUAL(RejectReasonFor(block), "");
+        BOOST_REQUIRE(MineBlock(block));
+    }
+    BOOST_REQUIRE_EQUAL(TipHeight(), H);
+
+    // H+1: the window is one block wide. Same outputs, same reject.
+    {
+        CBlock block = BuildTemplateBlock();
+        BOOST_CHECK_EQUAL(block.vtx[0]->vout.size(), 2U); // template appends nothing past H
+        std::vector<CTxOut> vout = block.vtx[0]->vout;
+        vout.insert(vout.begin() + 1, committed.begin(), committed.end());
+        BOOST_CHECK_EQUAL(RejectReasonFor(WithCoinbaseVout(block, vout)), "bad-cb-amount");
+    }
+}
+
+// Tampers 6+7: value inflation on the migration block. Inflating a COMMITTED
+// output is a hash mismatch (tamper 2 already pins that), so the interesting
+// case is the MINER output: the committed set stays byte-identical and only
+// vout[0] exceeds subsidy + fees.
+BOOST_AUTO_TEST_CASE(tamper_miner_output_inflated)
+{
+    const int H = TipHeight() + 1;
+    MigrationArming arm(HashOutputs(committed), SumOutputs(committed), H, committed);
+    CBlock block = BuildTemplateBlock();
+    std::vector<CTxOut> vout = block.vtx[0]->vout;
+    vout[0].nValue += 1; // one sat above subsidy + fees
+    BOOST_CHECK_EQUAL(RejectReasonFor(WithCoinbaseVout(block, vout)), "bad-cb-migration-miner-value");
+}
+
+// Tamper 8: armed-vs-null cross-check. The SAME block bytes flip verdict with
+// the constants: the honest migration block is valid armed and inflation when
+// null; the plain block is valid null and missing-outputs when armed.
+BOOST_AUTO_TEST_CASE(tamper_armed_vs_null_crosscheck)
+{
+    const int H = TipHeight() + 1;
+
+    CBlock migrationBlock, plainBlock;
+    {
+        MigrationArming arm(HashOutputs(committed), SumOutputs(committed), H, committed);
+        migrationBlock = BuildTemplateBlock();
+        BOOST_CHECK_EQUAL(RejectReasonFor(migrationBlock), "");
+    }
+    plainBlock = BuildTemplateBlock();
+    BOOST_CHECK_EQUAL(RejectReasonFor(plainBlock), "");
+
+    // Null constants: the migration block is unlicensed inflation.
+    BOOST_CHECK_EQUAL(RejectReasonFor(migrationBlock), "bad-cb-amount");
+
+    {
+        MigrationArming arm(HashOutputs(committed), SumOutputs(committed), H, committed);
+        // Armed: the plain block (miner + trailing commitment only) has no
+        // committed range at all.
+        BOOST_CHECK_EQUAL(RejectReasonFor(plainBlock), "bad-cb-migration-missing");
+    }
+}
+
+// Tamper 9: hash set but the coinbase carries no committed outputs — just the
+// miner output and the trailing witness commitment (which stays, both because
+// an honest lazy miner would produce exactly this shape and because stripping
+// it would trip the witness checks before the rule is ever reached).
+BOOST_AUTO_TEST_CASE(tamper_miner_output_only)
+{
+    const int H = TipHeight() + 1;
+    MigrationArming arm(HashOutputs(committed), SumOutputs(committed), H, committed);
+    CBlock block = BuildTemplateBlock();
+    std::vector<CTxOut> vout;
+    vout.push_back(block.vtx[0]->vout.front()); // miner
+    vout.push_back(block.vtx[0]->vout.back());  // witness commitment
+    BOOST_CHECK_EQUAL(RejectReasonFor(WithCoinbaseVout(block, vout)), "bad-cb-migration-missing");
+}
+
+// Tamper 10: armed constants internally inconsistent — nMigrationTotal does
+// not equal the committed sum. The hash matches, the sum check fails closed:
+// no block at H can ever validate under such constants.
+BOOST_AUTO_TEST_CASE(tamper_total_mismatch)
+{
+    const int H = TipHeight() + 1;
+    // The production miner would fail its own TestBlockValidity under the
+    // inconsistent constants (that is the fail-loudly property §A3 promises),
+    // so take the block from a consistent arming first. Sequential scopes, not
+    // nested — the guard's destructor resets the singleton unconditionally.
+    CBlock block;
+    {
+        MigrationArming consistent(HashOutputs(committed), SumOutputs(committed), H, committed);
+        block = BuildTemplateBlock();
+        BOOST_CHECK_EQUAL(RejectReasonFor(block), "");
+    }
+    MigrationArming arm(HashOutputs(committed), SumOutputs(committed) + 1, H, committed);
+    BOOST_CHECK_EQUAL(RejectReasonFor(block), "bad-cb-migration-total");
+}
+
+// The witness-commitment seam: the committed range must exclude a TRAILING
+// commitment output (the miner appends it after the allocation), but an
+// impostor commitment-shaped output that is NOT trailing is inside the range
+// and breaks the hash like any other insertion.
+BOOST_AUTO_TEST_CASE(witness_commitment_exclusion)
+{
+    const int H = TipHeight() + 1;
+    MigrationArming arm(HashOutputs(committed), SumOutputs(committed), H, committed);
+    CBlock block = BuildTemplateBlock();
+    const std::vector<CTxOut>& vout = block.vtx[0]->vout;
+
+    // Structure sanity: [miner, committed..., commitment]
+    BOOST_REQUIRE_EQUAL(vout.size(), 2U + committed.size());
+    const CTxOut& commitment = vout.back();
+    BOOST_REQUIRE(commitment.scriptPubKey.size() >= 38 && commitment.scriptPubKey[0] == OP_RETURN);
+
+    // A second commitment-shaped output inserted INSIDE the committed range is
+    // not excluded — hash mismatch.
+    {
+        std::vector<CTxOut> tampered = vout;
+        tampered.insert(tampered.begin() + 1, CTxOut(0, commitment.scriptPubKey));
+        BOOST_CHECK_EQUAL(RejectReasonFor(WithCoinbaseVout(block, tampered)), "bad-cb-migration-outputs");
+    }
+
+    // Moving the real commitment INSIDE the range (so nothing trails) also
+    // breaks the hash — exclusion applies to the trailing position only.
+    {
+        std::vector<CTxOut> tampered = vout;
+        std::swap(tampered[1], tampered.back());
+        BOOST_CHECK_EQUAL(RejectReasonFor(WithCoinbaseVout(block, tampered)), "bad-cb-migration-outputs");
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -99,6 +99,7 @@ CTxMemPool mempool(::minRelayTxFeeRate);
  */
 static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart, unsigned nRequired, const Consensus::Params& consensusParams);
 static void CheckBlockIndex(const Consensus::Params& consensusParams);
+static int GetWitnessCommitmentIndex(const CBlock& block);
 
 /** Constant stuff for coinbase transactions we create: */
 CScript COINBASE_FLAGS;
@@ -3634,6 +3635,58 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     LogPrint("bench", "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs]\n", (unsigned)block.vtx.size(), 0.001 * (nTime3 - nTime2), 0.001 * (nTime3 - nTime2) / block.vtx.size(), nInputs <= 1 ? 0 : 0.001 * (nTime3 - nTime2) / (nInputs - 1), nTimeConnect * 0.000001);
 
     CAmount blockReward = nFees + GetSoqucoinBlockSubsidy(pindex->nHeight, chainparams.GetConsensus(pindex->nHeight), hashPrevBlock);
+
+    // =========================================================================
+    // Genesis-migration one-shot allocation (DL-GENESIS-MIGRATION-IMPLEMENTATION
+    // §A2, bead gm-consensus-rule-bxws). Inert on every network until all three
+    // constants are armed: with nMigrationHeight == 0 or a null hash this block
+    // is byte-for-byte the pre-existing subsidy check. At exactly the armed
+    // height, the coinbase must carry the committed allocation outputs as
+    // vout[1..N] in committed order (a trailing segwit witness-commitment
+    // output, which the miner appends after them, is not part of the committed
+    // range): their standard serialization must hash to hashMigrationOutputs,
+    // their values must sum to exactly nMigrationTotal, and the miner's own
+    // output vout[0] stays bounded by subsidy + fees while the permitted total
+    // becomes subsidy + fees + nMigrationTotal.
+    // =========================================================================
+    {
+        const Consensus::Params& migrationConsensus = chainparams.GetConsensus(pindex->nHeight);
+        if (migrationConsensus.nMigrationHeight != 0 &&
+            pindex->nHeight == migrationConsensus.nMigrationHeight &&
+            !migrationConsensus.hashMigrationOutputs.IsNull()) {
+            const CTransaction& coinbase = *block.vtx[0];
+            size_t committedEnd = coinbase.vout.size();
+            const int commitpos = GetWitnessCommitmentIndex(block);
+            if (commitpos > 0 && (size_t)commitpos == coinbase.vout.size() - 1)
+                committedEnd--;
+            if (committedEnd < 2)
+                return state.DoS(100,
+                    error("ConnectBlock(): migration block %d carries no committed outputs", pindex->nHeight),
+                    REJECT_INVALID, "bad-cb-migration-missing");
+            const std::vector<CTxOut> committed(coinbase.vout.begin() + 1, coinbase.vout.begin() + committedEnd);
+            CHashWriter hasher(SER_GETHASH, PROTOCOL_VERSION);
+            hasher << committed;
+            if (hasher.GetHash() != migrationConsensus.hashMigrationOutputs)
+                return state.DoS(100,
+                    error("ConnectBlock(): migration block %d committed outputs do not match hashMigrationOutputs", pindex->nHeight),
+                    REJECT_INVALID, "bad-cb-migration-outputs");
+            CAmount committedSum = 0;
+            for (const CTxOut& out : committed)
+                committedSum += out.nValue; // per-output and total bounds already enforced by CheckTransaction
+            if (committedSum != migrationConsensus.nMigrationTotal)
+                return state.DoS(100,
+                    error("ConnectBlock(): migration block %d committed sum %d != nMigrationTotal %d",
+                        pindex->nHeight, committedSum, migrationConsensus.nMigrationTotal),
+                    REJECT_INVALID, "bad-cb-migration-total");
+            if (coinbase.vout[0].nValue > blockReward)
+                return state.DoS(100,
+                    error("ConnectBlock(): migration block %d miner output pays too much (actual=%d vs limit=%d)",
+                        pindex->nHeight, coinbase.vout[0].nValue, blockReward),
+                    REJECT_INVALID, "bad-cb-migration-miner-value");
+            blockReward += migrationConsensus.nMigrationTotal;
+        }
+    }
+
     if (block.vtx[0]->GetValueOut() > blockReward)
         return state.DoS(100,
             error("ConnectBlock(): coinbase pays too much (actual=%d vs limit=%d)",


### PR DESCRIPTION
## What

The genesis-migration one-shot allocation rule from DL-GENESIS-MIGRATION-IMPLEMENTATION section A (bead `gm-consensus-rule-bxws`), built inert and height-parameterized per the ruled plan of record: it rides the FC4 candidate with null constants, and validation is byte-for-byte unchanged on every network until a future ceremony arms `hashMigrationOutputs` / `nMigrationTotal` / `nMigrationHeight` together at a pre-announced height.

## Design properties

- **Inert guarantee**: `nMigrationHeight == 0` or a null hash short-circuits to the pre-existing subsidy check. Pinned by `migration_rule_tests/inert_by_default` and by the armed-vs-null cross-check.
- **One block wide**: the rule applies at exactly `nHeight == nMigrationHeight`. The committed outputs at any other height are unlicensed inflation and hit the pre-existing `bad-cb-amount` check (tested at H-1 and H+1).
- **Hash is the authority**: `vout[1..N]` (excluding a trailing witness-commitment output) must serialize to `hashMigrationOutputs`; the sum check against `nMigrationTotal` and the `vout[0] <= subsidy+fees` bound are belt and braces on top.
- **No new tx types, no CTxOut changes, no new chainstate.** Core consensus diff is ~85 lines.
- **Digest coverage**: the three constants are absorbed into the consensus digest, so arming them is a visible digest move exactly like touching a genesis field. Deliberate re-pin `df60b54d` -> `43eb9d6b` (coverage change, no rule moved). The F4 sweep re-run against the FC4 tag (P0 bead `71z6`) covers the new pin on the fleet toolchain.

## Found by execution, folded into the spec

1. The plan's `vout[1..N]` did not account for the segwit witness commitment the miner appends after the allocations; the committed range excludes it in trailing position only. The worst an adversary can smuggle past the hash is one zero-value OP_RETURN in trailing position, which allocates and spends nothing.
2. Committed outputs are subject to the SOQ-ARCH-003 utxo-cost floor where that deployment is active. The snapshot tool (bead `gm-snapshot-tool-cjqx`) must assert the per-output floor before producing a commitment; requirement recorded on that bead.

## Tests

- `migration_rule_tests.cpp`: the full 10-case tamper matrix from the DL plus cross-height and witness-commitment-exclusion cases, every reject driven through ConnectBlock and observed by its named reject string (r0vn discipline). 12/12 green.
- `qa/rpc-tests/genesis-migration.py`: end to end through a live node - regtest-only arming via init args, the production miner emitting the committed outputs at exactly the armed height, one-block window, chain continues. Passed.
- Full unit suite: **736 cases, 0 failures** (was 724; +12 here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
