### PR TITLE
rpc: gate work-serving mining RPCs behind -enablemining, default off on mainnet

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -114,6 +114,7 @@ testScripts = [
     'pat_basic.py',
     'maxreorgdepth.py',
     'genesis-migration.py',
+    'mining-gate.py',
     'getauxblock.py',
     'wallet.py',
     'wallet-accounts.py',

--- a/qa/rpc-tests/mining-gate.py
+++ b/qa/rpc-tests/mining-gate.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Soqucoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# The -enablemining gate (launch mining posture, bead
+# launch-mining-posture-gate-92yq, ratified 2026-08-29).
+#
+# Work-serving RPCs (getblocktemplate, generate, generatetoaddress and the
+# createauxblock family) refuse unless -enablemining is set; the default is ON
+# everywhere except mainnet. Regtest's default is ON — every other functional
+# test proves that path by mining — so this test drives the gate explicitly
+# with -enablemining=0, then proves the opt-in restores service.
+#
+# The mainnet DEFAULT (off) cannot be driven here (no mainnet in qa); it is
+# one line in EnsureMiningRPCsEnabled and is verified in the artifact by
+# audit lane A5 (PRE_LAUNCH_AUDIT_PLAN_FC4.md).
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+GATE_MSG = "Mining RPCs are disabled"
+
+class MiningGateTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self):
+        self.is_network_split = False
+        self.nodes = [start_node(0, self.options.tmpdir,
+                                 ["-debug", "-enablemining=0"])]
+
+    def assert_gated(self, fn, *args):
+        try:
+            fn(*args)
+        except JSONRPCException as e:
+            assert GATE_MSG in e.error["message"], (
+                "expected the gate, got: %s" % e.error["message"])
+            return
+        raise AssertionError("%s was served despite -enablemining=0" % fn)
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # Every work-serving RPC refuses, with the gate's own message.
+        self.assert_gated(node.getblocktemplate)
+        self.assert_gated(node.generate, 1)
+        self.assert_gated(node.generatetoaddress, 1, node.getnewaddress())
+        self.assert_gated(node.createauxblock, node.getnewaddress())
+        self.assert_gated(node.getauxblock)
+
+        # Read-only introspection and block acceptance are NOT gated.
+        node.getmininginfo()
+        try:
+            node.submitblock("00")   # garbage: must fail on CONTENT, not the gate
+        except JSONRPCException as e:
+            assert GATE_MSG not in e.error["message"]
+
+        # The opt-in restores service.
+        stop_node(node, 0)
+        self.nodes[0] = start_node(0, self.options.tmpdir,
+                                   ["-debug", "-enablemining=1"])
+        node = self.nodes[0]
+        node.generate(2)
+        assert_equal(node.getblockcount(), 2)
+
+        print("Mining-gate functional test passed")
+
+if __name__ == '__main__':
+    MiningGateTest().main()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -495,6 +495,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-mempoolreplacement", strprintf(_("Enable transaction replacement in the memory pool (default: %u)"), DEFAULT_ENABLE_REPLACEMENT));
 
     strUsage += HelpMessageGroup(_("Block creation options:"));
+    strUsage += HelpMessageOpt("-enablemining", _("Serve mining work over RPC (getblocktemplate, generate, the auxpow block RPCs). Default: 1 on every network except mainnet, where the launch-period default is 0; pool and miner-facing nodes opt in explicitly"));
     strUsage += HelpMessageOpt("-blockmaxweight=<n>", strprintf(_("Set maximum BIP141 block weight (default: %d)"), DEFAULT_BLOCK_MAX_WEIGHT));
     strUsage += HelpMessageOpt("-blockmaxsize=<n>", strprintf(_("Set maximum block size in bytes (default: %d)"), DEFAULT_BLOCK_MAX_SIZE));
     strUsage += HelpMessageOpt("-blockprioritysize=<n>", strprintf(_("Set maximum size of high-priority/low-fee transactions in bytes (default: %d)"), DEFAULT_BLOCK_PRIORITY_SIZE));

--- a/src/rpc/auxpow.cpp
+++ b/src/rpc/auxpow.cpp
@@ -38,6 +38,8 @@ static std::vector<std::unique_ptr<CBlockTemplate> > vNewBlockTemplate;
 
 void AuxMiningCheck()
 {
+    EnsureMiningRPCsEnabled();
+
     if (!g_connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
@@ -50,9 +52,10 @@ void AuxMiningCheck()
 
     /* Soqucoin uses Dogecoin-model dual mining: both legacy Scrypt blocks
        AND AuxPoW blocks are accepted simultaneously (fAllowLegacyBlocks = true
-       even in the AuxPoW phase). Enforce the Vanguard Window: AuxPoW blocks
-       are not accepted before nAuxpowStartHeight (mainnet=1000, stagenet=100).
-       Solo mining via getblocktemplate/submitblock is always available.  */
+       even in the AuxPoW phase). AuxPoW blocks are not accepted before
+       nAuxpowStartHeight — which is 0 on mainnet (AuxPoW from genesis, no
+       Vanguard Window; bead inu, ratified 2026-06-29), so on mainnet this
+       check never fires. Regtest keeps 20 as a test fixture. */
     {
         LOCK(cs_main);
         const Consensus::Params& consensusParams = Params().GetConsensus(chainActive.Height() + 1);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -43,6 +43,18 @@ using namespace std;
 // SECURITY NOTE: Pre-mainnet critical fix. See PRE-MAINNET-MINING-FIXES.md
 static CCriticalSection cs_blocktemplate;
 
+// See the contract in rpc/mining.h. Read-only introspection (getmininginfo,
+// getnetworkhashps, prioritisetransaction) stays available regardless.
+void EnsureMiningRPCsEnabled()
+{
+    const bool fDefault = Params().NetworkIDString() != CBaseChainParams::MAIN;
+    if (!GetBoolArg("-enablemining", fDefault))
+        throw JSONRPCError(RPC_METHOD_NOT_FOUND,
+            "Mining RPCs are disabled (launch-period default on mainnet). "
+            "Restart with -enablemining=1 to serve mining work; the supported "
+            "path for miners is the pool.");
+}
+
 /**
  * Return average network hashes per second based on the last 'lookup' blocks,
  * or from the last difficulty change if 'lookup' is nonpositive.
@@ -193,6 +205,8 @@ UniValue generate(const JSONRPCRequest& request)
             "\nGenerate 11 blocks\n" +
             HelpExampleCli("generate", "11"));
 
+    EnsureMiningRPCsEnabled();
+
     int nGenerate = request.params[0].get_int();
     uint64_t nMaxTries = 1000000;
     if (request.params.size() > 1) {
@@ -234,6 +248,8 @@ UniValue generatetoaddress(const JSONRPCRequest& request)
             "\nExamples:\n"
             "\nGenerate 11 blocks to myaddress\n" +
             HelpExampleCli("generatetoaddress", "11 \"myaddress\""));
+
+    EnsureMiningRPCsEnabled();
 
     int nGenerate = request.params[0].get_int();
     uint64_t nMaxTries = 1000000;
@@ -429,6 +445,8 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
 
             "\nExamples:\n" +
             HelpExampleCli("getblocktemplate", "") + HelpExampleRpc("getblocktemplate", ""));
+
+    EnsureMiningRPCsEnabled();
 
     LOCK(cs_main);
 

--- a/src/rpc/mining.h
+++ b/src/rpc/mining.h
@@ -39,4 +39,17 @@ public:
 
 UniValue BIP22ValidationResult(const CValidationState& state);
 
+/**
+ * Launch mining posture (ratified 2026-08-29, bead
+ * launch-mining-posture-gate-92yq): the work-serving RPCs — getblocktemplate,
+ * generate, generatetoaddress and the createauxblock/getauxblock/submitauxblock
+ * family — refuse to serve unless -enablemining is set. Default: ON everywhere
+ * except mainnet. This is deliberately friction, not a security boundary (the
+ * source is public); its purpose is that the default path for hashrate is the
+ * pool, whose vesting and caps are the launch-period dump controls. submitblock
+ * is NOT gated: blocks arrive over P2P regardless, so gating it buys nothing.
+ * Revisit the mainnet default in a post-launch release.
+ */
+void EnsureMiningRPCsEnabled();
+
 #endif // BITCOIN_RPCMINING_H


### PR DESCRIPTION
The ratified launch mining posture (bead `launch-mining-posture-gate-92yq`, 2026-08-29): `getblocktemplate`, `generate`, `generatetoaddress` and the `createauxblock`/`getauxblock`/`submitauxblock` family refuse unless `-enablemining` is set. **Default ON everywhere except mainnet** — regtest/testnet/stagenet and every existing test are undisturbed; mainnet pool and miner-facing nodes opt in with one config line at deploy.

What this is, stated honestly (also in the code contract): **friction, not a security boundary** — the source is public. Its purpose is channeling: the default path for hashrate is the pool, whose vesting and caps are the launch-period dump controls, and solo mining bypasses those controls entirely. `submitblock` is not gated (blocks arrive over P2P regardless); read-only introspection stays open; **no consensus change** — `fAllowLegacyBlocks` deliberately untouched. RPC-layer only, so post-freeze-eligible per the x7hb classification, but intended to ride the FC4 tag.

Also fixes the stale `mainnet=1000` AuxPoW comment in `AuxMiningCheck` (AuxPoW is from genesis; bead inu closed 06-29).

Tests: `qa/rpc-tests/mining-gate.py` (gated refusals by the gate's own message, non-gated RPCs proven open, opt-in restores service) — passing; `genesis-migration.py` re-run green. The mainnet *default* is one line in `EnsureMiningRPCsEnabled` and is verified in the shipped artifact by audit lane A5.

Companion pieces: unknown-miner block-share detection (ops, filed for the soak window) and the fleet-config step in the FC4 deploy runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)