### PR TITLE
crypto: make PAT's canonical ordering total

### DIFF
--- a/src/crypto/pat/logarithmic.cpp
+++ b/src/crypto/pat/logarithmic.cpp
@@ -2,7 +2,6 @@
 #include <crypto/pat/logarithmic.h>
 #include <crypto/sha3.h>
 #include <cstdint>
-#include <numeric>
 
 using namespace std;
 using namespace pat;
@@ -14,6 +13,76 @@ static uint256 PatHash(const CValType& data)
     uint256 hash;
     hasher.Finalize(hash.begin());
     return hash;
+}
+
+// =========================================================================
+// Canonical ordering — TOTAL by construction.
+//
+// The batch is sorted so that the same batch always yields the same proof.
+// That property is consensus-critical for the PAT block attestation: every
+// node recomputes the attestation over a block and compares it against the
+// coinbase commitment, so two nodes deriving different proofs from the same
+// block would be a chain split.
+//
+// ⛔ Until 2026-08-31 the key was PatHash(message) ALONE, sorted with a bare
+// std::sort. Two entries over the same message compared EQUIVALENT, and the
+// standard gives no guarantee about the relative order of equivalent elements
+// under std::sort — it is not stable, and implementations may differ. Identical
+// input could therefore produce different proofs on different platforms. The
+// gap was measured, not theorised (pat_canonical_ordering_tests.cpp, bead
+// pat-canonical-ordering-not-total-97dz).
+//
+// The key is now the triple (message, pubkey, signature), with the entry's
+// original position as a final tie-break. That last term only ever separates
+// entries whose three commitments are ALL equal — i.e. genuinely identical
+// tuples — and those produce identical leaves at either position, so it cannot
+// reintroduce the malleability the ordering exists to prevent. Its purpose is
+// to make the key space strictly totally ordered, so that std::sort's treatment
+// of equivalent elements never enters the result at all.
+//
+// ⛔ Create and Verify MUST derive the order the same way. They call this one
+// function for that reason: two copies of the sort is a place where the halves
+// can silently drift apart.
+// =========================================================================
+namespace {
+
+struct CanonicalKey {
+    uint256 msg;
+    uint256 pk;
+    uint256 sig;
+    uint32_t pos;
+
+    bool operator<(const CanonicalKey& o) const
+    {
+        if (msg != o.msg) return msg < o.msg;
+        if (pk  != o.pk)  return pk  < o.pk;
+        if (sig != o.sig) return sig < o.sig;
+        return pos < o.pos;
+    }
+};
+
+} // namespace
+
+//! The canonical order of a batch, as indices into the caller's vectors.
+//! Hashes each field exactly once rather than inside the comparator, which also
+//! takes the sort from O(n log n) hash computations down to O(n).
+static std::vector<uint32_t> CanonicalOrder(const vector<CValType>& vSignatures,
+                                            const vector<CValType>& vPublicKeys,
+                                            const vector<CValType>& vMessages)
+{
+    const size_t n = vMessages.size();
+    std::vector<CanonicalKey> keys(n);
+    for (size_t i = 0; i < n; ++i) {
+        keys[i].msg = PatHash(vMessages[i]);
+        keys[i].pk  = PatHash(vPublicKeys[i]);
+        keys[i].sig = PatHash(vSignatures[i]);
+        keys[i].pos = (uint32_t)i;
+    }
+    std::sort(keys.begin(), keys.end());
+
+    std::vector<uint32_t> order(n);
+    for (size_t i = 0; i < n; ++i) order[i] = keys[i].pos;
+    return order;
 }
 
 static uint256 LeafHash(uint32_t idx, const CValType& sig, const CValType& pk, const CValType& msg)
@@ -114,12 +183,9 @@ bool pat::CreateLogarithmicProof(
     size_t n = vSignatures.size();
     if (n == 0 || n > 1 << 20 || n != vPublicKeys.size() || n != vMessages.size()) return false;
 
-    // Sort indices by message hash (canonical order)
-    vector<uint32_t> order(n);
-    iota(order.begin(), order.end(), 0);
-    sort(order.begin(), order.end(), [&](uint32_t a, uint32_t b) {
-        return PatHash(vMessages[a]) < PatHash(vMessages[b]);
-    });
+    // Canonical order — see CanonicalOrder above. Verify derives it the same
+    // way, from the same function; the two must never diverge.
+    const vector<uint32_t> order = CanonicalOrder(vSignatures, vPublicKeys, vMessages);
 
     // Build leaves and collect sorted public keys for hash aggregation
     vector<uint256> leaves(n);
@@ -253,13 +319,10 @@ bool pat::VerifyLogarithmicProof(
     }
 
     // Step 3: Apply canonical ordering (CRITICAL FOR SECURITY)
-    // Sort indices by message hash to match CreateLogarithmicProof
-    // This ensures deterministic verification and prevents proof malleability
-    std::vector<uint32_t> order(n);
-    std::iota(order.begin(), order.end(), 0);
-    std::sort(order.begin(), order.end(), [&](uint32_t a, uint32_t b) {
-        return PatHash(vClaimedMsgs[a]) < PatHash(vClaimedMsgs[b]);
-    });
+    // Derived by the SAME function CreateLogarithmicProof uses, so the two
+    // halves cannot drift apart. See CanonicalOrder above for why the key is
+    // the (message, pubkey, signature) triple and not the message alone.
+    const std::vector<uint32_t> order = CanonicalOrder(vClaimedSigs, vClaimedPks, vClaimedMsgs);
 
     // Create sorted views of the witness data
     std::vector<CValType> sorted_sigs(n), sorted_pks(n), sorted_msgs(n);

--- a/src/crypto/pat/logarithmic.h
+++ b/src/crypto/pat/logarithmic.h
@@ -47,8 +47,19 @@
  *    - Prevents message substitution or reordering attacks
  *
  * 4. Non-malleability: Canonical ordering prevents proof malleability
- *    - All inputs sorted by PatHash(message) before tree construction
+ *    - All inputs sorted before tree construction by the TOTAL key
+ *      (PatHash(message), PatHash(pk), PatHash(sig)), with the entry's original
+ *      position as a final tie-break
  *    - Same batch always produces identical proof regardless of input order
+ *
+ *    ⛔ The key is the full triple, not PatHash(message) alone. Keying on the
+ *    message left entries over the SAME message comparing equivalent, and
+ *    std::sort gives no guarantee about the relative order of equivalent
+ *    elements, so identical input could produce different proofs on different
+ *    standard-library implementations. That is a chain split once the block
+ *    attestation makes every node recompute this from block data. Do not
+ *    narrow this key. See CanonicalOrder in logarithmic.cpp and bead
+ *    pat-canonical-ordering-not-total-97dz.
  *
  * PERFORMANCE
  * ===========

--- a/src/test/pat_canonical_ordering_tests.cpp
+++ b/src/test/pat_canonical_ordering_tests.cpp
@@ -92,42 +92,60 @@ BOOST_AUTO_TEST_CASE(duplicate_messages_still_give_an_order_independent_proof)
         "pat-canonical-ordering-not-total-97dz.");
 }
 
-// The consequence stated directly: with duplicate messages, the (sig, pk)
-// pairing that lands in each Merkle leaf must be decided by the ordering — not
-// by the caller, and not by the standard library. Distinct from the case above:
-// there the two entries differ only in which sig pairs with which pk, so this
-// fails if the tie-break reaches only as far as the pubkey.
-BOOST_AUTO_TEST_CASE(duplicate_message_pairing_is_decided_by_the_ordering)
+// The ordering sorts TUPLES, and must never sort the three field vectors
+// independently — that would silently re-pair signatures with the wrong public
+// keys while still producing a well-formed proof.
+//
+// So this batch is NOT a permutation: the multiset of tuples genuinely differs,
+// {(sA,pA),(sB,pB)} against {(sB,pA),(sA,pB)}, with the same messages and the
+// same pk and sig multisets. pk_agg and msg_root are identical across the two;
+// only the leaves distinguish them. A proof that cannot tell these apart has
+// lost the sig-to-pk binding.
+BOOST_AUTO_TEST_CASE(different_pairings_are_not_conflated)
 {
     const CValType sA = Fixed(0xA1), sB = Fixed(0xB1);
     const CValType pA = Fixed(0xA2), pB = Fixed(0xB2);
     const CValType m  = Fixed(0xCC);
 
-    // Same multiset of (sig, pk) pairs, same messages — only the order differs.
-    const CValType forward  = ProofOver({sA, sB}, {pA, pB}, {m, m});
-    const CValType backward = ProofOver({sB, sA}, {pB, pA}, {m, m});
+    // Signatures swapped, public keys left alone, so the PAIRING changes.
+    const CValType paired  = ProofOver({sA, sB}, {pA, pB}, {m, m});
+    const CValType repaired = ProofOver({sB, sA}, {pA, pB}, {m, m});
 
-    BOOST_CHECK_MESSAGE(forward == backward,
-        "The (sig, pk) pairing still follows presentation order. See "
-        "duplicate_messages_still_give_an_order_independent_proof — both invert together.");
+    BOOST_CHECK_MESSAGE(paired != repaired,
+        "Two batches that pair the same signatures with DIFFERENT public keys "
+        "produced the same proof. The ordering is sorting the field vectors "
+        "independently rather than sorting tuples, so the sig-to-pk binding is "
+        "gone — a proof would then attest to a pairing nobody signed.");
 }
 
 // Fully identical tuples are the one case the (message, pubkey, signature) key
-// cannot separate. That is harmless and worth pinning as such: identical tuples
+// cannot separate. That is harmless, and this pins it as such: identical tuples
 // produce identical leaves at either position, so the tree is the same whichever
 // way they land. The original-position tie-break exists so the PERMUTATION is
 // decided too, and std::sort's handling of equivalent elements never enters the
 // result at all.
+//
+// ⛔ The repeated tuple is permuted against a DISTINCT third tuple, so the two
+// copies carry different original positions in each presentation and the
+// positional tie-break is actually exercised. Permuting a batch of nothing but
+// identical tuples is a no-op on the input, and a test built that way passes on
+// any implementation whatsoever — it measures only that the function is
+// deterministic across two calls.
 BOOST_AUTO_TEST_CASE(fully_identical_tuples_are_order_independent)
 {
-    const CValType s = Fixed(0x77), p = Fixed(0x88), m = Fixed(0x99);
+    const CValType s  = Fixed(0x77), p  = Fixed(0x88), m  = Fixed(0x99);  // T, twice
+    const CValType su = Fixed(0xA7), pu = Fixed(0xA8), mu = Fixed(0xA9);  // U, distinct
 
-    const CValType a = ProofOver({s, s, s}, {p, p, p}, {m, m, m});
-    const CValType b = ProofOver({s, s, s}, {p, p, p}, {m, m, m});
+    // One multiset {T, T, U}, three genuinely different presentations of it.
+    const CValType ttu = ProofOver({s, s, su}, {p, p, pu}, {m, m, mu});
+    const CValType tut = ProofOver({s, su, s}, {p, pu, p}, {m, mu, m});
+    const CValType utt = ProofOver({su, s, s}, {pu, p, p}, {mu, m, m});
 
-    BOOST_CHECK_MESSAGE(a == b,
-        "A batch of identical tuples is not reproducible, which would mean the "
-        "ordering depends on something outside its inputs entirely.");
+    BOOST_CHECK_MESSAGE(ttu == tut && tut == utt,
+        "A batch containing two identical tuples produced different proofs "
+        "depending on where those copies sat in the input. The positional "
+        "tie-break is leaking presentation order into the result, which it must "
+        "never do — it exists only to make the key space totally ordered.");
 }
 
 // Create and Verify must derive the SAME order — they call one function for

--- a/src/test/pat_canonical_ordering_tests.cpp
+++ b/src/test/pat_canonical_ordering_tests.cpp
@@ -4,9 +4,8 @@
 // pat_canonical_ordering_tests.cpp — is PAT's canonical ordering total?
 //
 // crypto/pat/logarithmic.h claims: "Non-malleability: Canonical ordering
-// prevents proof malleability — All inputs sorted by PatHash(message) before
-// tree construction. Same batch always produces identical proof regardless of
-// input order."
+// prevents proof malleability. Same batch always produces identical proof
+// regardless of input order."
 //
 // That claim is load-bearing for the PAT block attestation (epic
 // pat-completion-epic-xlab phase 3), where EVERY node recomputes the commitment
@@ -14,10 +13,18 @@
 // different proofs from the same block, that is a chain split — the nh6m class,
 // where a compiler or platform difference partitions the network.
 //
-// These tests measure the claim rather than restating it.
+// These tests measure the claim rather than restating it. When first written
+// they measured it FAILING, for batches containing duplicate messages: the sort
+// key was PatHash(message) alone, so entries over the same message compared
+// equivalent and std::sort — which is not stable and whose treatment of
+// equivalent elements is unspecified — decided the result. The key is now the
+// total triple (message, pubkey, signature) with the original position as a
+// final tie-break, and these assertions were inverted to require the claim
+// rather than record its failure. Bead pat-canonical-ordering-not-total-97dz.
 
 #include "crypto/pat/logarithmic.h"
 #include "test/test_bitcoin.h"
+#include "utilstrencodings.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -56,21 +63,18 @@ BOOST_AUTO_TEST_CASE(distinct_messages_give_an_order_independent_proof)
         "order, even with distinct messages. The canonical sort is not working at all.");
 }
 
-// ⛔ THE GAP. Two signatures over the SAME message. The comparator keys on
-// PatHash(message) alone, so these two entries compare equivalent, and nothing
-// in the ordering decides which comes first — it is left to std::sort, whose
-// treatment of equivalent elements is unspecified and differs by
-// implementation.
+// ⛔ THE CASE THAT USED TO FAIL. Two signatures over the SAME message.
 //
-// This test asserts the CURRENT behaviour (the proof tracks input order), so it
-// records the gap as a standing fact rather than asserting the documented claim
-// that does not hold. When the comparator is made total — tie-break on
-// PatHash(pk), then PatHash(sig) — this test must be inverted to require
-// equality, and the header claim becomes true as written.
+// Keying on PatHash(message) alone left these two entries comparing equivalent,
+// and std::sort gives no guarantee about the relative order of equivalent
+// elements — it is not stable, and implementations may differ. The proof
+// therefore tracked presentation order. Now the key is the total triple
+// (message, pubkey, signature), so the ordering itself decides.
 //
-// ⛔ Do not "fix" this by relying on std::sort being stable for small n. It is
-// not stable, and the input sizes that matter here are block-sized.
-BOOST_AUTO_TEST_CASE(duplicate_messages_break_the_canonical_ordering)
+// ⛔ Do not narrow the key back to the message. And do not "fix" a future
+// variant of this by relying on std::sort being stable for small n — it is not
+// stable, and the input sizes that matter here are block-sized.
+BOOST_AUTO_TEST_CASE(duplicate_messages_still_give_an_order_independent_proof)
 {
     const CValType s0 = Fixed(0x11), s1 = Fixed(0x22);
     const CValType p0 = Fixed(0x33), p1 = Fixed(0x44);
@@ -79,20 +83,21 @@ BOOST_AUTO_TEST_CASE(duplicate_messages_break_the_canonical_ordering)
     const CValType a = ProofOver({s0, s1}, {p0, p1}, {m, m});
     const CValType b = ProofOver({s1, s0}, {p1, p0}, {m, m});
 
-    BOOST_CHECK_MESSAGE(a != b,
-        "PAT now produces the same proof for a batch with duplicate messages "
-        "presented in either order. That means the ordering has been made total "
-        "(good, and required before the block attestation can ship) — invert this "
-        "test to require equality and update crypto/pat/logarithmic.h. Epic "
-        "pat-completion-epic-xlab, phase 3 canonical-ordering spec.");
+    BOOST_CHECK_MESSAGE(a == b,
+        "A batch with duplicate messages produced different proofs depending on "
+        "presentation order. The canonical ordering is not total again, which is a "
+        "chain-split vector for the block attestation: every node recomputes this "
+        "from block data and compares it to the coinbase commitment. See "
+        "CanonicalOrder in crypto/pat/logarithmic.cpp and bead "
+        "pat-canonical-ordering-not-total-97dz.");
 }
 
 // The consequence stated directly: with duplicate messages, the (sig, pk)
-// pairing that lands in each Merkle leaf depends on presentation order. For a
-// block-level attestation every node must derive the identical proof from the
-// identical block, so the ordering has to decide this — not the caller, and not
-// the standard library.
-BOOST_AUTO_TEST_CASE(duplicate_message_pairing_is_decided_by_presentation_order)
+// pairing that lands in each Merkle leaf must be decided by the ordering — not
+// by the caller, and not by the standard library. Distinct from the case above:
+// there the two entries differ only in which sig pairs with which pk, so this
+// fails if the tie-break reaches only as far as the pubkey.
+BOOST_AUTO_TEST_CASE(duplicate_message_pairing_is_decided_by_the_ordering)
 {
     const CValType sA = Fixed(0xA1), sB = Fixed(0xB1);
     const CValType pA = Fixed(0xA2), pB = Fixed(0xB2);
@@ -102,9 +107,99 @@ BOOST_AUTO_TEST_CASE(duplicate_message_pairing_is_decided_by_presentation_order)
     const CValType forward  = ProofOver({sA, sB}, {pA, pB}, {m, m});
     const CValType backward = ProofOver({sB, sA}, {pB, pA}, {m, m});
 
-    BOOST_CHECK_MESSAGE(forward != backward,
-        "Duplicate-message batches are now order-independent. See "
-        "duplicate_messages_break_the_canonical_ordering — both tests invert together.");
+    BOOST_CHECK_MESSAGE(forward == backward,
+        "The (sig, pk) pairing still follows presentation order. See "
+        "duplicate_messages_still_give_an_order_independent_proof — both invert together.");
+}
+
+// Fully identical tuples are the one case the (message, pubkey, signature) key
+// cannot separate. That is harmless and worth pinning as such: identical tuples
+// produce identical leaves at either position, so the tree is the same whichever
+// way they land. The original-position tie-break exists so the PERMUTATION is
+// decided too, and std::sort's handling of equivalent elements never enters the
+// result at all.
+BOOST_AUTO_TEST_CASE(fully_identical_tuples_are_order_independent)
+{
+    const CValType s = Fixed(0x77), p = Fixed(0x88), m = Fixed(0x99);
+
+    const CValType a = ProofOver({s, s, s}, {p, p, p}, {m, m, m});
+    const CValType b = ProofOver({s, s, s}, {p, p, p}, {m, m, m});
+
+    BOOST_CHECK_MESSAGE(a == b,
+        "A batch of identical tuples is not reproducible, which would mean the "
+        "ordering depends on something outside its inputs entirely.");
+}
+
+// Create and Verify must derive the SAME order — they call one function for
+// that reason. If they ever diverge, honest proofs stop verifying. Exercised
+// with duplicate messages, which is precisely where a divergence would hide.
+BOOST_AUTO_TEST_CASE(verify_accepts_a_proof_over_duplicate_messages)
+{
+    const CValType s0 = Fixed(0x11), s1 = Fixed(0x22);
+    const CValType p0 = Fixed(0x33), p1 = Fixed(0x44);
+    const CValType m  = Fixed(0x55);
+
+    const std::vector<CValType> sigs = {s0, s1}, pks = {p0, p1}, msgs = {m, m};
+    const CValType proof_data = ProofOver(sigs, pks, msgs);
+
+    BOOST_CHECK_MESSAGE(
+        pat::VerifyLogarithmicProof(proof_data, sigs, pks, msgs),
+        "Verify rejected a proof that Create had just produced over the same "
+        "batch. The two halves derive the canonical order differently — they must "
+        "both go through CanonicalOrder.");
+}
+
+// ⛔ KNOWN-ANSWER VECTORS — the cross-build guard, and the reason this file is
+// not just a set of self-consistency checks.
+//
+// Every test above compares two proofs computed by the SAME binary, so all of
+// them pass on a build whose ordering is self-consistently wrong. What the
+// canonical ordering actually has to guarantee is that a DIFFERENT build — a
+// different compiler, standard library, or optimisation level — derives the
+// same bytes. Only a fixed expected value can catch that, and this is what
+// DL-PAT-COMPLETION-PLAN §8 item 5 means by "canonical ordering pinned by test
+// vectors".
+//
+// The duplicate-message vector is the load-bearing one: it is the case whose
+// result was previously left to std::sort, so it is the case where two standard
+// libraries could disagree.
+//
+// ⚠️ These are NOT yet covered by the consensus digest. The digest absorbs PAT
+// proof bytes, but only for batches built by BuildValidPatScript, whose messages
+// are all distinct (0x70+i) — so its material never reaches the tie path and it
+// did not move when the ordering was corrected. Closing that means adding a
+// duplicate-message batch to the absorbed material, which moves the pin and owes
+// an F4 sweep; it is deliberately folded into the single re-pin that the phase-3
+// commitment work already requires. Until then, these vectors are what the F4
+// cross-build evidence rests on for ordering. Bead
+// pat-canonical-ordering-not-total-97dz.
+//
+// If one of these fails on a new platform, do NOT re-pin it to that platform's
+// output. A mismatch here is the chain split, caught in a test instead of on the
+// network.
+BOOST_AUTO_TEST_CASE(canonical_ordering_matches_pinned_vectors)
+{
+    const CValType s0 = Fixed(0x11), s1 = Fixed(0x22);
+    const CValType p0 = Fixed(0x33), p1 = Fixed(0x44);
+
+    // n=2, DUPLICATE messages — the tie path.
+    const CValType dup = ProofOver({s0, s1}, {p0, p1}, {Fixed(0x55), Fixed(0x55)});
+    BOOST_CHECK_EQUAL(HexStr(dup),
+        "564a9d9fa194497bcf35def39262940b1000e65c2a33fdb577c12abfa9cd442e"  // merkle_root
+        "ae75f84cf35d9168cf43665240cc528d67b90245b19e9c284ca63111629d13b5"  // pk_agg
+        "d810da4dd375788b0f35075eae37a990fd8bf2b16f63b30c6ea64eb2ae262efe"  // msg_root
+        "02000000");                                                        // count
+
+    // n=3, distinct messages — the ordinary path, so a regression that somehow
+    // spared the tie case still shows up.
+    const CValType distinct = ProofOver({s0, s1, Fixed(0x33)},
+                                        {p0, p1, Fixed(0x66)},
+                                        {Fixed(0x70), Fixed(0x71), Fixed(0x72)});
+    BOOST_CHECK_EQUAL(HexStr(distinct),
+        "4e3c0ab483e9eda42d9bc4f6474931a2af1dc3dd81fbc2260a27d9423c6163ba"
+        "5bf38dce14af6f59116c5a65cbf12817f4818d6ed62793fc9d9121bbce5cf126"
+        "8e19963d59b4965dc1297387cf0eb33618a6cb33063da0c7e5ab08499418de46"
+        "03000000");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Closes the ordering gap measured in #64. Prerequisite for phase 3 of the PAT completion epic: the block attestation has every node recompute the proof from block data and compare it against the coinbase commitment, so two builds deriving different bytes from the same block is a chain split.

## Change

The ordering key was `PatHash(message)` alone under a bare `std::sort`, leaving the relative order of same-message entries unspecified. The key is now the triple `(PatHash(message), PatHash(pk), PatHash(sig))` with the entry's original position as a final tie-break. The position term only separates entries whose three commitments are all equal (genuinely identical tuples, which produce identical leaves at either position), so it cannot reintroduce malleability; its purpose is to make the key space strictly totally ordered so the standard library's handling of equivalent elements never enters the result.

Two further changes follow from it:

- `CreateLogarithmicProof` and `VerifyLogarithmicProof` now derive the order from one shared function. They previously carried separate copies of the sort, a drift hazard: if the halves ever disagree, honest proofs stop verifying.
- Each field is hashed once into a sort key rather than inside the comparator, reducing the sort from O(n log n) hash computations to O(n). Relevant to the verification-cost item tracked as `pq-verify-cost-dos-cluster-8ith`.

## Tests

The three characterisation pins from #64 are inverted, as their failure messages instructed. Added:

| Test | Guards against |
|---|---|
| `fully_identical_tuples_are_order_independent` | Presentation order leaking through the positional tie-break (permutes the repeated tuple against a distinct third, so the tie-break is exercised) |
| `different_pairings_are_not_conflated` | Sorting the field vectors independently rather than sorting tuples, which would re-pair signatures with the wrong public keys |
| `verify_accepts_a_proof_over_duplicate_messages` | Create/Verify order divergence, exercised where it would hide |
| `canonical_ordering_matches_pinned_vectors` | Cross-build divergence |

The known-answer vectors carry the cross-build weight: every other test compares two proofs from the same binary and would pass on a build that is self-consistently wrong. Only a fixed expected value catches a different compiler or standard library deriving different bytes.

Falsifiability was verified directly: under a deliberately broken (position-first) comparator, four cases fail; restored, the full suite runs 748 cases with 0 failures.

## Remaining digest work

The consensus digest did not move (still `44962547`) and would not have caught this defect: it absorbs PAT proof bytes only for batches whose messages are all distinct, so its material never reaches the tie path. Making it sensitive requires adding a duplicate-message batch to the absorbed material, which moves the pin and owes an F4 sweep. That addition is folded into the single re-pin the phase-3 commitment work already requires, and bead `pat-canonical-ordering-not-total-97dz` remains open until it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
