### PR TITLE
chainparams: zero mainnet nMinimumChainWork so a fresh chain can serve work

### DIFF
--- a/doc/GENESIS_CEREMONY.md
+++ b/doc/GENESIS_CEREMONY.md
@@ -141,6 +141,10 @@ be checked later.
    - `src/test/consensus_digest_tests.cpp` digest pins (the digest hashes
      `hashGenesisBlock`; the pinned digests WILL change and that is the
      tripwire working, not breaking)
+   - verify mainnet `nMinimumChainWork` and `defaultAssumeValid` are still
+     `0x00` (launch posture — a fresh chain has no accumulated work, and
+     IsInitialBlockDownload() gates the work-serving RPCs; both fields get
+     real values only in post-launch releases per doc/release-process.md)
 5. Run the full unit suite. Expected result: **everything green, zero
    failures. Any failure stops the ceremony.** (Until 2026-08-27 this step
    expected exactly three deliberate SoquObscura tripwire failures; those

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -13,6 +13,11 @@ Before every minor and major release:
 * Update version in sources (see below)
 * Write release notes (see below)
 * Update `src/chainparams.cpp` nMinimumChainWork with information from the getblockchaininfo rpc.
+  - ⚠ The mainnet value MUST come from a live Soqucoin mainnet node. It ships as
+    `0x00` at launch: an unreachable value (e.g. one inherited from an upstream
+    codebase) latches every fresh node in IBD, and IsInitialBlockDownload()
+    gates getblocktemplate and the auxpow work RPCs, so no node can serve
+    mining work (Phase A pre-launch audit finding, 2026-08-29).
 * Update `src/chainparams.cpp` defaultAssumeValid  with information from the getblockhash rpc.
   - The selected value must not be orphaned so it may be useful to set the value two blocks back from the tip.
   - Testnet should be set some tens of thousands back from the tip due to reorgs there.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -361,8 +361,16 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_V6_CONTROLFLOW].nActivationHeight   = Consensus::BIP9Deployment::NOT_SCHEDULED;
 
 
-        // The best chain should have at least this much work.
-        consensus.nMinimumChainWork = uint256S("0x000000000000000000000000000000000000000000000e993d2aa86cf246a49b"); // 5,050,000
+        // The best chain should have at least this much work. Zero for launch:
+        // this field is an IBD heuristic, and IsInitialBlockDownload() gates the
+        // work-serving RPCs (getblocktemplate exempts only stagenet/regtest;
+        // AuxMiningCheck exempts nothing), so any unreachable value here means a
+        // fresh mainnet can never serve mining work and never leaves height 0.
+        // The inherited upstream pin (chainwork at upstream block 5,050,000) did
+        // exactly that; found and driven 2026-08-29 (Phase A pre-launch audit,
+        // lane A1). Re-pin to real accumulated work in post-launch releases as
+        // part of the checkpoint-update routine (doc/release-process.md).
+        consensus.nMinimumChainWork = uint256S("0x00");
 
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x00");

--- a/src/test/genesis_chainparams_tests.cpp
+++ b/src/test/genesis_chainparams_tests.cpp
@@ -168,6 +168,35 @@ BOOST_AUTO_TEST_CASE(bip34_height_safety_testnet3)
     BOOST_CHECK_GT(consensus.BIP34Height, 16);
 }
 
+BOOST_AUTO_TEST_CASE(launch_ibd_thresholds_are_zero_on_every_network)
+{
+    // nMinimumChainWork is an IBD heuristic, and IsInitialBlockDownload()
+    // gates the work-serving RPCs (getblocktemplate exempts only
+    // stagenet/regtest; AuxMiningCheck exempts nothing). An unreachable
+    // value therefore latches every fresh node in IBD and no node can serve
+    // mining work: the chain never leaves height 0. Mainnet shipped exactly
+    // that (the upstream pin for upstream block 5,050,000) until the Phase A
+    // pre-launch audit drove it on 2026-08-29. Both fields stay 0x00 until a
+    // post-launch release re-pins them from a live Soqucoin mainnet node
+    // (doc/release-process.md).
+    const std::map<std::string, std::string> networks = {
+        {CBaseChainParams::MAIN, "main"},
+        {CBaseChainParams::TESTNET, "test"},
+        {CBaseChainParams::REGTEST, "regtest"},
+        {CBaseChainParams::STAGENET, "stagenet"},
+    };
+    for (const auto& net : networks) {
+        SelectParams(net.first);
+        const Consensus::Params& consensus = Params().GetConsensus(0);
+        BOOST_CHECK_MESSAGE(consensus.nMinimumChainWork == uint256S("0x00"),
+            net.second + ": nMinimumChainWork must be zero pre-launch, got " +
+            consensus.nMinimumChainWork.ToString());
+        BOOST_CHECK_MESSAGE(consensus.defaultAssumeValid == uint256S("0x00"),
+            net.second + ": defaultAssumeValid must be zero pre-launch, got " +
+            consensus.defaultAssumeValid.ToString());
+    }
+}
+
 // ============================================================================
 // BIP9 Deployment Sanity Tests
 //


### PR DESCRIPTION
## Tag-blocking Phase A audit finding (lane A1, bead mainnet-minchainwork-ibd-latch-cm0w)

Mainnet shipped the inherited upstream `nMinimumChainWork` pin (cumulative chainwork at upstream block 5,050,000, ~6.9e22 hashes). `IsInitialBlockDownload()` stays true until tip chainwork exceeds that value — unreachable for a fresh chain — and the IBD guards on `getblocktemplate` (exempts only stagenet/regtest) and `AuxMiningCheck` refuse to serve work during IBD. Net effect: a fresh mainnet could never leave height 0 through its designed mining path. Invisible to all prior sweeps because stagenet is both `0x00` and exempted.

## Fix
- Mainnet `nMinimumChainWork` → `0x00`, matching testnet/regtest/stagenet, with a comment explaining the launch posture and the post-launch re-pin routine.
- Unit test `launch_ibd_thresholds_are_zero_on_every_network` pins `nMinimumChainWork`/`defaultAssumeValid` == 0x00 on all four networks pre-launch.
- `doc/GENESIS_CEREMONY.md` step 4: verify both fields at the ceremony.
- `doc/release-process.md`: the mainnet value must come from a live Soqucoin mainnet node.

## Driven evidence
Before (audit): offline mainnet node → `initialblockdownload=True`, `getblocktemplate` → -10 "Soqucoin is downloading blocks...".
After (this branch): same probe → `initialblockdownload=False`, `getblocktemplate` serves a height-1 template with coinbasevalue 10000000000000 koinu (the 100,000 SOQ launch subsidy), zero peers, isolated datadir.

## Blast radius
IBD heuristic only — honest nodes cannot disagree over this field, and the consensus digest does not absorb it: `consensus_digest_tests` pins unchanged (suite-verified on this branch). `dormancy_matrix_tests`, `migration_rule_tests`, `genesis_chainparams_tests`, `soqucoin_tests` all green.