### PR TITLE
doc: record the attestation rulings and one v6 audit-scope precondition

### DIFF
--- a/doc/DEPLOYMENT_PRECONDITIONS.md
+++ b/doc/DEPLOYMENT_PRECONDITIONS.md
@@ -205,6 +205,14 @@ Stablecoin authority opcodes, witness v5 (authority) and v7 (holdings).
    is compound-gated on USDSOQ **and** SOQUOBSCURA, and fails closed when both are
    active. Activating both without satisfying the SoquObscura row above turns a
    fail-closed reject into a live confidential path with no verifier.
+5. ☐ **This activation is also a PAT attestation change.** Under
+   `doc/PAT_BLOCK_ATTESTATION.md` §2 (Decision 1, ruled 2026-09-01), v7 holdings
+   join the attested set at this height: every node's recomputed block
+   attestation changes definition at the activation boundary, which is exactly
+   the divergence class the attestation specification exists to prevent. The
+   attested-set tests must pass with the deployment active and withdrawn, and
+   the fleet-coverage requirement of rule 2 applies to the attestation rule as
+   much as to the opcodes.
 
 ### `DEPLOYMENT_BTCSOQ` (bit 14)
 Bitcoin-backed consensus asset, witness v8 (holding) and v9 (authority).
@@ -218,6 +226,12 @@ Bitcoin-backed consensus asset, witness v8 (holding) and v9 (authority).
    field is 64-byte Ed25519-shaped, which cannot carry ML-DSA-44 (bead `23q1`).
    ⛔ This violates the standing rule: ML-DSA-44 only in the bridge signing path.
 4. ☐ Halborn Phase 2 clearance for the BTCSOQ layer.
+5. ☐ **This activation is also a PAT attestation change.** Under
+   `doc/PAT_BLOCK_ATTESTATION.md` §2 (Decision 1, ruled 2026-09-01), v8 holdings
+   join the attested set at this height. Same obligation as the corresponding
+   USDSOQ precondition: the attested-set tests must pass with the deployment
+   active and withdrawn, and full fleet coverage before the height applies to
+   the attestation rule as much as to the opcodes.
 
 ### `DEPLOYMENT_CTV` (bit 7), `DEPLOYMENT_APO` (bit 8), `DEPLOYMENT_CSFS` (bit 9)
 BIP 119 `OP_CHECKTEMPLATEVERIFY`, BIP 118 `SIGHASH_ANYPREVOUT`, BIP 348

--- a/doc/DEPLOYMENT_PRECONDITIONS.md
+++ b/doc/DEPLOYMENT_PRECONDITIONS.md
@@ -242,6 +242,19 @@ Witness v6: P2WSH with Dilithium. Covenant script execution and L2SOQ Lightning.
    before any adjacent version is allocated. A v6 collision with P2WSH-Dilithium
    was green in CI once already and forced a reallocation to v10. Never derive
    the free list from a document.
+3. ☐ **The audit scope must include every opcode reachable from `EvalScript`,
+   not only the covenant set.** A v6 witnessScript executes with the live flag
+   set, and `SCRIPT_VERIFY_PAT` is always on, so a witnessScript consisting of
+   `OP_CHECKPATAGG` verifies attacker-supplied self-consistent tuples and
+   succeeds: an anyone-can-spend contract. The funder chooses the script, so
+   this is self-inflicted in the same class as funding `OP_TRUE`, and it steals
+   from nobody. It is recorded here because the v6 activation review must
+   treat "which opcodes can a witnessScript reach, and what does each one
+   actually bind" as in scope; the PAT anyone-can-spend defect (bead
+   `pat-v2-anyone-can-spend-ae6u`) came from precisely this question going
+   unasked at a different dispatch site. Note that v6 witness data is also
+   outside the PAT block attestation (`doc/PAT_BLOCK_ATTESTATION.md` §2), so
+   these scripts stay unpruned regardless.
 
 ### `DEPLOYMENT_V6_CONTROLFLOW` (bit 13)
 `IF`/`CLTV`/`CSV`/`DROP`/`SHA256`/`EQUAL` inside v6 `EvalScript`, for the eLTOO

--- a/doc/PAT_BLOCK_ATTESTATION.md
+++ b/doc/PAT_BLOCK_ATTESTATION.md
@@ -1,8 +1,8 @@
 # PAT block attestation — consensus specification
 
-**Status:** SPECIFICATION, pre-implementation. Phase 3 of the PAT completion
-epic (`pat-completion-epic-xlab`). Nothing in this document is implemented;
-§10 lists the decisions required before implementation begins.
+**Status:** SPECIFICATION, ratified. Phase 3 of the PAT completion epic
+(`pat-completion-epic-xlab`). Both open decisions were ruled on 2026-09-01;
+§10 records the rulings. Implementation may begin against this document.
 
 **Purpose.** This document defines the rules a node follows to compute, commit,
 and verify the per-block PAT attestation. The attestation is recomputed
@@ -56,13 +56,16 @@ specification today and diverge from it at a future activation height.
 | v10 (confidential USDSOQ) | No. Same payload shape as v4; compound gate; fails closed if activated | No | Same basis as v4 |
 | v11–v16 | No spend can exist. Unallocated; unfundable under the reservation rule | No | Same basis as v2/v3 |
 
-### The rule, as specified
+### The rule, as ruled (Decision 1, 2026-09-01)
 
 A spend is attested if and only if it is a witness spend whose witness stack is
 exactly two items and whose verification is the single-key Dilithium path. At
-genesis that set is v0 and v1. Whether the set extends to v7 and v8 at their
-activation heights is Decision 1 (§10), and the tradeoffs are set out there
-rather than assumed here.
+genesis that set is v0 and v1. The set extends to v7 at the `USDSOQ` activation
+height and to v8 at the `BTCSOQ` activation height, from those heights forward.
+Consequently each of those activations is also an attestation change: the
+activation review must confirm full fleet coverage before the height, per
+`doc/DEPLOYMENT_PRECONDITIONS.md` rule 2, and must re-verify the attested-set
+tests with the deployment active and withdrawn.
 
 ### The authority-signature note (v5, v9)
 
@@ -122,7 +125,7 @@ prefix before hashing to compare against the witness program
 (`interpreter.cpp:1921`). Tracked as bead
 `dilithium-pubkey-encoding-duality-flpa`.
 
-**Specified (pending Decision 2):** `pk` commits to the stripped canonical
+**Ruled (Decision 2, 2026-09-01):** `pk` commits to the stripped canonical
 form, the same bytes that are SHA-256'd to produce the witness program.
 
 The precise consequence of each option, stated carefully because the difference
@@ -305,24 +308,23 @@ coverage.
 
 ---
 
-## 10. Decisions required before implementation
+## 10. Decisions — RULED 2026-09-01
 
-1. **The attested set (§2).** Either the set extends to v7/v8 at their
-   activation heights under the two-item single-key rule, or it is frozen at
-   v0/v1 permanently. The tradeoffs are: extension honours the "every
-   single-key Dilithium signature is committed" contract and keeps v7/v8
-   witnesses prunable, at the cost that every relevant future activation is
-   also an attestation change and must be reviewed as one; freezing makes the
-   attested set invariant for the life of the chain, at the cost that v7/v8
-   witnesses are never prunable and the design contract must be restated.
-   In both options the authority signatures (v5/v9) and v6 witnessScript
-   checks remain out of scope, per §2.
-2. **The public-key commitment (§3).** Canonical stripped form, or raw witness
-   bytes. Consequences are set out in §3; neither is a consensus-divergence
-   risk, and the difference is auditability and coupling to bead `flpa`.
+1. **The attested set (§2): the set extends.** Attestation covers every
+   two-item single-key Dilithium spend, so v7 joins at the `USDSOQ` activation
+   height and v8 at the `BTCSOQ` activation height. Basis for the ruling: the
+   extension honours the "every single-key Dilithium signature is committed"
+   contract and keeps v7/v8 witnesses prunable, and the added process cost is
+   one review item on an activation checklist that `DEPLOYMENT_PRECONDITIONS.md`
+   rule 2 already imposes. Authority signatures (v5/v9) and v6 witnessScript
+   checks remain out of scope, per §2, with their costs recorded there.
+2. **The public-key commitment (§3): the canonical stripped form.** Basis for
+   the ruling: both encodings of a key attest identically, third parties cannot
+   choose which encoding of an unconfirmed transaction's key is attested, and
+   the rule needs no amendment if bead `flpa` later rejects one encoding.
 
-The magic bytes (§6) are specified as `PA` rather than left open; there is no
-tradeoff to rule on, only a collision to avoid.
+The magic bytes (§6) are specified as `PA`; there was no tradeoff to rule on,
+only a collision to avoid.
 
 ---
 

--- a/doc/PAT_BLOCK_ATTESTATION.md
+++ b/doc/PAT_BLOCK_ATTESTATION.md
@@ -151,11 +151,18 @@ is easy to overstate:
 
 ### The sighash
 
-`msg` is the sighash for that input as computed by `SignatureHash` with
-`scriptCode` equal to the prevout `scriptPubKey` and `SIGVERSION_WITNESS_V0`:
-the same value `CheckSig` verified against. It must be taken from the
-verification that already happened rather than derived a second time. Two
-independent derivations of the same value is the drift hazard that
+`msg` is the sighash for that input, byte-identical to the value `CheckSig`
+verified against. Stated in implementable terms: `SignatureHash(scriptCode,
+tx, nIn, nHashType, amount, SIGVERSION_WITNESS_V0, txdata)`, where `scriptCode`
+is the prevout `scriptPubKey`, `nHashType` is the trailing byte of the witness
+signature (exactly as `TransactionSignatureChecker::CheckSig` extracts it), and
+`amount` is the prevout value.
+
+The collector MUST obtain this value through the same `SignatureHash` function
+and the same argument derivation that `CheckSig` uses, either by capturing the
+value at verification time or by invoking the identical code path with
+identical arguments. What is prohibited is an independent reimplementation of
+the derivation: two implementations of the same value is the drift hazard that
 `CreateLogarithmicProof` and `VerifyLogarithmicProof` carried until PR #65.
 
 APO sighash types (`DEPLOYMENT_APO`, dormant) change what a sighash covers.
@@ -211,6 +218,20 @@ OP_RETURN OP_PUSHBYTES_34 0x50 0x41 <32-byte attestation hash>
 36 bytes total; magic `PA` (`0x50 0x41`). This does not collide with
 LatticeFold's `LF` (`0x4C 0x46`), and the 36-byte length is distinct from
 SegWit's 38-byte `aa21a9ed` form.
+
+**The 32-byte attestation hash is defined as:**
+
+```
+attestation_hash = SHA3-256(0x02 || proof)
+```
+
+where `proof` is the complete 100-byte PAT proof (`merkle_root || pk_agg ||
+msg_root || count`) produced by `CreateLogarithmicProof` over the block's
+canonical batch. The `0x02` prefix is a domain separator, continuing the scheme
+already used inside the proof (`0x00` for leaf hashes, `0x01` for internal
+nodes, `logarithmic.cpp`), so an attestation hash can never be confused with a
+tree node. Committing the hash of the whole proof rather than `merkle_root`
+alone binds `pk_agg`, `msg_root`, and `count` in the commitment as well.
 
 **Exactly one.** A block carrying more than one output that parses as a PAT
 commitment is invalid. This differs deliberately from the LatticeFold

--- a/doc/PAT_BLOCK_ATTESTATION.md
+++ b/doc/PAT_BLOCK_ATTESTATION.md
@@ -50,8 +50,8 @@ specification today and diverge from it at a future activation height.
 | v4 (confidential SOQ) | No. Witness carries `[range_proof, pubkey_hash, commitment]`; there is no per-input Dilithium signature over a sighash | No | Wrong payload shape; also unfundable while `SOQUOBSCURA` is dormant, and fails closed if activated (no verifier ships) |
 | v5 (USDSOQ authority marker) | Not per-input. Authority transactions carry M-of-N ML-DSA signatures verified whole-transaction in `ConnectBlock`; they skip `VerifyScript` entirely | No — see the authority-signature note below | Not a per-input tuple; a different verification model |
 | v6 (P2WSH-Dilithium) | Sometimes. A witnessScript may perform zero, one, or many signature checks (`OP_CHECKSIGFROMSTACK`, `OP_CHECKDILITHIUMSIG` variants) at positions the block structure does not expose | No — see the v6 note below | No 1:1 spend-to-tuple mapping exists without re-executing scripts |
-| v7 (USDSOQ holding) | Yes, once `USDSOQ` activates. Falls through to the same single-key path as v1; witness is exactly `[sig, pubkey]` | **Decision 1** | Identical verification to v1; dormant at genesis |
-| v8 (BTCSOQ holding) | Yes, once `BTCSOQ` activates. Same fall-through | **Decision 1** | Identical verification to v1; dormant at genesis |
+| v7 (USDSOQ holding) | Yes, once `USDSOQ` activates. Falls through to the same single-key path as v1; witness is exactly `[sig, pubkey]` | **Yes, from the `USDSOQ` activation height** (Decision 1) | Identical verification to v1; dormant at genesis |
+| v8 (BTCSOQ holding) | Yes, once `BTCSOQ` activates. Same fall-through | **Yes, from the `BTCSOQ` activation height** (Decision 1) | Identical verification to v1; dormant at genesis |
 | v9 (BTCSOQ authority marker) | Not per-input. Same whole-transaction M-of-N model as v5 | No — see the authority-signature note below | Same basis as v5 |
 | v10 (confidential USDSOQ) | No. Same payload shape as v4; compound gate; fails closed if activated | No | Same basis as v4 |
 | v11–v16 | No spend can exist. Unallocated; unfundable under the reservation rule | No | Same basis as v2/v3 |
@@ -82,8 +82,10 @@ This exclusion is a deliberate scope decision, recorded with its costs:
   surface of §3 for negligible benefit.
 
 If the design contract "every Dilithium signature in a block is committed" is
-read to include authority signatures, that contract must be amended to match
-whatever Decision 1 rules, and the public documentation corrected with it
+read to include authority signatures, it overstates what is attested. The
+accurate statement of the ruled scope is: every single-key Dilithium spend
+signature is committed; authority M-of-N signatures and v6 witnessScript checks
+are not. The public documentation must state the contract in that form
 (tracked under `pat-public-claims-correction-pq03`).
 
 ### The v6 note

--- a/doc/PAT_BLOCK_ATTESTATION.md
+++ b/doc/PAT_BLOCK_ATTESTATION.md
@@ -268,10 +268,18 @@ The complete risk surface, collected for review as a single list:
 
 1. **Tie-breaking in the canonical ordering.** Closed by PR #65 and pinned by
    known-answer vectors. This was a measured defect, not a hypothetical.
-2. **The attested set changing under deployment activation** (§2). Open;
-   Decision 1.
-3. **Public-key encoding duality** (§3). Addressed by committing the canonical
-   stripped form, pending Decision 2; coupled to bead `flpa`.
+2. **The attested set changing under deployment activation** (§2). Ruled
+   (Decision 1): the set extends to v7 and v8 at their activation heights, so
+   the hazard is managed rather than removed. Each such activation is an
+   attestation change, and the activation review must re-verify the
+   attested-set tests with the deployment active and withdrawn. This
+   requirement is carried as a precondition on the `DEPLOYMENT_USDSOQ` and
+   `DEPLOYMENT_BTCSOQ` rows of `doc/DEPLOYMENT_PRECONDITIONS.md`.
+3. **Public-key encoding duality** (§3). Ruled (Decision 2): `pk` commits to
+   the canonical stripped form, so both accepted encodings of a key attest
+   identically. Coupled to bead `flpa`: if the duality is later closed by
+   rejecting one encoding, the rule stands unamended, but the coupling note in
+   §3 must be revisited.
 4. **Sighash provenance.** `msg` must come from the verification that happened,
    never from a second derivation.
 5. **APO sighash types.** Dormant. Activation changes what a sighash covers;


### PR DESCRIPTION
Records the two rulings that unblock implementation of the PAT block attestation, and adds one audit-scope precondition found during the post-merge review of the PAT arc (#63–#66).

## Rulings (2026-09-01)

**Decision 1 — the attested set extends.** Attestation covers every two-item single-key Dilithium spend: v0/v1 at genesis, v7 from the `USDSOQ` activation height, v8 from the `BTCSOQ` activation height. Each of those activations is therefore also an attestation change, and section 2 states the review requirement that follows. Basis: the extension honours the contract that every single-key Dilithium signature is committed and keeps v7/v8 witnesses prunable, and the added process cost is one item on an activation checklist the preconditions document already imposes.

**Decision 2 — canonical stripped public-key form.** The `pk` field commits to the same bytes hashed to produce the witness program. Both accepted encodings of a key attest identically, third parties cannot select which encoding of an unconfirmed transaction's key is attested, and the rule needs no amendment if the encoding duality (bead `flpa`) is later closed by rejecting one form.

The specification status moves from pre-implementation to ratified.

## Precondition added to `DEPLOYMENT_PRECONDITIONS.md`

The P2WSH-Dilithium (v6) row gains an audit-scope item. A v6 witnessScript executes under the live flag set, and `SCRIPT_VERIFY_PAT` is always active, so a witnessScript consisting of `OP_CHECKPATAGG` alone verifies attacker-supplied self-consistent tuples and succeeds: an anyone-can-spend contract. The funder chooses the script, so this is self-inflicted in the same class as funding `OP_TRUE` and steals from nobody. It is recorded because the v6 activation review must cover every opcode reachable from `EvalScript`, and the PAT anyone-can-spend defect arose from exactly that question going unasked at a different dispatch site.

## Verification behind this PR

Post-merge review of the consensus work in #63/#65 on current main:

- Full suite on the merge: 748 cases, 0 failures. Consensus digest unmoved at `44962547`.
- `uint256` comparison underlying the canonical ordering key is raw `memcmp`, platform-independent.
- No wallet, RPC, or miner code path constructs a v2 output.
- Non-34-byte v2-shaped programs are not caught by the reservation rule but fail closed on spend (`SCRIPT_ERR_DISALLOWED_CLASSICAL_CRYPTO`, funds burn rather than transfer); this is pre-existing behaviour common to all witness versions, not introduced by the PAT work.
- **Cross-platform known-answer confirmation, previously outstanding:** a standalone harness reproducing the canonical-ordering vectors was run on Linux x86_64, gcc 13.3, libstdc++, at `-O0/-O1/-O2/-O3/-Os`. All five binaries produce the pinned bytes, matching macOS clang/libc++. The ordering fix now has two-platform, six-build evidence rather than one build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
