### PR TITLE
validation, amount, params: Phase A audit hygiene (digest-neutral)

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -70,11 +70,13 @@ static const CAmount MAX_MONEY = 20000000000 * COIN; // 20B SOQ, a per-TX ceilin
 //! The overflow bound argued for above, enforced rather than trusted: every
 //! accumulator in the validation path adds two in-range amounts before it calls
 //! MoneyRange, so twice MAX_MONEY has to remain representable.
-static_assert(MAX_MONEY > 0 && MAX_MONEY <= 2049638230412172714LL,
-              "MAX_MONEY must fit the CompressAmount codec (~9n+81 in a uint64, "
-              "see the comment above): amounts past ~20.49B coins silently "
-              "corrupt in the chainstate. Raising this bound means replacing "
-              "the amount codec first.");
+static_assert(MAX_MONEY > 0 && MAX_MONEY < 2049638230412172403LL,
+              "MAX_MONEY must fit the CompressAmount codec: 2049638230412172403 "
+              "koinu is the FIRST amount whose compress/decompress round-trip "
+              "corrupts (uint64 overflow in the codec; driven exhaustively near "
+              "the bound, 2026-08-29), so the bound is exclusive. Amounts past "
+              "it silently corrupt in the chainstate. Raising this bound means "
+              "replacing the amount codec first.");
 static_assert(MAX_MONEY <= 4611686018427387903LL,
               "MAX_MONEY must satisfy 2 * MAX_MONEY <= INT64_MAX: validation "
               "accumulators sum before they range-check, so a larger value makes "

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -123,7 +123,14 @@ struct Params {
     /** Soqucoin-specific parameters */
     bool fDigishieldDifficultyCalculation;
     bool fPowAllowDigishieldMinDifficultyBlocks; // Allow minimum difficulty blocks where a retarget would normally occur
-    bool fSimplifiedRewards;                     // Use block height derived rewards rather than previous block hash derived
+    bool fSimplifiedRewards = false;             // Use block height derived rewards rather than previous block hash derived.
+                                                 // Every live network sets true explicitly on the tiers it schedules; only
+                                                 // the testnet base tier (height 0 only, consensus-unreachable: genesis is
+                                                 // skipped) leaves it defaulted. The default is false DELIBERATELY: it is
+                                                 // the value zero-initialization has always produced, and the consensus
+                                                 // digest absorbs this field per tier — defaulting true would move the
+                                                 // digest for a hygiene change. Was an uninitialized read (UB for any
+                                                 // non-static instance) until 2026-08-29.
     int nInitialSubsidy = 100000;                // Epoch-0 block reward in whole SOQ; halved each nSubsidyHalvingInterval (GetSoqucoinBlockSubsidy). Mainnet/testnet/stagenet = 100000 (47B model, bead c61); regtest keeps 500000 as a test fixture.
 
     uint256 nMinimumChainWork;

--- a/src/test/serialization_invariance_tests.cpp
+++ b/src/test/serialization_invariance_tests.cpp
@@ -194,6 +194,23 @@ BOOST_AUTO_TEST_CASE(amount_compression_roundtrips_at_boundaries)
     }
 }
 
+// The codec's uint64 overflow boundary, pinned exactly. 2049638230412172403 is
+// the FIRST amount whose round-trip corrupts (verified exhaustively for 2M
+// values below it and by 200M random samples across [0, bound), 2026-08-29).
+// The amount.h static_assert keeps MAX_MONEY strictly below this value; if
+// this test ever moves, that assert's bound must move with it.
+BOOST_AUTO_TEST_CASE(amount_compression_overflow_boundary_is_pinned)
+{
+    const uint64_t kFirstCorrupt = 2049638230412172403ULL;
+    BOOST_CHECK_EQUAL(
+        CTxOutCompressor::DecompressAmount(CTxOutCompressor::CompressAmount(kFirstCorrupt - 1)),
+        kFirstCorrupt - 1);
+    BOOST_CHECK(
+        CTxOutCompressor::DecompressAmount(CTxOutCompressor::CompressAmount(kFirstCorrupt)) !=
+        kFirstCorrupt);
+    BOOST_CHECK_LT((uint64_t)MAX_MONEY, kFirstCorrupt);
+}
+
 // A spent output travels through the undo file in compressed form and must come
 // back identical, or a reorg restores a different UTXO than it removed.
 BOOST_AUTO_TEST_CASE(txundo_roundtrips_every_script_shape)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1265,8 +1265,13 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
 
         for (const auto& txin : tx.vin) {
             const CCoins* c = view.AccessCoins(txin.prevout.hash);
+            // IsAnyUSDSOQ(): must match the ConnectBlock freeze-spend guard,
+            // which was widened to v7 AND v10 so a frozen confidential outpoint
+            // is unspendable too. With IsUSDSOQ() (v7 only) here, a spend of a
+            // frozen v10 outpoint relayed and then rejected in-block — the
+            // accept-then-reject/template-poison class. Phase A audit, lane A3.
             if (c && c->IsAvailable(txin.prevout.n) &&
-                c->vout[txin.prevout.n].IsUSDSOQ() &&
+                c->vout[txin.prevout.n].IsAnyUSDSOQ() &&
                 pcoinsdbview && pcoinsdbview->IsFrozenOutpoint(txin.prevout)) {
                 return state.DoS(100, false, REJECT_INVALID,
                     "bad-txns-spend-frozen-usdsoq", false,
@@ -2696,16 +2701,12 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
                         const CTxOut& restoredOut = txundo.vprevout[j].txout;
                         // Must match the CONNECT-side predicate at the supply
                         // accounting loop, which counts IsAnyUSDSOQ() (v7 AND
-                        // v10). That widening was done under bead n1vf and
-                        // applied to the connect path only, leaving this mirror
-                        // v7-only. Currently masked — an authority tx spending a
-                        // confidential input is refused by
-                        // bad-txns-usdsoq-conf-input, so a v10 amount never
-                        // reaches the counter for this to miss — but "correct
-                        // via a different rule" is not correct by construction.
-                        // If SOQ-ARCH-004 is ever relaxed or reordered, a v10
-                        // burn would inflate total_burned permanently on reorg.
-                        // THE TWO PREDICATES MUST MOVE TOGETHER.
+                        // v10). Both sides use IsAnyUSDSOQ() (the n1vf widening
+                        // reached this mirror too; an earlier revision of this
+                        // comment claimed otherwise and was stale). If either
+                        // side ever changes, THE TWO PREDICATES MUST MOVE
+                        // TOGETHER, or a v10 burn would inflate total_burned
+                        // permanently on reorg.
                         if (restoredOut.IsAnyUSDSOQ()) {
                             nUSDSOQReversedBurn += restoredOut.nValue;
                         }


### PR DESCRIPTION
## Three Phase A audit findings, fixed digest-neutral

Every change here was chosen so that no consensus-digest-absorbed value moves: `consensus_digest_tests` re-verified at the pinned `43eb9d6b` on this branch, and the full unit suite is green (zero failures, one known skip).

### 1. Mempool freeze-spend guard: IsUSDSOQ → IsAnyUSDSOQ (weh5)
The ConnectBlock freeze-spend guard was widened to v7+v10 (frozen confidential outpoints unspendable); the mempool guard stayed v7-only, so a spend of a frozen v10 outpoint relayed and then rejected in-block — the accept-then-reject/template-poison class. Unreachable at launch (USDSOQ and SoquObscura unscheduled, empty authority keyset); fixed now so the predicates cannot drift further. Policy-side only. The stale disconnect-side comment describing the pre-widening asymmetry is rewritten to match the code.

### 2. fSimplifiedRewards default-initialized, deliberately to false (4c05)
The testnet base tier never set the field; static-storage zero-init made it a stable false — **which the consensus digest absorbs per tier** (`AbsorbConsensus`). Driven on this branch: defaulting it `true` moved the digest `43eb9d6b → 7c18a0cc` (the tripwire working as built). The landed default is `false` — the exact value zero-init has always produced — removing the uninitialized read while keeping every absorbed value bit-identical. The digest coupling is now documented at the declaration; flipping the base tier true in the future is possible but must budget a deliberate digest re-pin.

### 3. CompressAmount static_assert bound corrected (z6lv)
The old inclusive ceiling `2049638230412172714` itself fails the round-trip (compresses to 2805, decompresses to 3120000). New exclusive bound `2049638230412172403` = the FIRST corrupting amount, driven exhaustively for 2M values below it plus 200M random samples across the safe range; shipped MAX_MONEY keeps ~2.4% headroom. New unit test `amount_compression_overflow_boundary_is_pinned` keeps the assert and the codec from drifting apart. Compile-time only — zero codegen change.