### PR TITLE
consensus: make witness v2 (PAT) permanently unfundable

### DIFF
--- a/doc/DEPLOYMENT_PRECONDITIONS.md
+++ b/doc/DEPLOYMENT_PRECONDITIONS.md
@@ -52,6 +52,18 @@ feature that satisfies its own row and violates one of these is **not** ready.
    feature actually engages — for example that a newly created output of that
    type is no longer anyone-can-spend.
 
+   ⛔ **The first test written for any new output or script type is: create one,
+   fund it, mine it, and TRY TO STEAL IT.** Unit-testing a verifier proves what
+   it computes, never what it *authorizes*. This is not a style preference — it
+   is the control that failed. `DL-PAT-REMEDIATION.md` prescribed exactly this
+   test for witness v2 and it was never written, which is the direct reason a
+   fund-loss defect (bead `pat-v2-anyone-can-spend-ae6u`) survived a full L1
+   audit: every PAT test asserted the proof arithmetic, and none asserted that a
+   stranger could not spend the output. A verifier-only test suite is green in
+   precisely the case that loses the money. The test belongs in
+   `witness_version_reservation_tests.cpp`, must drive a real block through
+   `ConnectBlock`, and must be shown to fail against the pre-fix rule.
+
 6. **A rollback posture must be written down BEFORE the height is set.** A
    soft-fork cannot be cleanly un-activated without coordination.
 
@@ -78,8 +90,24 @@ P2WSH-Dilithium, v6) would never execute even once height-activated. Confirm the
 launch binary carries the `g7c` fix (`7117c22f9`).
 
 ### `DEPLOYMENT_CHECKPATAGG` (bit 3) — `ALWAYS_ACTIVE`
-PAT, the Practical **Attestation** Technique. Dilithium aggregation via
-`OP_CHECKPATAGG` and witness v2.
+PAT, the Practical **Attestation** Technique: Dilithium batch attestation via
+`OP_CHECKPATAGG`.
+
+⛔ **This deployment no longer means "witness v2 outputs are allowed."** Ruled
+2026-08-31: PAT's attestation is block metadata — a commitment in the coinbase,
+validated in `ConnectBlock` — and not an output type. **Witness v2 is
+permanently unfundable at consensus, unconditionally and not gated on this
+deployment** (`validation.cpp` `versionActive` case 2). Read the flag as "the
+PAT commitment rules are in force", never as a witness-version gate.
+
+The reason is recorded because it is counter-intuitive: the v2 spend path binds
+neither the witness program nor the sighash, and PAT by design verifies no
+signature — only the internal consistency of witness-supplied 32-byte tuples. So
+any v2 output that ever confirmed would be spendable by anybody. That is not a
+binding bug to fix: PAT stores 32-byte commitments, and a commitment cannot
+verify a signature, which is information-theoretic. Unfundability is therefore
+the control, and it must not be re-openable by flipping a deployment. Pinned by
+`pat_v2_unfundable_tests.cpp` and `witness_version_reservation_tests.cpp`.
 
 **This is the only Soqucoin-specific consensus cryptography live at launch, so it
 carries the launch risk the others defer.**

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -123,6 +123,7 @@ BITCOIN_TESTS =\
   test/miner_tests.cpp \
   test/net_tests.cpp \
   test/netbase_tests.cpp \
+  test/pat_v2_unfundable_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \

--- a/src/test/pat_v2_unfundable_tests.cpp
+++ b/src/test/pat_v2_unfundable_tests.cpp
@@ -1,0 +1,151 @@
+// Copyright (c) 2026 Soqucoin Labs Inc.
+// Distributed under the MIT software license.
+//
+// pat_v2_unfundable_tests.cpp — why witness v2 (PAT) must never be fundable.
+//
+// Bead pat-v2-anyone-can-spend-ae6u, found by the Phase B chain review 2026-08-31.
+//
+// THE DEFECT, as driven: DEPLOYMENT_CHECKPATAGG is ALWAYS_ACTIVE on every
+// network, so ConnectBlock's versionActive(2) returned true and a v2 output
+// could be created. Meanwhile the v2 spend path in interpreter.cpp binds
+// nothing an attacker does not control: it delegates to OP_CHECKPATAGG, which
+// by design verifies no signature — only the internal consistency of
+// attacker-supplied 32-byte tuples — and it references neither the 32-byte
+// witness program nor the sighash. A stranger could therefore mint a
+// self-consistent proof over values of their choosing and spend ANY v2 output.
+// VerifyScript printed ACCEPTED.
+//
+// ⛔ The unbound spend path is NOT a bug to fix. PAT stores 32-byte
+// commitments, not signatures, and VerifyLogarithmicProof structurally
+// requires 32-byte fields; a commitment cannot verify a signature. That is
+// information-theoretic, and the whitepaper never claimed otherwise
+// (§4.3/§5: signatures are verified natively under v0/v1, PAT attests over
+// them). So the remedy is not to bind the spend — it is to ensure there is
+// never anything to spend.
+//
+// THE REMEDY, ruled 2026-08-31: PAT's attestation is block metadata — a
+// commitment in the coinbase, validated in ConnectBlock — and not an output
+// type. Witness v2 is therefore PERMANENTLY unfundable at consensus,
+// unconditionally rather than gated on the deployment. OP_CHECKPATAGG stays in
+// the binary (audited, harmless) but is no longer load-bearing, which removes
+// the coupling that produced this defect.
+//
+// WHERE EACH HALF IS PINNED:
+//   - consensus, the control that protects funds — witness_version_reservation_tests
+//     v2_output_unfundable_even_though_checkpatagg_is_active (drives a real block)
+//   - relay, the second layer                    — PIN 2 below
+//   - the reason both are required               — PIN 1 below
+
+#include "crypto/pat/logarithmic.h"
+#include "policy/policy.h"
+#include "random.h"
+#include "script/interpreter.h"
+#include "script/script.h"
+#include "script/script_error.h"
+#include "script/standard.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+typedef std::vector<unsigned char> valtype;
+
+BOOST_FIXTURE_TEST_SUITE(pat_v2_unfundable_tests, BasicTestingSetup)
+
+static valtype RandHashVec()
+{
+    uint256 h;
+    GetRandBytes(h.begin(), 32);
+    return valtype(h.begin(), h.end());
+}
+
+//! The 34-byte witness form every Soqucoin version uses: OP_N <32 bytes>.
+static CScript V2Program(const valtype& program)
+{
+    CScript spk;
+    spk << OP_2 << program;
+    return spk;
+}
+
+// PIN 1 — the reason v2 must never be fundable.
+//
+// With SCRIPT_VERIFY_PAT set (as it is on every network, since the deployment
+// is ALWAYS_ACTIVE), a stranger spends a victim's v2 output using a proof over
+// values they chose freely. The attacker never learns the victim's program
+// preimage and never sees a private key.
+//
+// This test asserts the spend SUCCEEDS. It is a characterisation test, not an
+// approval: it records the unbound spend path as a standing fact, so that the
+// unfundability rule always has its justification attached. If someone ever
+// binds the program and the sighash AND verifies real signatures, this test
+// fails loudly and sends the fixer to the bead — at which point re-opening v2
+// as a spendable type becomes discussable. Until then, it is the argument.
+BOOST_AUTO_TEST_CASE(v2_spend_path_is_unbound_which_is_why_v2_must_be_unfundable)
+{
+    const valtype victimProgram = RandHashVec();  // attacker never learns the preimage
+    const CScript victimScriptPubKey = V2Program(victimProgram);
+    BOOST_REQUIRE_EQUAL(victimScriptPubKey.size(), 34U);
+
+    std::vector<valtype> sigs, pks, msgs;
+    sigs.push_back(RandHashVec());
+    pks.push_back(RandHashVec());
+    msgs.push_back(RandHashVec());
+
+    valtype proof_data;
+    BOOST_REQUIRE(pat::CreateLogarithmicProof(sigs, pks, msgs, proof_data));
+    pat::LogarithmicProof proof;
+    BOOST_REQUIRE(pat::ParseLogarithmicProof(proof_data, proof));
+
+    uint32_t n = 1;
+    valtype count_blob(4);
+    memcpy(count_blob.data(), &n, 4);
+
+    CScriptWitness witness;
+    witness.stack.push_back(sigs[0]);
+    witness.stack.push_back(pks[0]);
+    witness.stack.push_back(msgs[0]);
+    witness.stack.push_back(count_blob);
+    witness.stack.push_back(proof_data);
+    witness.stack.push_back(valtype(proof.pk_agg.begin(), proof.pk_agg.end()));
+    witness.stack.push_back(valtype(proof.msg_root.begin(), proof.msg_root.end()));
+
+    BaseSignatureChecker checker;
+    ScriptError serror = SCRIPT_ERR_OK;
+    const bool spent = VerifyScript(CScript(), victimScriptPubKey, &witness,
+                                    SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_PAT,
+                                    checker, &serror);
+
+    BOOST_CHECK_MESSAGE(spent,
+        "The v2 spend path now REJECTS a self-made proof over attacker-chosen values. "
+        "That is a behaviour change: if the proof is genuinely bound to the witness "
+        "program and the spending transaction AND real signatures are verified, "
+        "re-opening witness v2 as a fundable type becomes discussable. Read bead "
+        "pat-v2-anyone-can-spend-ae6u first — the consensus rule in ConnectBlock is "
+        "what actually protects funds, and this test is its justification.");
+}
+
+// PIN 2 — the relay layer must refuse the shape too.
+//
+// Consensus unfundability is the control; this is defence in depth. It is
+// pinned separately because the two layers reach the same verdict by different
+// routes, and the route matters: v2 is non-standard because Solver never names
+// the form, which happens BEFORE IsStandard consults the activation mask. That
+// is why the v2 bit in validation.cpp's activeWitnessVersions was dead, and why
+// removing it changed no behaviour — it only stopped policy from asserting
+// something consensus contradicts.
+//
+// The mask is passed here with EVERY version bit set, so a pass means "refused
+// regardless of activation state", not "refused because dormant".
+BOOST_AUTO_TEST_CASE(v2_output_is_never_relay_standard)
+{
+    const CScript spk = V2Program(RandHashVec());
+    txnouttype whichType;
+    const WitnessVersionMask allVersionsActive = ~WitnessVersionMask(0);
+
+    BOOST_CHECK_MESSAGE(!IsStandard(spk, whichType, /*witnessEnabled=*/true, allVersionsActive),
+        "a witness v2 output became relay-standard. Policy must not offer to propagate "
+        "a shape that ConnectBlock refuses to create — and if Solver has learned the v2 "
+        "form, that is a deliberate relay-policy change that has to be made together "
+        "with the consensus rule, not ahead of it (bead pat-v2-anyone-can-spend-ae6u).");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/witness_version_reservation_tests.cpp
+++ b/src/test/witness_version_reservation_tests.cpp
@@ -92,6 +92,35 @@ BOOST_AUTO_TEST_CASE(v6_output_accepted_once_p2wsh_dilithium_active)
         "dormancy rejection above proves nothing");
 }
 
+// ⛔ THE STEAL TEST for witness v2 (PAT). Bead pat-v2-anyone-can-spend-ae6u.
+//
+// Every other case in this file gates on a DORMANT deployment. v2 is the
+// opposite shape and that is the whole point: DEPLOYMENT_CHECKPATAGG is
+// ALWAYS_ACTIVE on every network, and until 2026-08-31 that made a v2 output
+// fundable — while the v2 spend path binds neither the witness program nor the
+// sighash, so a stranger could sweep any v2 output that confirmed (the spend
+// itself is driven in pat_v2_spend_poc_tests.cpp). Nothing could RELAY one,
+// because Solver never names the v2 form, so the exposure was the miner-
+// included path — which is exactly the path this rule exists to close.
+//
+// The rule is now unconditional rather than deployment-gated, because PAT's
+// attestation is a coinbase commitment and not an output type at all. This test
+// asserts the deployment is active first: if the rejection ever starts
+// depending on dormancy, the guarantee has silently weakened to the one that
+// already failed.
+BOOST_AUTO_TEST_CASE(v2_output_unfundable_even_though_checkpatagg_is_active)
+{
+    const int h = chainActive.Height() + 1;
+    const auto& dep = Params().GetConsensus(h).vDeployments[Consensus::DEPLOYMENT_CHECKPATAGG];
+    BOOST_REQUIRE_MESSAGE(dep.nStartTime == Consensus::BIP9Deployment::ALWAYS_ACTIVE,
+        "DEPLOYMENT_CHECKPATAGG is no longer ALWAYS_ACTIVE on regtest, so this test "
+        "would now be proving dormancy rather than unconditional unfundability. Read "
+        "bead pat-v2-anyone-can-spend-ae6u before changing it.");
+
+    CMutableTransaction tx = SpendTo(coinbaseTxns[14], Spk(OP_2));
+    BOOST_CHECK_EQUAL(RejectReasonFor({tx}), "bad-txns-witness-version-not-active");
+}
+
 // v3 (LatticeFold) is retired and never activates on ANY network, so a v3
 // output is permanently anyone-can-spend at the script layer. Consensus must
 // refuse to create one everywhere, not just on mainnet.

--- a/src/test/witness_version_reservation_tests.cpp
+++ b/src/test/witness_version_reservation_tests.cpp
@@ -99,9 +99,9 @@ BOOST_AUTO_TEST_CASE(v6_output_accepted_once_p2wsh_dilithium_active)
 // ALWAYS_ACTIVE on every network, and until 2026-08-31 that made a v2 output
 // fundable — while the v2 spend path binds neither the witness program nor the
 // sighash, so a stranger could sweep any v2 output that confirmed (the spend
-// itself is driven in pat_v2_unfundable_tests.cpp, PIN 1). Nothing could RELAY one,
-// because Solver never names the v2 form, so the exposure was the miner-
-// included path — which is exactly the path this rule exists to close.
+// itself is driven in pat_v2_unfundable_tests.cpp, PIN 1). Nothing could
+// RELAY one, because Solver never names the v2 form, so the exposure was the
+// miner-included path — which is exactly the path this rule exists to close.
 //
 // The rule is now unconditional rather than deployment-gated, because PAT's
 // attestation is a coinbase commitment and not an output type at all. This test

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -684,7 +684,16 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
             return VersionBitsState(chainActive.Tip(), cons, pos, versionbitscache) == THRESHOLD_ACTIVE;
         };
         // v0/v1 are the always-standard base forms and are handled by Solver.
-        if (bip9Active(Consensus::DEPLOYMENT_CHECKPATAGG))     activeWitnessVersions |= WitnessVersionBit(2);
+        // v2 (PAT) is deliberately absent and must stay absent: it is
+        // permanently unfundable at consensus (ConnectBlock's versionActive),
+        // because PAT's attestation is a coinbase commitment rather than an
+        // output type. Setting the bit from DEPLOYMENT_CHECKPATAGG would state
+        // the opposite of the consensus rule. It would also have no effect —
+        // Solver never names the v2 form, so IsStandard returns false before it
+        // reads this mask (witness_version_allocation_tests
+        // mask_bits_for_v2_v3_v4_cannot_affect_standardness) — and a dead bit
+        // that contradicts consensus is exactly the kind of disagreement this
+        // mask exists to prevent. Bead pat-v2-anyone-can-spend-ae6u.
         if (bip9Active(Consensus::DEPLOYMENT_LATTICEFOLD))     activeWitnessVersions |= WitnessVersionBit(3);
         if (heightActive(Consensus::DEPLOYMENT_SOQUOBSCURA))   activeWitnessVersions |= WitnessVersionBit(4);
         // USDSOQ governs both the v5 authority marker and the v7 holding form.
@@ -3745,24 +3754,45 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     //      patching each exemption (SOQ-I009 proper).
     //
     // So: an output may only use a witness version whose deployment is active
-    // in THIS block. v0/v1 are the always-available base Dilithium forms;
-    // v11-v16 are unallocated and can never be created until one is assigned a
-    // deployment. Policy already refuses to relay all of these
-    // (activeWitnessVersions, above), so this closes the miner-included path
-    // that policy cannot reach.
+    // in THIS block. v0/v1 are the always-available base Dilithium forms; v2 is
+    // permanently unfundable (see the case below); v11-v16 are unallocated and
+    // can never be created until one is assigned a deployment. Policy already
+    // refuses to relay all of these (activeWitnessVersions, above), so this
+    // closes the miner-included path that policy cannot reach.
     //
     // Blast radius: v5/v7/v8/v9 are dormant on mainnet ONLY, so those cannot
     // affect an existing chain. v3 (LatticeFold, retired) and v11-v16 are
     // dormant on every network — neither has ever been relay-standard anywhere,
     // so no honest wallet can have produced one, but this is the part of the
     // rule that wants a stagenet resync before fleet deploy.
+    // ⛔ v2 is the one version whose posture TIGHTENS here rather than merely
+    // being pinned: it was fundable on every network until 2026-08-31, because
+    // DEPLOYMENT_CHECKPATAGG is ALWAYS_ACTIVE. Nothing could relay one (Solver
+    // never named the form, so the v2 policy bit was dead), so only a directly
+    // mined output could exist — but stagenet must be checked for one before
+    // the fleet takes this rule, or a node running it will reject the chain.
     // v4/v10 are pre-empted by SOQ-ARCH-001 above and never reach this loop.
     // =========================================================================
     {
         auto versionActive = [&flags](int version) -> bool {
             switch (version) {
             case 0: case 1: return true;                                  // base Dilithium forms
-            case 2:  return (flags & SCRIPT_VERIFY_PAT) != 0;             // PAT aggregation
+            // v2 (PAT) is PERMANENTLY unfundable, and not gated on
+            // SCRIPT_VERIFY_PAT like the rest. PAT's attestation is block
+            // metadata — a commitment in the coinbase, validated here in
+            // ConnectBlock — not a UTXO, so there is no v2 output type to
+            // create and nothing that needs to be payable.
+            //
+            // This is a hard "no" rather than a dormancy gate because the v2
+            // spend path in interpreter.cpp binds NEITHER the witness program
+            // NOR the sighash: it delegates to OP_CHECKPATAGG, which by design
+            // verifies no signature, only the internal consistency of
+            // attacker-supplied 32-byte tuples. Anyone can mint a self-
+            // consistent proof, so any v2 output that ever confirmed would be
+            // spendable by anybody. Unfundability is therefore the control, and
+            // it must not be re-openable by flipping a deployment.
+            // Ruled 2026-08-31; bead pat-v2-anyone-can-spend-ae6u.
+            case 2:  return false;                                        // PAT attestation is not an output type
             case 3:  return (flags & SCRIPT_VERIFY_LATTICEFOLD) != 0;     // LatticeFold+ (retired)
             case 4:  return (flags & SCRIPT_VERIFY_SOQUOBSCURA) != 0;     // confidential SOQ
             case 5: case 7: return (flags & SCRIPT_VERIFY_USDSOQ) != 0;   // USDSOQ marker / holding


### PR DESCRIPTION
Closes the P0 from the Phase B chain review: witness v2 outputs were fundable while the v2 spend path authorizes anybody. Phase 2 of the PAT completion epic, following the 2026-08-31 ruling that the PAT attestation is carried as a coinbase commitment and witness v2 is made permanently unfundable.

## Defect

`DEPLOYMENT_CHECKPATAGG` is `ALWAYS_ACTIVE` on every network, so `ConnectBlock`'s `versionActive(2)` returned true and a block creating a v2 output connected. The v2 spend path binds neither the witness program nor the sighash: it delegates to `OP_CHECKPATAGG`, which by design verifies no signature, only the internal consistency of witness-supplied 32-byte tuples. Any v2 output that confirmed was therefore spendable by anyone.

One correction to the original finding: it reported v2 as fundable and relay-standard. Only the first half holds. `IsStandard` runs `Solver` before consulting the activation mask (`policy/policy.cpp:39`), and `Solver` does not name the v2 form, so v2 was never relay-standard and the v2 mask bit was dead (already pinned by `witness_version_allocation_tests.cpp:268`). Severity is unchanged; the delivery vector was direct mining rather than mempool propagation.

## Remedy

The unbound spend path is not a defect to repair. PAT stores 32-byte commitments, and a commitment cannot verify a signature; the whitepaper never claimed otherwise (signatures verify natively under v0/v1, PAT attests over them). The attestation is block metadata rather than an output type, so the remedy is that no v2 output can ever exist.

- `versionActive(2)` returns `false` unconditionally rather than reading `SCRIPT_VERIFY_PAT`, so unfundability cannot be reopened by flipping a deployment.
- The dead v2 bit is removed from the relay-side `activeWitnessVersions` mask, which previously asserted the opposite of the consensus rule.

## Tests

Per the standing rule this defect produced (create it, fund it, mine it, attempt the theft):

- `witness_version_reservation_tests` drives a real block creating a v2 output through `ConnectBlock` and requires `bad-txns-witness-version-not-active`. It first asserts the deployment is ACTIVE, so the rejection proves unconditional unfundability rather than dormancy. Shown load-bearing: against the pre-fix rule the reject reason is empty, meaning the block connects and the output is funded.
- `pat_v2_unfundable_tests` characterises the unbound spend path (the standing justification for the rule) and pins that v2 is never relay-standard even with every mask bit set.

`doc/DEPLOYMENT_PRECONDITIONS.md` rule 5 now requires this test class explicitly. It was prescribed in the remediation log for v2 and never written, which is the direct reason the defect survived a full L1 audit.

## Verification

- Consensus digest unmoved at `44962547`. The rule lives in `ConnectBlock` and policy, neither of which the digest absorbs, so no F4 re-sweep is owed for this change (correcting the completion plan's assumption that it would be).
- Full unit suite: 742 cases, 0 failures; case-count delta versus base is exactly the three cases added.

## Deploy gate

v2 was fundable until this change, so a node running this rule rejects any historical block containing a v2 output on a fresh sync. Mainnet is unaffected (genesis is re-mined at the ceremony). Stagenet has not been scanned (no `scantxoutset` in this codebase) and joins the existing stagenet-resync gate for v3 and v11–v16. Running nodes do not re-validate connected blocks, so this is a sync-time gate rather than a restart-time one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
