### PR TITLE
consensus: PAT block attestation computation module

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -347,6 +347,8 @@ libsoqucoin_consensus_a_SOURCES = \
   consensus/params.h \
   consensus/block_accumulator.cpp \
   consensus/block_accumulator.h \
+  consensus/pat_attestation.cpp \
+  consensus/pat_attestation.h \
   consensus/usdsoq.cpp \
   consensus/usdsoq.h \
   consensus/btcsoq.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -123,6 +123,7 @@ BITCOIN_TESTS =\
   test/miner_tests.cpp \
   test/net_tests.cpp \
   test/netbase_tests.cpp \
+  test/pat_attestation_tests.cpp \
   test/pat_canonical_ordering_tests.cpp \
   test/pat_v2_unfundable_tests.cpp \
   test/pmt_tests.cpp \

--- a/src/consensus/pat_attestation.cpp
+++ b/src/consensus/pat_attestation.cpp
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Soqucoin Labs Inc.
+// Distributed under the MIT software license.
+//
+// PAT block attestation. Specification: doc/PAT_BLOCK_ATTESTATION.md.
+
+#include "consensus/pat_attestation.h"
+
+#include "crypto/pat/logarithmic.h"
+#include "crypto/sha3.h"
+#include "script/interpreter.h"
+
+namespace patattest {
+
+namespace {
+
+//! SHA3-256 of a byte range. The same hash the PAT proof uses internally
+//! (PatHash in logarithmic.cpp), reproduced here because that helper is
+//! file-static. The two must stay the same function: spec §3 commits tuple
+//! fields with the proof's own hash.
+uint256 Sha3(const unsigned char* data, size_t len)
+{
+    SHA3_256 hasher;
+    hasher.Write(data, len);
+    uint256 out;
+    hasher.Finalize(out.begin());
+    return out;
+}
+
+std::vector<unsigned char> Sha3Vec(const std::vector<unsigned char>& data)
+{
+    const uint256 h = Sha3(data.data(), data.size());
+    return std::vector<unsigned char>(h.begin(), h.end());
+}
+
+} // namespace
+
+int WitnessVersionOf(const CScript& scriptPubKey)
+{
+    if (scriptPubKey.size() != 34 || scriptPubKey[1] != 32) return -1;
+    if (scriptPubKey[0] == OP_0) return 0;
+    if (scriptPubKey[0] >= OP_1 && scriptPubKey[0] <= OP_16) {
+        return scriptPubKey[0] - (OP_1 - 1);
+    }
+    return -1;
+}
+
+bool IsAttestedVersion(int version, const AttestedSetParams& params)
+{
+    switch (version) {
+    case 0: case 1: return true;                  // base forms, active from genesis
+    case 7: return params.fUsdsoqActive;          // USDSOQ holding, joins at activation
+    case 8: return params.fBtcsoqActive;          // BTCSOQ holding, joins at activation
+    default: return false;                        // spec §2 disposition table
+    }
+}
+
+PatBatch CollectBatch(const CBlock& block,
+                      const std::function<bool(const COutPoint&, CTxOut&)>& prevoutLookup,
+                      const AttestedSetParams& params)
+{
+    PatBatch batch;
+
+    // Block order — transaction index, then input index — is the "original
+    // position" of spec §4. CreateLogarithmicProof applies the canonical
+    // ordering internally, using insertion order as the positional tie-break,
+    // so insertion order here IS the consensus definition. Do not reorder.
+    for (size_t txIdx = 1; txIdx < block.vtx.size(); ++txIdx) { // coinbase spends nothing
+        const CTransaction& tx = *block.vtx[txIdx];
+        const PrecomputedTransactionData txdata(tx);
+
+        for (size_t in = 0; in < tx.vin.size(); ++in) {
+            CTxOut prevout;
+            if (!prevoutLookup(tx.vin[in].prevout, prevout)) continue;
+
+            const int version = WitnessVersionOf(prevout.scriptPubKey);
+            if (version < 0 || !IsAttestedVersion(version, params)) continue;
+
+            // Spec §2: attested iff the witness stack is exactly two items
+            // (the single-key Dilithium shape, [sig, pubkey]).
+            const CScriptWitness& wit = tx.vin[in].scriptWitness;
+            if (wit.stack.size() != 2) continue;
+
+            const std::vector<unsigned char>& sig = wit.stack[0];
+            const std::vector<unsigned char>& pubkey = wit.stack[1];
+
+            // Spec §3: pk commits to the canonical stripped form — the same
+            // normalisation TransactionSignatureChecker::CheckSig and
+            // VerifyScript perform (Decision 2).
+            const unsigned char* pkData = pubkey.data();
+            size_t pkSize = pubkey.size();
+            if (pkSize == 1313 && pubkey[0] == 0x00) {
+                pkData += 1;
+                pkSize -= 1;
+            }
+
+            // Spec §3: msg is the sighash CheckSig verified against, obtained
+            // through the same SignatureHash function with the same argument
+            // derivation: nHashType from the trailing signature byte,
+            // scriptCode from the prevout, amount from the prevout value.
+            // An empty signature cannot verify, so the block is invalid
+            // regardless; nHashType = 0 keeps this function total.
+            const int nHashType = sig.empty() ? 0 : sig.back();
+            const uint256 sighash = SignatureHash(prevout.scriptPubKey, tx, in,
+                                                  nHashType, prevout.nValue,
+                                                  SIGVERSION_WITNESS_V0, &txdata);
+
+            const uint256 pkHash = Sha3(pkData, pkSize);
+            batch.sigs.push_back(Sha3Vec(sig));
+            batch.pks.push_back(std::vector<unsigned char>(pkHash.begin(), pkHash.end()));
+            batch.msgs.push_back(std::vector<unsigned char>(sighash.begin(), sighash.end()));
+        }
+    }
+
+    return batch;
+}
+
+uint256 AttestationHash(const std::vector<unsigned char>& proof)
+{
+    SHA3_256 hasher;
+    const unsigned char domain = 0x02; // spec §6: 0x00 leaf, 0x01 node, 0x02 attestation
+    hasher.Write(&domain, 1);
+    hasher.Write(proof.data(), proof.size());
+    uint256 out;
+    hasher.Finalize(out.begin());
+    return out;
+}
+
+bool ComputeBlockAttestation(const PatBatch& batch, uint256& hashOut)
+{
+    if (batch.empty()) return false; // spec §5: no attested spends, no attestation
+
+    std::vector<unsigned char> proof;
+    if (!pat::CreateLogarithmicProof(batch.sigs, batch.pks, batch.msgs, proof)) {
+        return false; // n > 2^20, unreachable under block limits but defined (spec §5)
+    }
+
+    hashOut = AttestationHash(proof);
+    return true;
+}
+
+CScript BuildCommitmentScript(const uint256& attestationHash)
+{
+    CScript script;
+    script.resize(36);
+    script[0] = OP_RETURN;
+    script[1] = 0x22; // OP_PUSHBYTES_34
+    script[2] = 0x50; // 'P'
+    script[3] = 0x41; // 'A'
+    memcpy(&script[4], attestationHash.begin(), 32);
+    return script;
+}
+
+bool ParseCommitmentScript(const CScript& script, uint256& hashOut)
+{
+    if (script.size() != 36) return false;
+    if (script[0] != OP_RETURN) return false;
+    if (script[1] != 0x22) return false;
+    if (script[2] != 0x50 || script[3] != 0x41) return false;
+    memcpy(hashOut.begin(), &script[4], 32);
+    return true;
+}
+
+int FindCommitments(const CTransaction& coinbase, uint256& hashOut)
+{
+    int found = 0;
+    for (const CTxOut& out : coinbase.vout) {
+        uint256 h;
+        if (ParseCommitmentScript(out.scriptPubKey, h)) {
+            if (found == 0) hashOut = h;
+            ++found;
+            // Deliberately no break: the count is what lets the caller
+            // enforce exactly-one (spec §6). Stopping at the first match is
+            // the LatticeFold validator behaviour the spec rejects.
+        }
+    }
+    return found;
+}
+
+} // namespace patattest

--- a/src/consensus/pat_attestation.h
+++ b/src/consensus/pat_attestation.h
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Soqucoin Labs Inc.
+// Distributed under the MIT software license.
+//
+// PAT block attestation (SOQ-P001, phase 3 of the PAT completion epic).
+//
+// Specification: doc/PAT_BLOCK_ATTESTATION.md. Every rule this module
+// implements is defined there; this header cites sections rather than
+// restating them. The attestation is recomputed independently by every node
+// and compared byte-for-byte against the miner's coinbase commitment, so
+// every function here must be a total, deterministic function of its inputs.
+//
+// This module is deliberately free of chain state. Callers (the miner's
+// commitment producer and ConnectBlock's validator) supply the prevout lookup
+// and the activation facts; the module never consults globals. That keeps the
+// computation testable in isolation and keeps both callers on one code path,
+// which is the property that prevents producer/validator drift.
+
+#ifndef BITCOIN_CONSENSUS_PAT_ATTESTATION_H
+#define BITCOIN_CONSENSUS_PAT_ATTESTATION_H
+
+#include "primitives/block.h"
+#include "script/script.h"
+#include "uint256.h"
+
+#include <functional>
+#include <vector>
+
+namespace patattest {
+
+//! Which fall-through witness versions are in the attested set at this block's
+//! height (spec §2, Decision 1: v7 joins at USDSOQ activation, v8 at BTCSOQ
+//! activation). The caller derives these from DeploymentActiveAtHeight; this
+//! module takes facts, not chain state.
+struct AttestedSetParams {
+    bool fUsdsoqActive = false;
+    bool fBtcsoqActive = false;
+};
+
+//! Witness version of the one canonical Soqucoin shape, OP_N <32 bytes>
+//! (34-byte scriptPubKey). Returns 0-16, or -1 for anything else. Matches the
+//! shape predicate used by ConnectBlock's reservation rule and VerifyScript's
+//! dispatch; those three must never diverge.
+int WitnessVersionOf(const CScript& scriptPubKey);
+
+//! The attested-set rule of spec §2: v0/v1 always; v7/v8 per params. Every
+//! other version is never attested, each for the reason recorded in the
+//! spec's disposition table.
+bool IsAttestedVersion(int version, const AttestedSetParams& params);
+
+//! One block's batch, as the three parallel vectors CreateLogarithmicProof
+//! takes. Entries are the 32-byte commitments of spec §3, in block order
+//! (transaction index, then input index — the "original position" that feeds
+//! the canonical ordering's final tie-break, spec §4).
+struct PatBatch {
+    std::vector<std::vector<unsigned char>> sigs;
+    std::vector<std::vector<unsigned char>> pks;
+    std::vector<std::vector<unsigned char>> msgs;
+
+    bool empty() const { return sigs.empty(); }
+    size_t size() const { return sigs.size(); }
+};
+
+//! Collect the attested tuples of a block (spec §2-§4). `prevoutLookup` must
+//! return the output being spent (from the UTXO view in ConnectBlock, or the
+//! block template's known prevouts in the miner) and return false when it
+//! cannot; an input whose prevout cannot be resolved contributes nothing,
+//! which is safe because such a block is invalid long before the attestation
+//! is compared.
+//!
+//! Total over block bytes: never fails, returns an empty batch for a block
+//! with no attested spends. A witness signature can be empty in a malformed
+//! block; the collector uses nHashType = 0 for it so the function stays total
+//! (the block is rejected by script verification regardless).
+PatBatch CollectBatch(const CBlock& block,
+                      const std::function<bool(const COutPoint&, CTxOut&)>& prevoutLookup,
+                      const AttestedSetParams& params);
+
+//! attestation_hash = SHA3-256(0x02 || proof), spec §6. The 0x02 prefix
+//! continues the domain-separation scheme inside the proof (0x00 leaves,
+//! 0x01 internal nodes), so an attestation hash can never collide with a
+//! tree node.
+uint256 AttestationHash(const std::vector<unsigned char>& proof);
+
+//! Compute the block attestation over a collected batch. Returns false for an
+//! empty batch: a block with no attested spends has no attestation, and MUST
+//! NOT carry a commitment (spec §5).
+bool ComputeBlockAttestation(const PatBatch& batch, uint256& hashOut);
+
+//! The 36-byte coinbase commitment script of spec §6:
+//! OP_RETURN OP_PUSHBYTES_34 0x50 0x41 <32-byte attestation hash>.
+CScript BuildCommitmentScript(const uint256& attestationHash);
+
+//! Parse one output script against the spec §6 shape. Strict: exactly 36
+//! bytes, exact opcodes, exact magic.
+bool ParseCommitmentScript(const CScript& script, uint256& hashOut);
+
+//! Scan a coinbase transaction for PAT commitments. Returns how many outputs
+//! parse as one and sets hashOut to the first. The exactly-one rule
+//! (bad-blk-pat-commitment-duplicate, spec §6) is enforced by the caller from
+//! the returned count; this deliberately does not stop at the first match,
+//! which is the LatticeFold validator behaviour the spec rejects.
+int FindCommitments(const CTransaction& coinbase, uint256& hashOut);
+
+} // namespace patattest
+
+#endif // BITCOIN_CONSENSUS_PAT_ATTESTATION_H

--- a/src/test/pat_attestation_tests.cpp
+++ b/src/test/pat_attestation_tests.cpp
@@ -1,0 +1,340 @@
+// Copyright (c) 2026 Soqucoin Labs Inc.
+// Distributed under the MIT software license.
+//
+// pat_attestation_tests.cpp — the PAT block attestation module against its
+// specification, doc/PAT_BLOCK_ATTESTATION.md. Section references below are to
+// that document. Each case names the input that would make it fail; a check
+// with no such input is documentation, not coverage.
+
+#include "consensus/pat_attestation.h"
+#include "crypto/pat/logarithmic.h"
+#include "crypto/sha3.h"
+#include "script/interpreter.h"
+#include "test/dilithium_chain_setup.h"
+
+#include <boost/test/unit_test.hpp>
+
+typedef std::vector<unsigned char> valtype;
+
+namespace {
+
+//! SHA3-256, matching the tuple-commitment hash of spec §3.
+valtype Sha3Of(const unsigned char* data, size_t len)
+{
+    SHA3_256 h;
+    h.Write(data, len);
+    uint256 out;
+    h.Finalize(out.begin());
+    return valtype(out.begin(), out.end());
+}
+
+valtype Sha3Of(const valtype& v) { return Sha3Of(v.data(), v.size()); }
+
+} // namespace
+
+struct PatAttestationSetup : public DilithiumChainSetup {
+    //! A block containing one transaction that spends `cb`'s output 0 to
+    //! `destSpk`, signed for real. The block is synthetic (never connected):
+    //! the collector is a pure function of block bytes plus the prevout
+    //! lookup, so nothing here needs a chain.
+    CBlock BlockSpending(const CTransaction& cb, const CScript& prevoutSpkOverride,
+                         CTxOut& prevoutOut)
+    {
+        // The prevout the lookup will report. Overriding its scriptPubKey lets
+        // a test present the same signed spend as a different witness version.
+        prevoutOut = cb.vout[0];
+        if (!prevoutSpkOverride.empty()) prevoutOut.scriptPubKey = prevoutSpkOverride;
+
+        CMutableTransaction tx;
+        tx.nVersion = 2;
+        CTxIn in;
+        in.prevout = COutPoint(cb.GetHash(), 0);
+        in.nSequence = CTxIn::SEQUENCE_FINAL;
+        tx.vin.push_back(in);
+        CTxOut out;
+        out.nValue = prevoutOut.nValue - 10000;
+        out.scriptPubKey = Spk(OP_1);
+        tx.vout.push_back(out);
+        SignInput(tx, 0, prevoutOut.scriptPubKey, prevoutOut.nValue);
+
+        CBlock block;
+        block.vtx.push_back(MakeTransactionRef(CTransaction(coinbaseTxns[0]))); // stand-in coinbase
+        block.vtx.push_back(MakeTransactionRef(CTransaction(tx)));
+        return block;
+    }
+
+    //! Lookup that resolves every input of the (single) spend to `prevout`.
+    static std::function<bool(const COutPoint&, CTxOut&)> LookupReturning(const CTxOut& prevout)
+    {
+        return [prevout](const COutPoint&, CTxOut& out) { out = prevout; return true; };
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(pat_attestation_tests, PatAttestationSetup)
+
+// --- §6: commitment script encoding -----------------------------------------
+
+// Fails if the builder or parser drifts from the 36-byte OP_RETURN + PA shape.
+BOOST_AUTO_TEST_CASE(commitment_script_round_trip)
+{
+    uint256 h;
+    GetRandBytes(h.begin(), 32);
+
+    const CScript script = patattest::BuildCommitmentScript(h);
+    BOOST_CHECK_EQUAL(script.size(), 36u);
+
+    uint256 parsed;
+    BOOST_REQUIRE(patattest::ParseCommitmentScript(script, parsed));
+    BOOST_CHECK(parsed == h);
+}
+
+// Fails if the parser loosens: every near-miss shape must be refused, because
+// anything that parses as a commitment is consensus-compared against the
+// recomputation.
+BOOST_AUTO_TEST_CASE(commitment_parser_rejects_near_misses)
+{
+    uint256 h, ignored;
+    GetRandBytes(h.begin(), 32);
+    const CScript good = patattest::BuildCommitmentScript(h);
+
+    // Wrong magic: the LatticeFold commitment ('LF') must not parse as PAT.
+    CScript lf = good;
+    lf[2] = 0x4C; lf[3] = 0x46;
+    BOOST_CHECK(!patattest::ParseCommitmentScript(lf, ignored));
+
+    // Truncated by one byte.
+    CScript shortScript(good.begin(), good.end() - 1);
+    BOOST_CHECK(!patattest::ParseCommitmentScript(shortScript, ignored));
+
+    // One byte appended (the SegWit commitment is 38 bytes; length must bind).
+    CScript longScript = good;
+    longScript.push_back(0x00);
+    BOOST_CHECK(!patattest::ParseCommitmentScript(longScript, ignored));
+
+    // Not an OP_RETURN.
+    CScript notOpReturn = good;
+    notOpReturn[0] = OP_NOP;
+    BOOST_CHECK(!patattest::ParseCommitmentScript(notOpReturn, ignored));
+}
+
+// Fails if FindCommitments regresses to first-match-and-stop — the LatticeFold
+// validator behaviour the spec rejects (§6), under which a miner could place a
+// decoy ahead of the real commitment and have the decoy be the one compared.
+BOOST_AUTO_TEST_CASE(find_commitments_counts_every_match)
+{
+    uint256 h1, h2;
+    GetRandBytes(h1.begin(), 32);
+    GetRandBytes(h2.begin(), 32);
+
+    CMutableTransaction cb;
+    cb.vout.resize(3);
+    cb.vout[0].scriptPubKey = Spk(OP_1);                            // ordinary payout
+    cb.vout[1].scriptPubKey = patattest::BuildCommitmentScript(h1); // the "decoy"
+    cb.vout[2].scriptPubKey = patattest::BuildCommitmentScript(h2); // the second
+
+    uint256 first;
+    BOOST_CHECK_EQUAL(patattest::FindCommitments(CTransaction(cb), first), 2);
+    BOOST_CHECK(first == h1);
+
+    cb.vout.resize(2); // exactly one commitment
+    BOOST_CHECK_EQUAL(patattest::FindCommitments(CTransaction(cb), first), 1);
+
+    cb.vout.resize(1); // none
+    BOOST_CHECK_EQUAL(patattest::FindCommitments(CTransaction(cb), first), 0);
+}
+
+// --- §2: the attested set ----------------------------------------------------
+
+// Fails if the version rule drifts from the spec's disposition table in either
+// direction: a version wrongly attested changes every affected block's
+// commitment; a version wrongly excluded breaks the Decision 1 extension.
+BOOST_AUTO_TEST_CASE(attested_set_matches_the_disposition_table)
+{
+    patattest::AttestedSetParams off;                 // genesis posture
+    patattest::AttestedSetParams on;                  // both deployments active
+    on.fUsdsoqActive = true;
+    on.fBtcsoqActive = true;
+
+    for (int v = -1; v <= 17; ++v) {
+        const bool baseForm = (v == 0 || v == 1);
+        BOOST_CHECK_MESSAGE(patattest::IsAttestedVersion(v, off) == baseForm,
+            "genesis attested set must be exactly {v0, v1}; disagreed at v" << v);
+
+        const bool extended = baseForm || v == 7 || v == 8;
+        BOOST_CHECK_MESSAGE(patattest::IsAttestedVersion(v, on) == extended,
+            "fully-activated attested set must be exactly {v0, v1, v7, v8}; "
+            "disagreed at v" << v);
+    }
+}
+
+// --- §2-§4: collection -------------------------------------------------------
+
+// Fails if the collector's tuple construction drifts from §3 in any argument:
+// the expected values are recomputed here from first principles (explicit
+// SignatureHash arguments, explicit SHA3 of the witness items), so a wrong
+// amount, scriptCode, input index, or hash-type byte shows up as a mismatch.
+BOOST_AUTO_TEST_CASE(collector_builds_the_specified_tuple_for_a_v1_spend)
+{
+    CTxOut prevout;
+    const CBlock block = BlockSpending(coinbaseTxns[0], CScript(), prevout);
+    const CTransaction& spend = *block.vtx[1];
+
+    patattest::PatBatch batch =
+        patattest::CollectBatch(block, LookupReturning(prevout), patattest::AttestedSetParams());
+
+    BOOST_REQUIRE_EQUAL(batch.size(), 1u);
+
+    const valtype& sig = spend.vin[0].scriptWitness.stack[0];
+    BOOST_CHECK(batch.sigs[0] == Sha3Of(sig));
+
+    // pk commits to the STRIPPED canonical form (Decision 2): the witness
+    // carries the 1313-byte prefixed key, the tuple must hash the 1312 bytes.
+    BOOST_CHECK(batch.pks[0] == Sha3Of(coinbasePkBytes));
+
+    const PrecomputedTransactionData txdata(spend);
+    const uint256 expectedSighash =
+        SignatureHash(prevout.scriptPubKey, spend, 0, sig.back(), prevout.nValue,
+                      SIGVERSION_WITNESS_V0, &txdata);
+    BOOST_CHECK(batch.msgs[0] == valtype(expectedSighash.begin(), expectedSighash.end()));
+}
+
+// The Decision 2 pin, end to end. Fails if the collector commits raw witness
+// bytes: the same key under its two accepted encodings would then produce two
+// different attestations for otherwise identical spends.
+BOOST_AUTO_TEST_CASE(both_pubkey_encodings_attest_identically)
+{
+    CTxOut prevout;
+    CBlock prefixed = BlockSpending(coinbaseTxns[1], CScript(), prevout);
+
+    // The same block with the witness key re-encoded to the bare 1312-byte
+    // form. Consensus treats the two as the same key; so must the attestation.
+    CBlock bare = prefixed;
+    CMutableTransaction tx(*bare.vtx[1]);
+    tx.vin[0].scriptWitness.stack[1] = coinbasePkBytes;
+    bare.vtx[1] = MakeTransactionRef(CTransaction(tx));
+
+    const patattest::AttestedSetParams params;
+    uint256 a, b;
+    BOOST_REQUIRE(patattest::ComputeBlockAttestation(
+        patattest::CollectBatch(prefixed, LookupReturning(prevout), params), a));
+    BOOST_REQUIRE(patattest::ComputeBlockAttestation(
+        patattest::CollectBatch(bare, LookupReturning(prevout), params), b));
+
+    BOOST_CHECK_MESSAGE(a == b,
+        "the two accepted encodings of the same key produced different "
+        "attestations. The collector is committing raw witness bytes instead "
+        "of the canonical stripped form (spec section 3, Decision 2).");
+}
+
+// The Decision 1 activation boundary. Fails in one direction if v7 spends are
+// attested at genesis posture (the set silently widened), and in the other if
+// activation does not extend the set (the ruling not implemented).
+BOOST_AUTO_TEST_CASE(v7_joins_the_attested_set_only_at_activation)
+{
+    CTxOut prevout;
+    const CBlock block = BlockSpending(coinbaseTxns[2], Spk(OP_7), prevout);
+
+    patattest::AttestedSetParams genesis;
+    BOOST_CHECK_EQUAL(
+        patattest::CollectBatch(block, LookupReturning(prevout), genesis).size(), 0u);
+
+    patattest::AttestedSetParams activated;
+    activated.fUsdsoqActive = true;
+    BOOST_CHECK_EQUAL(
+        patattest::CollectBatch(block, LookupReturning(prevout), activated).size(), 1u);
+}
+
+// Fails if the collector widens past the two-item single-key shape. A v6-style
+// multi-item witness has no defined tuple (spec §2), and a v1 spend with a
+// third witness item is not the single-key shape even though the version is
+// attested.
+BOOST_AUTO_TEST_CASE(collector_requires_the_exact_single_key_shape)
+{
+    CTxOut prevout;
+    CBlock block = BlockSpending(coinbaseTxns[3], CScript(), prevout);
+
+    CMutableTransaction tx(*block.vtx[1]);
+    tx.vin[0].scriptWitness.stack.push_back(valtype(1, 0x01)); // third item
+    block.vtx[1] = MakeTransactionRef(CTransaction(tx));
+
+    BOOST_CHECK_EQUAL(
+        patattest::CollectBatch(block, LookupReturning(prevout),
+                                patattest::AttestedSetParams()).size(), 0u);
+}
+
+// Fails if an excluded version leaks into the batch. The spend is signed and
+// two-item, so only the version rule excludes it — the discriminating input.
+BOOST_AUTO_TEST_CASE(excluded_versions_never_contribute)
+{
+    const opcodetype excluded[] = {OP_3, OP_4, OP_5, OP_6, OP_9, OP_10, OP_16};
+    patattest::AttestedSetParams everythingOn;
+    everythingOn.fUsdsoqActive = true;
+    everythingOn.fBtcsoqActive = true;
+
+    int idx = 4;
+    for (opcodetype v : excluded) {
+        CTxOut prevout;
+        const CBlock block = BlockSpending(coinbaseTxns[idx++], Spk(v), prevout);
+        BOOST_CHECK_MESSAGE(
+            patattest::CollectBatch(block, LookupReturning(prevout), everythingOn).empty(),
+            "witness version opcode " << (int)v << " contributed to the batch; "
+            "the spec section 2 disposition table excludes it");
+    }
+}
+
+// --- §5: empty batch ---------------------------------------------------------
+
+// Fails if an empty block acquires an attestation. Every coinbase-only block
+// on the chain exercises this rule.
+BOOST_AUTO_TEST_CASE(empty_batch_has_no_attestation)
+{
+    uint256 h;
+    BOOST_CHECK(!patattest::ComputeBlockAttestation(patattest::PatBatch(), h));
+}
+
+// --- §6: the attestation hash ------------------------------------------------
+
+// Fails if the 0x02 domain prefix is dropped or changed: the hash would then
+// collide with the proof's own leaf/node hash space or plain SHA3.
+BOOST_AUTO_TEST_CASE(attestation_hash_is_domain_separated)
+{
+    valtype proof(100, 0xAB);
+    const uint256 attested = patattest::AttestationHash(proof);
+
+    SHA3_256 plain;
+    plain.Write(proof.data(), proof.size());
+    uint256 plainHash;
+    plain.Finalize(plainHash.begin());
+    BOOST_CHECK(attested != plainHash);
+
+    for (unsigned char domain : {(unsigned char)0x00, (unsigned char)0x01}) {
+        SHA3_256 other;
+        other.Write(&domain, 1);
+        other.Write(proof.data(), proof.size());
+        uint256 otherHash;
+        other.Finalize(otherHash.begin());
+        BOOST_CHECK(attested != otherHash);
+    }
+}
+
+// Known-answer pin for the batch-to-hash pipeline (CreateLogarithmicProof over
+// a fixed batch, then the domain-separated hash). Fails on any cross-build or
+// cross-platform divergence in that pipeline — the same role the canonical
+// ordering vectors play one layer down. Do not re-pin to a new platform's
+// output; a mismatch here is the divergence, caught in a test.
+BOOST_AUTO_TEST_CASE(attestation_matches_pinned_vector)
+{
+    patattest::PatBatch batch;
+    for (unsigned char i = 0; i < 3; ++i) {
+        batch.sigs.push_back(valtype(32, (unsigned char)(0x10 + i)));
+        batch.pks.push_back(valtype(32, (unsigned char)(0x40 + i)));
+        batch.msgs.push_back(valtype(32, (unsigned char)(0x70 + i)));
+    }
+
+    uint256 h;
+    BOOST_REQUIRE(patattest::ComputeBlockAttestation(batch, h));
+    BOOST_CHECK_EQUAL(h.GetHex(),
+        "dcbd3730c01846a58a2d00b476ff9c056dc8a4224650232a805349d0fc4d86c0");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Phase 3 of the PAT completion epic, first of two stages: the pure attestation computation, exactly as `doc/PAT_BLOCK_ATTESTATION.md` defines it. Stage two wires it into the miner and `ConnectBlock`, adds the mandatory-height parameter, and performs the deliberate digest re-pin with its F4 sweep — kept separate so the re-pin is one reviewed event rather than a side effect.

**No consensus behaviour changes in this PR.** Nothing calls the module yet; the consensus digest is unmoved at `44962547`.

## Contents

| Specification section | Implementation |
|---|---|
| §2 attested set (Decision 1 as ruled) | `IsAttestedVersion`: v0/v1 always; v7/v8 by activation fact supplied by the caller |
| §3 tuple (Decision 2 as ruled) | `CollectBatch`: SHA3-256 of the signature, SHA3-256 of the canonical stripped pubkey, the sighash via the same `SignatureHash` arguments `CheckSig` uses |
| §4 block order | Collection in transaction-index, input-index order — the position that feeds the canonical ordering's tie-break |
| §5 empty batch | `ComputeBlockAttestation` returns false for an empty batch |
| §6 commitment encoding | 36-byte `OP_RETURN`/`PA` builder, strict parser, and a coinbase scanner that counts every match |

Two design properties worth review attention:

- **The module is free of chain state.** Callers supply the prevout lookup and activation facts, so the miner's producer and the validator run one code path. Producer/validator drift is the failure mode #65 closed one layer down.
- **`CollectBatch` is total over block bytes.** Unresolvable prevouts and malformed witnesses contribute nothing rather than failing; such blocks are rejected by script verification regardless, and a collector that can fail differently on different nodes is itself a divergence surface.

`FindCommitments` deliberately counts all matches rather than stopping at the first, so the validator can enforce the exactly-one rule; the LatticeFold validator's first-match behaviour is the recorded counterexample.

## Tests

Eleven cases, each written to a named failure input: encoding round-trip and near-miss rejection (including the LatticeFold magic), the full seventeen-version disposition table under both activation postures, tuple construction against independently recomputed expected values, the Decision 1 activation boundary, the Decision 2 encoding-independence pin, exclusion and shape rules, empty batch, domain separation, and a known-answer vector for the batch-to-hash pipeline.

## Verification

- Full suite: 760 cases, 0 failures. Digest unmoved.
- The known-answer vector was confirmed on macOS clang/libc++ and Linux gcc 13.3/libstdc++ at `-O0/-O2/-O3` via the standalone harness **before** pinning.
- Falsifiability probe: with the pubkey stripping deliberately disabled, exactly the two Decision 2 cases fail with their written messages; restored, all green. One implementation bug (a vector constructed from iterators into two distinct temporaries) was caught by the tests during development, which is the intended direction of that dependency.

## Note for stage 2

The empty-signature rule (`nHashType = 0` when the witness signature is empty, keeping the collector total) is currently stated in the module and header but not yet in the specification, because the spec file is being amended in #67. Stage 2 adds the one-line rule to §3 once #67 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
