### PR TITLE
chainparams: stagenet mirrors mainnet coinbase maturity from height 100,000

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1070,6 +1070,7 @@ class CStageNetParams : public CChainParams
 private:
     Consensus::Params digishieldConsensus;
     Consensus::Params auxpowConsensus;
+    Consensus::Params maturityMirrorConsensus;
 
 public:
     CStageNetParams()
@@ -1336,9 +1337,30 @@ public:
         auxpowConsensus.nHeightEffective = 100;
         auxpowConsensus.fAllowLegacyBlocks = true;
 
+        // Mainnet-maturity mirror from block 100,000 (ruled 2026-08-29, bead
+        // maturity-tier-doc-divergence-x48g): coinbases MINED at height >=
+        // 100000 mature at 240 like mainnet's post-genesis tiers, so the soak
+        // exercises launch maturity. HEIGHT-GATED, not retroactive: maturity is
+        // read from the tier at the COINBASE's height (CheckTxInputs), so every
+        // historical spend of a pre-gate coinbase stays valid and the stagenet
+        // history replay (differential validation) is unaffected.
+        // ⚠ OPERATIONAL CONSTRAINT: the FC4 fleet deploy must COMPLETE before
+        // stagenet reaches 100000 (~2026-09-25 at 1440 blocks/day from 61372 on
+        // 08-29). A pre-FC4 node spending a post-gate coinbase at depth < 240
+        // would bake history the FC4 binary rejects, forcing a stagenet reset.
+        // The consensus digest absorbs nCoinbaseMaturity per tier, so this
+        // change re-pins the digest deliberately (see the pin history in
+        // consensus_digest_tests.cpp).
+        maturityMirrorConsensus = auxpowConsensus;
+        maturityMirrorConsensus.nHeightEffective = 100000;
+        maturityMirrorConsensus.nCoinbaseMaturity = 240;
+        maturityMirrorConsensus.pLeft = NULL;
+        maturityMirrorConsensus.pRight = NULL;
+
         pConsensusRoot = &digishieldConsensus;
         digishieldConsensus.pLeft = &consensus;
         digishieldConsensus.pRight = &auxpowConsensus;
+        auxpowConsensus.pRight = &maturityMirrorConsensus;
 
         // Message start - unique for stagenet
         pchMessageStart[0] = 0x53; // 'S'

--- a/src/test/consensus_digest_tests.cpp
+++ b/src/test/consensus_digest_tests.cpp
@@ -551,8 +551,18 @@ BOOST_AUTO_TEST_CASE(consensus_digest_is_pinned)
     // the digest exactly like touching a genesis field, so they are absorbed
     // from the day they exist. The F4 sweep is re-run against the FC4 tag
     // (bead 71z6), which covers this move on the fleet toolchain.
+    //
+    // Moved from 43eb9d6b... on 2026-08-29 when stagenet gained the
+    // height-gated mainnet-maturity mirror tier (nCoinbaseMaturity 240 from
+    // height 100000, bead maturity-tier-doc-divergence-x48g). A RULE change
+    // on stagenet, made deliberately by ruling: the single absorbed input
+    // that moves is stagenet GetConsensus(1000000).nCoinbaseMaturity, 30 ->
+    // 240 (the other sampled heights are all below the gate). Mainnet,
+    // testnet and regtest inputs are untouched. The tag-day F4 sweep covers
+    // this pin on the fleet toolchain; the digest moves again at the genesis
+    // ceremony as designed.
     const std::string expected =
-        "43eb9d6bc5907f9d7ba13aba375c63ada6ef3d915f1941e6c754a35f971b5a24";
+        "449625478996b2b5003bfdf63a5700d7fd17b67b36daaa6a928e557a371b2de3";
 
     BOOST_CHECK_MESSAGE(digest.ToString() == expected,
         "consensus digest is " + digest.ToString() + ", expected " + expected +

--- a/src/test/genesis_chainparams_tests.cpp
+++ b/src/test/genesis_chainparams_tests.cpp
@@ -197,6 +197,28 @@ BOOST_AUTO_TEST_CASE(launch_ibd_thresholds_are_zero_on_every_network)
     }
 }
 
+// Stagenet mirrors mainnet's effective coinbase maturity (240) from height
+// 100,000, HEIGHT-GATED so historical spends of pre-gate coinbases stay valid
+// and the stagenet history replay is unaffected (ruled 2026-08-29, bead
+// maturity-tier-doc-divergence-x48g). Maturity is read from the tier at the
+// COINBASE's height, so the boundary below is about when a coinbase was MINED.
+BOOST_AUTO_TEST_CASE(stagenet_maturity_mirrors_mainnet_from_the_gate_height)
+{
+    SelectParams(CBaseChainParams::STAGENET);
+    BOOST_CHECK_EQUAL(Params().GetConsensus(0).nCoinbaseMaturity, 30);
+    BOOST_CHECK_EQUAL(Params().GetConsensus(1).nCoinbaseMaturity, 30);
+    BOOST_CHECK_EQUAL(Params().GetConsensus(100).nCoinbaseMaturity, 30);
+    BOOST_CHECK_EQUAL(Params().GetConsensus(99999).nCoinbaseMaturity, 30);
+    BOOST_CHECK_EQUAL(Params().GetConsensus(100000).nCoinbaseMaturity, 240);
+    BOOST_CHECK_EQUAL(Params().GetConsensus(100001).nCoinbaseMaturity, 240);
+    BOOST_CHECK_EQUAL(Params().GetConsensus(1000000).nCoinbaseMaturity, 240);
+
+    // The value being mirrored: mainnet's effective maturity from height 1.
+    SelectParams(CBaseChainParams::MAIN);
+    BOOST_CHECK_EQUAL(Params().GetConsensus(1).nCoinbaseMaturity, 240);
+    BOOST_CHECK_EQUAL(Params().GetConsensus(1000000).nCoinbaseMaturity, 240);
+}
+
 // ============================================================================
 // BIP9 Deployment Sanity Tests
 //


### PR DESCRIPTION
## Ruled 2026-08-29 (bead x48g follow-up)

Stagenet soaks with a flat 30-block maturity while mainnet's effective maturity is 240 from height 1 — the rehearsal network never exercised launch maturity or the pool's behavior under it.

## Shape: height-gated fourth tier, not retroactive
`maturityMirrorConsensus` (nHeightEffective **100,000**, nCoinbaseMaturity **240**) appended to stagenet's consensus-height BST. `CheckTxInputs` reads maturity from the tier at the **coinbase's** height, so:
- every historical spend of a pre-gate coinbase stays valid — the live chain and the diffval history replay are untouched;
- coinbases **mined** at ≥ 100,000 mature at 240, mirroring mainnet.

Retroactive 240 was rejected: historical pool payouts spent coinbases at depth 30–239 and would have invalidated the live stagenet chain.

## Digest re-pin (deliberate)
The digest absorbs `nCoinbaseMaturity` per tier: pin moved **43eb9d6b → 44962547**, with the single mover identified in the pin-history comment (stagenet `GetConsensus(1000000)` maturity; every other sampled height is below the gate). Mainnet/testnet/regtest inputs untouched. Tag-day F4 sweep covers the new pin; the ceremony moves it again as designed.

## Operational constraint
Fleet window must complete **before stagenet height 100,000** (~2026-09-25 at 1,440 blocks/day from 61,372 on 08-29) — recorded with a checkpoint-and-escalate line in the ops FC4 runbook (soqucoin-ops PR #67). Past the gate on the old binary, the pool would bake history the FC4 binary rejects → stagenet reset path.

## Evidence
- New unit test `stagenet_maturity_mirrors_mainnet_from_the_gate_height`: 30 at 0/1/100/99,999; 240 at 100,000/100,001/1,000,000; mainnet mirror value pinned.
- Full suite on this branch: **740 cases, 739 passed, 0 failed, 1 skipped** (known script_PushData).