### PR TITLE
consensus: wire the PAT block attestation — producer, validation, digest re-pin

### DIFF
--- a/doc/PAT_BLOCK_ATTESTATION.md
+++ b/doc/PAT_BLOCK_ATTESTATION.md
@@ -165,6 +165,12 @@ identical arguments. What is prohibited is an independent reimplementation of
 the derivation: two implementations of the same value is the drift hazard that
 `CreateLogarithmicProof` and `VerifyLogarithmicProof` carried until PR #65.
 
+A witness signature can be empty in a malformed block. The collector uses
+`nHashType = 0` for an empty signature so the computation stays total; such a
+block fails script verification regardless, so the value never reaches a
+connected chain, but a collector that could fail differently on different
+nodes would itself be a divergence surface.
+
 APO sighash types (`DEPLOYMENT_APO`, dormant) change what a sighash covers.
 Because `msg` is defined as whatever the input actually verified against, the
 attestation inherits an APO activation automatically; the APO activation review

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -115,6 +115,7 @@ testScripts = [
     'maxreorgdepth.py',
     'genesis-migration.py',
     'mining-gate.py',
+    'pat-commitment.py',
     'getauxblock.py',
     'wallet.py',
     'wallet-accounts.py',

--- a/qa/rpc-tests/pat-commitment.py
+++ b/qa/rpc-tests/pat-commitment.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Soqucoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# PAT block-attestation commitment, end to end through a real node
+# (doc/PAT_BLOCK_ATTESTATION.md; the reject-path matrix lives in
+# src/test/pat_commitment_rule_tests.cpp, driven through ConnectBlock with
+# named reject strings).
+#
+# This test covers what the unit suite cannot: the production miner emitting
+# the commitment for a block whose spends came through the real mempool, the
+# node accepting its own commitments across consecutive blocks, and the
+# empty-block rule holding on a live chain.
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+# OP_RETURN OP_PUSHBYTES_34 'P' 'A' <32-byte hash> = 36 bytes = 72 hex chars.
+PAT_PREFIX = "6a225041"
+PAT_HEXLEN = 72
+
+# Regtest coinbase maturity (60 * 4).
+MATURITY = 240
+
+
+class PatCommitmentTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self):
+        self.is_network_split = False
+        self.nodes = [start_node(0, self.options.tmpdir, ["-debug"])]
+
+    def pat_commitments_in_coinbase(self, height):
+        node = self.nodes[0]
+        block = node.getblock(node.getblockhash(height))
+        vout = node.getrawtransaction(block['tx'][0], 1)['vout']
+        return [out for out in vout
+                if out['scriptPubKey']['hex'].startswith(PAT_PREFIX)
+                and len(out['scriptPubKey']['hex']) == PAT_HEXLEN]
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # Mature one coinbase. Every one of these blocks is coinbase-only, so
+        # per the empty-batch rule none may carry a commitment.
+        node.generate(MATURITY + 1)
+        assert_equal(node.getblockcount(), MATURITY + 1)
+        for height in (1, MATURITY // 2, MATURITY + 1):
+            assert_equal(len(self.pat_commitments_in_coinbase(height)), 0)
+
+        # A real spend through the mempool: the next block carries exactly one
+        # attested tuple, so the miner must emit exactly one commitment, and
+        # the node must accept its own block (generate would fail otherwise).
+        node.sendtoaddress(node.getnewaddress(), 1)
+        node.generate(1)
+        spend_height = node.getblockcount()
+        assert_equal(len(self.pat_commitments_in_coinbase(spend_height)), 1)
+
+        # The rule is per-block, not sticky: the next empty block carries none.
+        node.generate(1)
+        assert_equal(len(self.pat_commitments_in_coinbase(spend_height + 1)), 0)
+
+        # Several spends in one block still mean ONE commitment (one batch per
+        # block), and the chain keeps extending normally past it.
+        for _ in range(3):
+            node.sendtoaddress(node.getnewaddress(), 1)
+        node.generate(1)
+        multi_height = node.getblockcount()
+        assert_equal(len(self.pat_commitments_in_coinbase(multi_height)), 1)
+        node.generate(2)
+        assert_equal(node.getblockcount(), multi_height + 2)
+
+        print("PAT commitment functional test passed")
+
+
+if __name__ == '__main__':
+    PatCommitmentTest().main()

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -125,6 +125,7 @@ BITCOIN_TESTS =\
   test/netbase_tests.cpp \
   test/pat_attestation_tests.cpp \
   test/pat_canonical_ordering_tests.cpp \
+  test/pat_commitment_rule_tests.cpp \
   test/pat_v2_unfundable_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1054,6 +1054,14 @@ public:
         auxpowConsensus.nMigrationHeight = nHeight;
         vMigrationOutputs = vOutputs;
     }
+
+    void UpdatePatCommitmentMandatoryHeight(int nHeight)
+    {
+        // Same height-indexed-tree caveat as the setters above (bead tofg).
+        consensus.nPatCommitmentMandatoryHeight = nHeight;
+        digishieldConsensus.nPatCommitmentMandatoryHeight = nHeight;
+        auxpowConsensus.nPatCommitmentMandatoryHeight = nHeight;
+    }
 };
 static CRegTestParams regTestParams;
 
@@ -1485,4 +1493,9 @@ void UpdateRegtestMigrationParams(const uint256& hashOutputs, CAmount nTotal, in
                                   const std::vector<CTxOut>& vOutputs)
 {
     regTestParams.UpdateMigrationParams(hashOutputs, nTotal, nHeight, vOutputs);
+}
+
+void UpdateRegtestPatCommitmentMandatoryHeight(int nHeight)
+{
+    regTestParams.UpdatePatCommitmentMandatoryHeight(nHeight);
 }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -170,4 +170,8 @@ void UpdateRegtestMaxReorgDepth(int nMaxReorgDepth);
 void UpdateRegtestMigrationParams(const uint256& hashOutputs, CAmount nTotal, int nHeight,
                                   const std::vector<CTxOut>& vOutputs);
 
+/** Test-only (regtest): set the PAT mandatory-commitment height
+ *  (doc/PAT_BLOCK_ATTESTATION.md §7). 0 restores the never-mandatory default. */
+void UpdateRegtestPatCommitmentMandatoryHeight(int nHeight);
+
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -216,8 +216,9 @@ struct Params {
 
     /** Genesis-migration one-shot allocation (DL-GENESIS-MIGRATION-IMPLEMENTATION §A).
      *  At exactly nHeight == nMigrationHeight (non-zero, hash set), the coinbase must
-     *  carry the committed allocation outputs as vout[1..N] (a trailing segwit
-     *  witness-commitment output is excluded from the committed range): their standard
+     *  carry the committed allocation outputs as vout[1..N] (trailing block-commitment
+     *  outputs — segwit witness, LatticeFold, PAT attestation — are excluded from the
+     *  committed range): their standard
      *  vector serialization must double-SHA256 to hashMigrationOutputs, their values
      *  must sum to exactly nMigrationTotal, and the permitted block reward becomes
      *  subsidy + fees + nMigrationTotal with vout[0] (the miner) still bounded by
@@ -229,6 +230,17 @@ struct Params {
     uint256 hashMigrationOutputs;   // null = inert
     CAmount nMigrationTotal = 0;    // exact sum of the committed outputs, in sats
     int nMigrationHeight = 0;       // 0 = inert; the one height the rule applies at
+
+    /** PAT block attestation — the mandatory-commitment height (doc/PAT_BLOCK_ATTESTATION.md §7).
+     *  The attestation itself is optional-but-verified from genesis: a miner MAY
+     *  emit the coinbase commitment, any node that sees one MUST verify it, and a
+     *  block without one is valid. From this height onward, a block that contains
+     *  attested spends and carries no commitment is invalid
+     *  (bad-blk-missing-pat-commitment). 0 = never mandatory, the launch posture
+     *  on every network; a real height is set only by a coordinated release under
+     *  doc/DEPLOYMENT_PRECONDITIONS.md rules 1-2. Same inert-by-default model as
+     *  the migration fields above. Absorbed by the consensus digest. */
+    int nPatCommitmentMandatoryHeight = 0;  // 0 = never mandatory
 };
 
 /**

--- a/src/consensus/pat_attestation.cpp
+++ b/src/consensus/pat_attestation.cpp
@@ -54,63 +54,70 @@ bool IsAttestedVersion(int version, const AttestedSetParams& params)
     }
 }
 
+void AppendTuples(PatBatch& batch, const CTransaction& tx,
+                  const std::function<bool(const COutPoint&, CTxOut&)>& prevoutLookup,
+                  const AttestedSetParams& params)
+{
+    if (tx.IsCoinBase()) return; // spends nothing
+
+    const PrecomputedTransactionData txdata(tx);
+
+    // Input order within the transaction is part of the "original position"
+    // of spec §4 (transaction index, then input index). CreateLogarithmicProof
+    // applies the canonical ordering internally, using insertion order as the
+    // positional tie-break, so insertion order here IS the consensus
+    // definition. Do not reorder.
+    for (size_t in = 0; in < tx.vin.size(); ++in) {
+        CTxOut prevout;
+        if (!prevoutLookup(tx.vin[in].prevout, prevout)) continue;
+
+        const int version = WitnessVersionOf(prevout.scriptPubKey);
+        if (version < 0 || !IsAttestedVersion(version, params)) continue;
+
+        // Spec §2: attested iff the witness stack is exactly two items
+        // (the single-key Dilithium shape, [sig, pubkey]).
+        const CScriptWitness& wit = tx.vin[in].scriptWitness;
+        if (wit.stack.size() != 2) continue;
+
+        const std::vector<unsigned char>& sig = wit.stack[0];
+        const std::vector<unsigned char>& pubkey = wit.stack[1];
+
+        // Spec §3: pk commits to the canonical stripped form — the same
+        // normalisation TransactionSignatureChecker::CheckSig and
+        // VerifyScript perform (Decision 2).
+        const unsigned char* pkData = pubkey.data();
+        size_t pkSize = pubkey.size();
+        if (pkSize == 1313 && pubkey[0] == 0x00) {
+            pkData += 1;
+            pkSize -= 1;
+        }
+
+        // Spec §3: msg is the sighash CheckSig verified against, obtained
+        // through the same SignatureHash function with the same argument
+        // derivation: nHashType from the trailing signature byte,
+        // scriptCode from the prevout, amount from the prevout value.
+        // An empty signature cannot verify, so the block is invalid
+        // regardless; nHashType = 0 keeps this function total.
+        const int nHashType = sig.empty() ? 0 : sig.back();
+        const uint256 sighash = SignatureHash(prevout.scriptPubKey, tx, in,
+                                              nHashType, prevout.nValue,
+                                              SIGVERSION_WITNESS_V0, &txdata);
+
+        const uint256 pkHash = Sha3(pkData, pkSize);
+        batch.sigs.push_back(Sha3Vec(sig));
+        batch.pks.push_back(std::vector<unsigned char>(pkHash.begin(), pkHash.end()));
+        batch.msgs.push_back(std::vector<unsigned char>(sighash.begin(), sighash.end()));
+    }
+}
+
 PatBatch CollectBatch(const CBlock& block,
                       const std::function<bool(const COutPoint&, CTxOut&)>& prevoutLookup,
                       const AttestedSetParams& params)
 {
     PatBatch batch;
-
-    // Block order — transaction index, then input index — is the "original
-    // position" of spec §4. CreateLogarithmicProof applies the canonical
-    // ordering internally, using insertion order as the positional tie-break,
-    // so insertion order here IS the consensus definition. Do not reorder.
-    for (size_t txIdx = 1; txIdx < block.vtx.size(); ++txIdx) { // coinbase spends nothing
-        const CTransaction& tx = *block.vtx[txIdx];
-        const PrecomputedTransactionData txdata(tx);
-
-        for (size_t in = 0; in < tx.vin.size(); ++in) {
-            CTxOut prevout;
-            if (!prevoutLookup(tx.vin[in].prevout, prevout)) continue;
-
-            const int version = WitnessVersionOf(prevout.scriptPubKey);
-            if (version < 0 || !IsAttestedVersion(version, params)) continue;
-
-            // Spec §2: attested iff the witness stack is exactly two items
-            // (the single-key Dilithium shape, [sig, pubkey]).
-            const CScriptWitness& wit = tx.vin[in].scriptWitness;
-            if (wit.stack.size() != 2) continue;
-
-            const std::vector<unsigned char>& sig = wit.stack[0];
-            const std::vector<unsigned char>& pubkey = wit.stack[1];
-
-            // Spec §3: pk commits to the canonical stripped form — the same
-            // normalisation TransactionSignatureChecker::CheckSig and
-            // VerifyScript perform (Decision 2).
-            const unsigned char* pkData = pubkey.data();
-            size_t pkSize = pubkey.size();
-            if (pkSize == 1313 && pubkey[0] == 0x00) {
-                pkData += 1;
-                pkSize -= 1;
-            }
-
-            // Spec §3: msg is the sighash CheckSig verified against, obtained
-            // through the same SignatureHash function with the same argument
-            // derivation: nHashType from the trailing signature byte,
-            // scriptCode from the prevout, amount from the prevout value.
-            // An empty signature cannot verify, so the block is invalid
-            // regardless; nHashType = 0 keeps this function total.
-            const int nHashType = sig.empty() ? 0 : sig.back();
-            const uint256 sighash = SignatureHash(prevout.scriptPubKey, tx, in,
-                                                  nHashType, prevout.nValue,
-                                                  SIGVERSION_WITNESS_V0, &txdata);
-
-            const uint256 pkHash = Sha3(pkData, pkSize);
-            batch.sigs.push_back(Sha3Vec(sig));
-            batch.pks.push_back(std::vector<unsigned char>(pkHash.begin(), pkHash.end()));
-            batch.msgs.push_back(std::vector<unsigned char>(sighash.begin(), sighash.end()));
-        }
+    for (size_t txIdx = 1; txIdx < block.vtx.size(); ++txIdx) {
+        AppendTuples(batch, *block.vtx[txIdx], prevoutLookup, params);
     }
-
     return batch;
 }
 

--- a/src/consensus/pat_attestation.h
+++ b/src/consensus/pat_attestation.h
@@ -60,17 +60,30 @@ struct PatBatch {
     size_t size() const { return sigs.size(); }
 };
 
-//! Collect the attested tuples of a block (spec §2-§4). `prevoutLookup` must
-//! return the output being spent (from the UTXO view in ConnectBlock, or the
-//! block template's known prevouts in the miner) and return false when it
-//! cannot; an input whose prevout cannot be resolved contributes nothing,
-//! which is safe because such a block is invalid long before the attestation
-//! is compared.
+//! Append one transaction's attested tuples to a batch, in input order
+//! (spec §2-§4). This is the collection primitive: ConnectBlock calls it per
+//! transaction inside its main loop, where the UTXO view still holds that
+//! transaction's prevouts, and CollectBatch below composes it over a whole
+//! block. Both consumers therefore run the identical tuple construction.
 //!
-//! Total over block bytes: never fails, returns an empty batch for a block
-//! with no attested spends. A witness signature can be empty in a malformed
-//! block; the collector uses nHashType = 0 for it so the function stays total
-//! (the block is rejected by script verification regardless).
+//! `prevoutLookup` must return the output being spent and return false when
+//! it cannot; an input whose prevout cannot be resolved contributes nothing,
+//! which is safe because such a block is invalid long before the attestation
+//! is compared. A coinbase transaction contributes nothing by definition.
+//!
+//! Total over transaction bytes: never fails. A witness signature can be
+//! empty in a malformed block; the collector uses nHashType = 0 for it so the
+//! computation stays total (the block is rejected by script verification
+//! regardless).
+void AppendTuples(PatBatch& batch, const CTransaction& tx,
+                  const std::function<bool(const COutPoint&, CTxOut&)>& prevoutLookup,
+                  const AttestedSetParams& params);
+
+//! Collect the attested tuples of a whole block: AppendTuples over every
+//! non-coinbase transaction, in block order. Used by the commitment producer
+//! and by tests; ConnectBlock collects incrementally with AppendTuples
+//! instead, because its view resolves each transaction's prevouts only while
+//! that transaction is being connected.
 PatBatch CollectBatch(const CBlock& block,
                       const std::function<bool(const COutPoint&, CTxOut&)>& prevoutLookup,
                       const AttestedSetParams& params);

--- a/src/test/consensus_digest_tests.cpp
+++ b/src/test/consensus_digest_tests.cpp
@@ -37,6 +37,7 @@
 #include "amount.h"
 #include "consensus/consensus.h"
 #include "consensus/params.h"
+#include "consensus/pat_attestation.h"
 #include "crypto/pat/logarithmic.h"
 #include "crypto/sha256.h"
 #include "primitives/block.h"
@@ -120,6 +121,11 @@ void AbsorbConsensus(DigestBuilder& d, const Consensus::Params& c)
     d.Hash(c.hashMigrationOutputs);
     d.I64(c.nMigrationTotal);
     d.I64(c.nMigrationHeight);
+
+    // PAT mandatory-commitment height (doc/PAT_BLOCK_ATTESTATION.md sec. 7).
+    // 0 = never mandatory on every network today; scheduling it is a consensus
+    // change and must move the digest.
+    d.I64(c.nPatCommitmentMandatoryHeight);
 
     // The derived privacy seed. THIS is the field whose class of defect F4 exists
     // for: it is computed at startup by HKDF over the genesis hash, so it is both
@@ -208,13 +214,21 @@ std::vector<unsigned char> FixedVec(size_t n, unsigned char seed)
 //! verifies no signatures by design; it proves an aggregation relation over the
 //! supplied material. Fixed vectors are therefore a faithful input, and the
 //! upstream PAT tests use random ones of exactly this shape.
-bool BuildValidPatScript(uint32_t n, CScript& out)
+//! fSharedMessage = true gives every entry the SAME message. That is the
+//! canonical-ordering tie path: with the message key equal, ordering falls to
+//! the pk/sig tie-breaks and the positional term (CanonicalOrder in
+//! crypto/pat/logarithmic.cpp). Absorbing this batch is what makes the digest
+//! sensitive to ordering at all — with distinct messages only, the digest was
+//! blind to the ordering defect PR #65 fixed (bead
+//! pat-canonical-ordering-not-total-97dz).
+bool BuildValidPatScript(uint32_t n, CScript& out, bool fSharedMessage = false)
 {
     std::vector<std::vector<unsigned char> > sigs, pks, msgs;
     for (uint32_t i = 0; i < n; ++i) {
         sigs.push_back(FixedVec(32, (unsigned char)(0x10 + i)));
         pks.push_back(FixedVec(32, (unsigned char)(0x40 + i)));
-        msgs.push_back(FixedVec(32, (unsigned char)(0x70 + i)));
+        msgs.push_back(FixedVec(32, fSharedMessage ? (unsigned char)0x70
+                                                   : (unsigned char)(0x70 + i)));
     }
 
     std::vector<unsigned char> proof_data;
@@ -270,6 +284,56 @@ bool BuildValidPatScript(uint32_t n, CScript& out)
 //!   * New ScriptError values go at the END of the enum. This function absorbs
 //!     the NUMERIC value, so inserting mid-enum renumbers every later error and
 //!     moves the digest for no behavioural reason.
+//! The PAT block-attestation pipeline (doc/PAT_BLOCK_ATTESTATION.md), absorbed
+//! end to end over fixed batches: CreateLogarithmicProof through the canonical
+//! ordering to the domain-separated attestation hash and the 36-byte coinbase
+//! commitment script. This is the value every node recomputes per block and
+//! compares byte-for-byte against the miner's commitment, so a cross-build
+//! difference anywhere in the pipeline is a chain split; absorbing it is what
+//! makes the F4 sweep evidence for the attestation, not just for the opcode.
+//! The duplicate-message batch is deliberate: it is the ordering tie path
+//! (bead pat-canonical-ordering-not-total-97dz).
+void AbsorbPatAttestation(DigestBuilder& d)
+{
+    struct BatchSpec {
+        uint32_t n;
+        bool fSharedMessage;
+    };
+    for (const BatchSpec& spec : {BatchSpec{3, false}, BatchSpec{2, true}}) {
+        patattest::PatBatch batch;
+        for (uint32_t i = 0; i < spec.n; ++i) {
+            batch.sigs.push_back(FixedVec(32, (unsigned char)(0x10 + i)));
+            batch.pks.push_back(FixedVec(32, (unsigned char)(0x40 + i)));
+            batch.msgs.push_back(FixedVec(32, spec.fSharedMessage
+                                                  ? (unsigned char)0x70
+                                                  : (unsigned char)(0x70 + i)));
+        }
+        d.I64(spec.n);
+        d.I64(spec.fSharedMessage ? 1 : 0);
+
+        uint256 attestation;
+        const bool ok = patattest::ComputeBlockAttestation(batch, attestation);
+        d.I64(ok ? 1 : 0);
+        if (!ok) continue;
+        d.Hash(attestation);
+
+        const CScript commitment = patattest::BuildCommitmentScript(attestation);
+        d.U64(commitment.size());
+        d.Bytes((const unsigned char*)commitment.data(), commitment.size());
+
+        // The parser must invert the builder; absorb that verdict too, so a
+        // codegen difference in either direction is visible.
+        uint256 parsed;
+        d.I64(patattest::ParseCommitmentScript(commitment, parsed) ? 1 : 0);
+        d.I64(parsed == attestation ? 1 : 0);
+    }
+
+    // The empty batch has NO attestation (spec sec. 5) — a rule every
+    // coinbase-only block exercises, absorbed as the verdict.
+    uint256 unused;
+    d.I64(patattest::ComputeBlockAttestation(patattest::PatBatch(), unused) ? 1 : 0);
+}
+
 void AbsorbOpcodeVerdicts(DigestBuilder& d)
 {
     BaseSignatureChecker checker;
@@ -305,6 +369,32 @@ void AbsorbOpcodeVerdicts(DigestBuilder& d)
                 if (!item.empty()) d.Bytes(item.data(), item.size());
             }
         }
+    }
+
+    // -- The canonical-ordering tie path: duplicate-message batches --
+    // Every batch above has distinct messages, so nothing above reaches the
+    // ordering's tie-breaks; the digest measured NOTHING about ordering until
+    // this section existed, and did not move when the ordering was corrected
+    // (PR #65). Absorbing the proof bytes of shared-message batches puts the
+    // tie path inside the digest, so the F4 cross-build sweep now covers the
+    // single highest-risk element of the PAT attestation: an ordering that
+    // differs by compiler or platform (bead pat-canonical-ordering-not-total-97dz).
+    for (uint32_t n : {uint32_t(2), uint32_t(3)}) {
+        CScript dupScript;
+        const bool built = BuildValidPatScript(n, dupScript, /*fSharedMessage=*/true);
+        d.I64(built ? 1 : 0);
+        d.I64(n);
+        if (!built) continue;
+
+        d.U64(dupScript.size());
+        d.Bytes((const unsigned char*)dupScript.data(), dupScript.size());
+
+        std::vector<std::vector<unsigned char> > stack;
+        ScriptError serr = SCRIPT_ERR_OK;
+        const bool ok = EvalScript(stack, dupScript, SCRIPT_VERIFY_PAT, checker,
+                                   SIGVERSION_BASE, &serr);
+        d.I64(ok ? 1 : 0);
+        d.I64((int64_t)serr);
     }
 
     // -- A tampered PAT proof must be rejected, and the REASON is absorbed --
@@ -484,6 +574,7 @@ uint256 ComputeConsensusDigest()
 
     AbsorbScriptVerdicts(d);
     AbsorbOpcodeVerdicts(d);
+    AbsorbPatAttestation(d);
 
     SelectParams(CBaseChainParams::MAIN);
     return d.Finalize();
@@ -561,8 +652,29 @@ BOOST_AUTO_TEST_CASE(consensus_digest_is_pinned)
     // testnet and regtest inputs are untouched. The tag-day F4 sweep covers
     // this pin on the fleet toolchain; the digest moves again at the genesis
     // ceremony as designed.
+    //
+    // Moved from 44962547... on 2026-09-01 with the PAT block-attestation
+    // wiring (doc/PAT_BLOCK_ATTESTATION.md §9, epic pat-completion-epic-xlab
+    // phase 3). A COVERAGE change plus one inert field, in the single
+    // deliberate re-pin the plan prescribed:
+    //   1. AbsorbConsensus gained nPatCommitmentMandatoryHeight (0 = never
+    //      mandatory on every network today; scheduling it must move the
+    //      digest).
+    //   2. AbsorbOpcodeVerdicts gained duplicate-message PAT batches — the
+    //      canonical-ordering TIE PATH. Until this, every absorbed batch had
+    //      distinct messages, so the digest measured nothing about ordering
+    //      and did not move when the ordering defect was fixed (PR #65, bead
+    //      pat-canonical-ordering-not-total-97dz). This closes that bead's
+    //      digest half: the F4 sweep now covers ordering.
+    //   3. AbsorbPatAttestation is new: the block-attestation pipeline end to
+    //      end (canonical batch -> proof -> domain-separated hash -> 36-byte
+    //      commitment script -> parser round-trip), over a distinct-message
+    //      and a duplicate-message batch, plus the empty-batch verdict.
+    // The rules themselves (producer, ConnectBlock enforcement) ship in the
+    // same commit; their reject paths are driven in pat_commitment_rule_tests.
+    // The sweep of record re-runs against the tag as always.
     const std::string expected =
-        "449625478996b2b5003bfdf63a5700d7fd17b67b36daaa6a928e557a371b2de3";
+        "c4029fd7baefc9718ec0ca8a1ae9e4830d82c2bd1e27d240cf34365975936730";
 
     BOOST_CHECK_MESSAGE(digest.ToString() == expected,
         "consensus digest is " + digest.ToString() + ", expected " + expected +

--- a/src/test/pat_commitment_rule_tests.cpp
+++ b/src/test/pat_commitment_rule_tests.cpp
@@ -1,0 +1,261 @@
+// Copyright (c) 2026 Soqucoin Labs Inc.
+// Distributed under the MIT software license.
+//
+// pat_commitment_rule_tests.cpp — the PAT block-attestation consensus rule
+// (doc/PAT_BLOCK_ATTESTATION.md §7), driven through real blocks.
+//
+// Every case here goes through ConnectBlock (via TestBlockValidity, fJustCheck)
+// and pins its verdict by NAMED reject string, the same discipline as
+// migration_rule_tests. The blocks come from the production miner path
+// (BuildSolvedBlock -> CreateNewBlock -> GenerateCoinbaseCommitment), so the
+// honest case exercises the real producer and the real validator against each
+// other — the pair whose drift is the failure mode.
+//
+// Regtest posture: USDSOQ and BTCSOQ are active from height 0, so the attested
+// set here is the fully-extended one. The activation BOUNDARY (v7 joining the
+// set) is pinned at module level in pat_attestation_tests; these tests pin the
+// block-level rule.
+
+#include "chainparams.h"
+#include "consensus/pat_attestation.h"
+#include "consensus/validation.h"
+#include "random.h"
+#include "test/dilithium_chain_setup.h"
+#include "validation.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+//! Arm the PAT mandatory-commitment height for the duration of a scope, and
+//! always restore the never-mandatory default (0).
+struct ScopedPatMandatoryHeight {
+    explicit ScopedPatMandatoryHeight(int nHeight)
+    {
+        UpdateRegtestPatCommitmentMandatoryHeight(nHeight);
+        SelectParams(CBaseChainParams::REGTEST);
+    }
+    ~ScopedPatMandatoryHeight()
+    {
+        UpdateRegtestPatCommitmentMandatoryHeight(0);
+        SelectParams(CBaseChainParams::REGTEST);
+    }
+};
+
+} // namespace
+
+struct PatCommitmentChainSetup : public DilithiumChainSetup {
+    //! A correctly-signed v1 spend of `cb`'s output 0. Its inclusion makes a
+    //! block carry exactly one attested tuple.
+    CMutableTransaction SpendTo(const CTransaction& cb)
+    {
+        const CAmount inVal = cb.vout[0].nValue;
+        CMutableTransaction tx;
+        tx.nVersion = 2;
+        CTxIn in;
+        in.prevout = COutPoint(cb.GetHash(), 0);
+        in.nSequence = CTxIn::SEQUENCE_FINAL;
+        tx.vin.push_back(in);
+        CTxOut out;
+        out.nValue = inVal - 10000;
+        out.scriptPubKey = Spk(OP_1);
+        tx.vout.push_back(out);
+        SignInput(tx, 0, coinbaseSpk, inVal);
+        return tx;
+    }
+
+    //! ConnectBlock (fJustCheck) verdict by reject string; "" = validated.
+    //! PoW and merkle are skipped so tampered coinbases can be driven straight
+    //! at the rule.
+    std::string RejectReasonFor(const CBlock& block)
+    {
+        CValidationState st;
+        LOCK(cs_main);
+        if (TestBlockValidity(st, Params(), block, chainActive.Tip(), false, false))
+            return std::string();
+        return st.GetRejectReason();
+    }
+
+    //! Index of the (first) PAT commitment output in the coinbase, or -1.
+    static int PatCommitmentIndex(const CBlock& block)
+    {
+        const CTransaction& cb = *block.vtx[0];
+        for (size_t o = 0; o < cb.vout.size(); ++o) {
+            uint256 ignored;
+            if (patattest::ParseCommitmentScript(cb.vout[o].scriptPubKey, ignored))
+                return (int)o;
+        }
+        return -1;
+    }
+
+    //! Return the block with its coinbase vout vector replaced.
+    static CBlock WithCoinbaseVout(const CBlock& block, const std::vector<CTxOut>& vout)
+    {
+        CBlock modified = block;
+        CMutableTransaction cbMut(*modified.vtx[0]);
+        cbMut.vout = vout;
+        modified.vtx[0] = MakeTransactionRef(std::move(cbMut));
+        return modified;
+    }
+
+    static CTxOut CommitmentOut(const uint256& hash)
+    {
+        CTxOut out;
+        out.nValue = 0;
+        out.scriptPubKey = patattest::BuildCommitmentScript(hash);
+        return out;
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(pat_commitment_rule_tests, PatCommitmentChainSetup)
+
+// The honest path: the production miner emits the commitment and ConnectBlock
+// accepts it. This is producer and validator run against each other, and it is
+// the case every future block with spends exercises. Fails if either half
+// drifts from the other in any tuple argument, the ordering, or the encoding.
+BOOST_AUTO_TEST_CASE(miner_emits_commitment_and_it_validates)
+{
+    CBlock block = BuildSolvedBlock({SpendTo(coinbaseTxns[0])}, Spk(OP_1));
+
+    BOOST_REQUIRE_MESSAGE(PatCommitmentIndex(block) != -1,
+        "the production miner did not emit a PAT commitment for a block with an "
+        "attested spend — the producer half of the optional-but-verified contract "
+        "is not running");
+
+    BOOST_CHECK_EQUAL(RejectReasonFor(block), "");
+}
+
+// A block with no attested spends must carry no commitment, and the miner must
+// not emit one. Every coinbase-only block on the chain is this case.
+BOOST_AUTO_TEST_CASE(miner_emits_nothing_for_an_empty_block)
+{
+    CBlock block = BuildSolvedBlock({}, Spk(OP_1));
+    BOOST_CHECK_EQUAL(PatCommitmentIndex(block), -1);
+    BOOST_CHECK_EQUAL(RejectReasonFor(block), "");
+}
+
+// Tampered commitment ⇒ bad-blk-pat-commitment. The byte flipped is inside the
+// 32-byte hash, so the output still PARSES as a commitment — flipping the magic
+// instead would make it invisible and the block would pass as commitment-less.
+BOOST_AUTO_TEST_CASE(tampered_commitment_rejected)
+{
+    CBlock block = BuildSolvedBlock({SpendTo(coinbaseTxns[1])}, Spk(OP_1));
+    const int idx = PatCommitmentIndex(block);
+    BOOST_REQUIRE(idx != -1);
+
+    std::vector<CTxOut> vout(block.vtx[0]->vout);
+    vout[idx].scriptPubKey[10] ^= 0x01; // inside the hash bytes
+    const CBlock tampered = WithCoinbaseVout(block, vout);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor(tampered), "bad-blk-pat-commitment");
+}
+
+// More than one commitment ⇒ bad-blk-pat-commitment-duplicate, even when the
+// duplicate is byte-identical to the honest one. Exactly-one is a shape rule,
+// not a correctness vote.
+BOOST_AUTO_TEST_CASE(duplicate_commitment_rejected)
+{
+    CBlock block = BuildSolvedBlock({SpendTo(coinbaseTxns[2])}, Spk(OP_1));
+    const int idx = PatCommitmentIndex(block);
+    BOOST_REQUIRE(idx != -1);
+
+    std::vector<CTxOut> vout(block.vtx[0]->vout);
+    vout.push_back(vout[idx]); // identical second commitment
+    const CBlock doubled = WithCoinbaseVout(block, vout);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor(doubled), "bad-blk-pat-commitment-duplicate");
+}
+
+// A decoy placed BEFORE the honest commitment must not win. This is the
+// first-match hazard the spec forbids copying from the LatticeFold validator:
+// under first-match-wins this block would be rejected as a MISMATCH against
+// the decoy at best, or accepted at worst if a validator compared the decoy
+// and a miner precomputed it; under the exactly-one rule it is rejected for
+// carrying two, independent of order.
+BOOST_AUTO_TEST_CASE(decoy_before_honest_commitment_rejected_as_duplicate)
+{
+    CBlock block = BuildSolvedBlock({SpendTo(coinbaseTxns[3])}, Spk(OP_1));
+    const int idx = PatCommitmentIndex(block);
+    BOOST_REQUIRE(idx != -1);
+
+    uint256 decoyHash;
+    GetRandBytes(decoyHash.begin(), 32);
+    std::vector<CTxOut> vout(block.vtx[0]->vout);
+    vout.insert(vout.begin() + idx, CommitmentOut(decoyHash)); // decoy first
+
+    BOOST_CHECK_EQUAL(RejectReasonFor(WithCoinbaseVout(block, vout)),
+                      "bad-blk-pat-commitment-duplicate");
+}
+
+// A commitment on a block with no attested spends ⇒ bad-blk-pat-commitment-empty.
+// There is no attestation for such a block (spec §5), so there is nothing a
+// commitment could correctly commit to.
+BOOST_AUTO_TEST_CASE(commitment_on_empty_block_rejected)
+{
+    CBlock block = BuildSolvedBlock({}, Spk(OP_1));
+    BOOST_REQUIRE_EQUAL(PatCommitmentIndex(block), -1);
+
+    uint256 anyHash;
+    GetRandBytes(anyHash.begin(), 32);
+    std::vector<CTxOut> vout(block.vtx[0]->vout);
+    vout.push_back(CommitmentOut(anyHash));
+
+    BOOST_CHECK_EQUAL(RejectReasonFor(WithCoinbaseVout(block, vout)),
+                      "bad-blk-pat-commitment-empty");
+}
+
+// The optional posture: a block with attested spends and NO commitment is
+// valid before the mandatory height. This is the fail-safe half of
+// optional-but-verified — a commitment-computation bug must not be able to
+// halt the chain at genesis.
+BOOST_AUTO_TEST_CASE(absent_commitment_accepted_before_mandatory_height)
+{
+    CBlock block = BuildSolvedBlock({SpendTo(coinbaseTxns[4])}, Spk(OP_1));
+    const int idx = PatCommitmentIndex(block);
+    BOOST_REQUIRE(idx != -1);
+
+    std::vector<CTxOut> vout(block.vtx[0]->vout);
+    vout.erase(vout.begin() + idx);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor(WithCoinbaseVout(block, vout)), "");
+}
+
+// The mandatory posture, all three verdicts under one armed height:
+//   attested spends without a commitment  ⇒ bad-blk-missing-pat-commitment
+//   attested spends with the commitment   ⇒ valid
+//   no attested spends, no commitment     ⇒ valid (no obligation to satisfy)
+BOOST_AUTO_TEST_CASE(mandatory_height_requires_the_commitment)
+{
+    ScopedPatMandatoryHeight armed(1); // every block past genesis
+
+    CBlock block = BuildSolvedBlock({SpendTo(coinbaseTxns[5])}, Spk(OP_1));
+    const int idx = PatCommitmentIndex(block);
+    BOOST_REQUIRE(idx != -1);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor(block), "");
+
+    std::vector<CTxOut> vout(block.vtx[0]->vout);
+    vout.erase(vout.begin() + idx);
+    BOOST_CHECK_EQUAL(RejectReasonFor(WithCoinbaseVout(block, vout)),
+                      "bad-blk-missing-pat-commitment");
+
+    const CBlock empty = BuildSolvedBlock({}, Spk(OP_1));
+    BOOST_CHECK_EQUAL(RejectReasonFor(empty), "");
+}
+
+// The mandatory rule is height-gated, not retroactive: armed ABOVE the next
+// block's height, an absent commitment is still the optional posture.
+BOOST_AUTO_TEST_CASE(mandatory_height_in_the_future_changes_nothing)
+{
+    ScopedPatMandatoryHeight armed(1000000);
+
+    CBlock block = BuildSolvedBlock({SpendTo(coinbaseTxns[6])}, Spk(OP_1));
+    const int idx = PatCommitmentIndex(block);
+    BOOST_REQUIRE(idx != -1);
+
+    std::vector<CTxOut> vout(block.vtx[0]->vout);
+    vout.erase(vout.begin() + idx);
+    BOOST_CHECK_EQUAL(RejectReasonFor(WithCoinbaseVout(block, vout)), "");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -16,6 +16,7 @@
 #include "consensus/btcsoq.h"
 #include "consensus/privacy.h"
 #include "consensus/block_accumulator.h"
+#include "consensus/pat_attestation.h"
 #include "consensus/validation.h"
 #include "fs.h"
 #include "hash.h"
@@ -3544,6 +3545,18 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     blockundo.vtxundo.reserve(block.vtx.size() - 1);
     std::vector<PrecomputedTransactionData> txdata;
     txdata.reserve(block.vtx.size()); // Required so that pointers to individual PrecomputedTransactionData don't get invalidated
+
+    // PAT block attestation (doc/PAT_BLOCK_ATTESTATION.md): tuples are
+    // collected inside the loop below, per transaction, because the view
+    // resolves each transaction's prevouts only until UpdateCoins spends them.
+    // The attested set derives from the same flags that gate v7/v8 fundability,
+    // so the set and fundability cannot disagree. Enforcement happens after the
+    // loop, once the batch is complete.
+    patattest::PatBatch patBatch;
+    patattest::AttestedSetParams patParams;
+    patParams.fUsdsoqActive = (flags & SCRIPT_VERIFY_USDSOQ) != 0;
+    patParams.fBtcsoqActive = (flags & SCRIPT_VERIFY_BTCSOQ) != 0;
+
     for (unsigned int i = 0; i < block.vtx.size(); i++) {
         const CTransaction& tx = *(block.vtx[i]);
 
@@ -3629,6 +3642,19 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 return error("ConnectBlock(): CheckInputs on %s failed with %s",
                     tx.GetHash().ToString(), FormatStateMessage(state));
             control.Add(vChecks);
+
+            // PAT attestation tuple collection. The prevouts consulted here
+            // are exactly the ones this transaction spends (view.HaveInputs
+            // held above, UpdateCoins has not yet run for this transaction),
+            // so in-block chained spends resolve the same way the producer
+            // resolves them.
+            patattest::AppendTuples(patBatch, tx,
+                [&view](const COutPoint& out, CTxOut& txOut) -> bool {
+                    const CCoins* coins = view.AccessCoins(out.hash);
+                    if (coins == nullptr || !coins->IsAvailable(out.n)) return false;
+                    txOut = coins->vout[out.n];
+                    return true;
+                }, patParams);
         }
 
         CTxUndo undoDummy;
@@ -3652,9 +3678,9 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // constants are armed: with nMigrationHeight == 0 or a null hash this block
     // is byte-for-byte the pre-existing subsidy check. At exactly the armed
     // height, the coinbase must carry the committed allocation outputs as
-    // vout[1..N] in committed order (a trailing segwit witness-commitment
-    // output, which the miner appends after them, is not part of the committed
-    // range): their standard serialization must hash to hashMigrationOutputs,
+    // vout[1..N] in committed order (trailing block-commitment outputs — the
+    // segwit witness, LatticeFold, and PAT attestation commitments, which the
+    // producer appends after them — are not part of the committed range): their standard serialization must hash to hashMigrationOutputs,
     // their values must sum to exactly nMigrationTotal, and the miner's own
     // output vout[0] stays bounded by subsidy + fees while the permitted total
     // becomes subsidy + fees + nMigrationTotal.
@@ -3665,9 +3691,31 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             pindex->nHeight == migrationConsensus.nMigrationHeight &&
             !migrationConsensus.hashMigrationOutputs.IsNull()) {
             const CTransaction& coinbase = *block.vtx[0];
+            // The committed range excludes TRAILING block-commitment outputs.
+            // Originally only the SegWit witness commitment; generalised
+            // 2026-09-01 when the PAT attestation commitment (also appended by
+            // GenerateCoinbaseCommitment, after the SegWit one) made "the
+            // witness commitment is last" false for any migration block that
+            // contains attested spends. Walk back over every recognised
+            // block-commitment shape so the exclusion does not depend on the
+            // order the producer appends them in. LatticeFold's commitment is
+            // included for the same reason even though it cannot fire while
+            // the deployment is withdrawn.
+            const auto isBlockCommitmentOutput = [](const CTxOut& out) -> bool {
+                const CScript& s = out.scriptPubKey;
+                // SegWit witness commitment: >=38 bytes, OP_RETURN 0x24 aa21a9ed.
+                if (s.size() >= 38 && s[0] == OP_RETURN && s[1] == 0x24 &&
+                    s[2] == 0xaa && s[3] == 0x21 && s[4] == 0xa9 && s[5] == 0xed)
+                    return true;
+                uint256 ignored;
+                if (patattest::ParseCommitmentScript(s, ignored)) return true;   // PAT ('PA')
+                std::vector<uint8_t> raw(s.begin(), s.end());
+                if (BlockProofAccumulator::ParseCoinbaseCommitment(raw, ignored))
+                    return true;                                                 // LatticeFold ('LF')
+                return false;
+            };
             size_t committedEnd = coinbase.vout.size();
-            const int commitpos = GetWitnessCommitmentIndex(block);
-            if (commitpos > 0 && (size_t)commitpos == coinbase.vout.size() - 1)
+            while (committedEnd > 1 && isBlockCommitmentOutput(coinbase.vout[committedEnd - 1]))
                 committedEnd--;
             if (committedEnd < 2)
                 return state.DoS(100,
@@ -5427,6 +5475,61 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         }
     }
 
+    // =========================================================================
+    // PAT block attestation enforcement (doc/PAT_BLOCK_ATTESTATION.md §7,
+    // epic pat-completion-epic-xlab phase 3). Optional-but-verified: a miner
+    // MAY emit the coinbase commitment; any commitment present MUST match the
+    // attestation recomputed over the tuples collected in the loop above; from
+    // nPatCommitmentMandatoryHeight onward, a block with attested spends and
+    // no commitment is invalid. The four reject reasons are named in the spec
+    // and pinned by string in pat_commitment_rule_tests.
+    //
+    // Unlike the LatticeFold check above, MORE THAN ONE commitment is invalid
+    // rather than first-match-wins: a first-match scan makes validation depend
+    // on coinbase output order and lets a miner place a decoy ahead of the
+    // real commitment (spec §6).
+    // =========================================================================
+    {
+        uint256 committed;
+        const int nCommitments = patattest::FindCommitments(*block.vtx[0], committed);
+        uint256 computed;
+        const bool fHaveAttestation = patattest::ComputeBlockAttestation(patBatch, computed);
+
+        if (nCommitments > 1) {
+            return state.DoS(100,
+                error("ConnectBlock(): block %d carries %d PAT commitments, only one is permitted",
+                      pindex->nHeight, nCommitments),
+                REJECT_INVALID, "bad-blk-pat-commitment-duplicate");
+        }
+        if (nCommitments == 1) {
+            if (!fHaveAttestation) {
+                return state.DoS(100,
+                    error("ConnectBlock(): block %d carries a PAT commitment but has no attested spends",
+                          pindex->nHeight),
+                    REJECT_INVALID, "bad-blk-pat-commitment-empty");
+            }
+            if (committed != computed) {
+                return state.DoS(100,
+                    error("ConnectBlock(): block %d PAT commitment mismatch (committed %s, computed %s)",
+                          pindex->nHeight,
+                          committed.ToString().substr(0, 16), computed.ToString().substr(0, 16)),
+                    REJECT_INVALID, "bad-blk-pat-commitment");
+            }
+            LogPrintf("PAT: block %d attestation verified (%u tuples, hash=%s)\n",
+                pindex->nHeight, (unsigned)patBatch.size(), computed.ToString().substr(0, 16));
+        } else if (fHaveAttestation) {
+            const int nMandatory =
+                chainparams.GetConsensus(pindex->nHeight).nPatCommitmentMandatoryHeight;
+            if (nMandatory != 0 && pindex->nHeight >= nMandatory) {
+                return state.DoS(100,
+                    error("ConnectBlock(): block %d has %u attested spends but no PAT commitment "
+                          "(mandatory from height %d)",
+                          pindex->nHeight, (unsigned)patBatch.size(), nMandatory),
+                    REJECT_INVALID, "bad-blk-missing-pat-commitment");
+            }
+        }
+    }
+
     if (!control.Wait())
         return state.DoS(100, false);
     int64_t nTime4 = GetTimeMicros();
@@ -6645,6 +6748,65 @@ std::vector<unsigned char> GenerateCoinbaseCommitment(CBlock& block, const CBloc
                     blockAccum.nProofCount,
                     blockAccum.hashAccumulator.ToString().substr(0, 16));
             }
+        }
+    }
+
+    // =========================================================================
+    // PAT block attestation commitment (doc/PAT_BLOCK_ATTESTATION.md §6-§7,
+    // epic pat-completion-epic-xlab phase 3). If the block contains attested
+    // Dilithium spends, compute the batch attestation and add its hash as a
+    // 36-byte OP_RETURN 'PA' output in the coinbase. Optional-but-verified:
+    // emitting is the miner's side of the contract; ConnectBlock verifies any
+    // commitment that is present and, past nPatCommitmentMandatoryHeight,
+    // requires one. The tuple construction is patattest::AppendTuples — the
+    // SAME function ConnectBlock recomputes with, which is what prevents
+    // producer/validator drift.
+    // =========================================================================
+    if (pcoinsTip != nullptr && block.vtx.size() > 1) {
+        const int nHeight = pindexPrev == nullptr ? 0 : pindexPrev->nHeight + 1;
+        const Consensus::Params& patConsensus = Params().GetConsensus(nHeight);
+
+        // The attested set at this height (spec §2, Decision 1): the same
+        // DeploymentActiveAtHeight facts ConnectBlock turns into
+        // SCRIPT_VERIFY_USDSOQ / SCRIPT_VERIFY_BTCSOQ.
+        patattest::AttestedSetParams patParams;
+        patParams.fUsdsoqActive = Consensus::DeploymentActiveAtHeight(
+            nHeight, patConsensus, Consensus::DEPLOYMENT_USDSOQ);
+        patParams.fBtcsoqActive = Consensus::DeploymentActiveAtHeight(
+            nHeight, patConsensus, Consensus::DEPLOYMENT_BTCSOQ);
+
+        // Prevouts: outputs created earlier in this block first (in-block
+        // chained spends), then the chain view. Same resolution order the
+        // validator sees, because ConnectBlock's view gains each transaction's
+        // outputs before the next transaction is connected.
+        std::map<uint256, CTransactionRef> inBlock;
+        for (const auto& txRef : block.vtx) inBlock[txRef->GetHash()] = txRef;
+        const auto lookup = [&inBlock](const COutPoint& out, CTxOut& txOut) -> bool {
+            const auto it = inBlock.find(out.hash);
+            if (it != inBlock.end()) {
+                if (out.n >= it->second->vout.size()) return false;
+                txOut = it->second->vout[out.n];
+                return true;
+            }
+            const CCoins* coins = pcoinsTip->AccessCoins(out.hash);
+            if (coins == nullptr || !coins->IsAvailable(out.n)) return false;
+            txOut = coins->vout[out.n];
+            return true;
+        };
+
+        uint256 attestation;
+        uint256 existing;
+        if (patattest::FindCommitments(*block.vtx[0], existing) == 0 &&
+            patattest::ComputeBlockAttestation(
+                patattest::CollectBatch(block, lookup, patParams), attestation)) {
+            CTxOut patOut;
+            patOut.nValue = 0;
+            patOut.scriptPubKey = patattest::BuildCommitmentScript(attestation);
+            CMutableTransaction tx(*block.vtx[0]);
+            tx.vout.push_back(patOut);
+            block.vtx[0] = MakeTransactionRef(std::move(tx));
+            LogPrintf("PAT: added block attestation commitment (hash=%s)\n",
+                attestation.ToString().substr(0, 16));
         }
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3552,6 +3552,20 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // The attested set derives from the same flags that gate v7/v8 fundability,
     // so the set and fundability cannot disagree. Enforcement happens after the
     // loop, once the batch is complete.
+    //
+    // Gated on fScriptChecks, the assumevalid/checkpoint window where signature
+    // verification itself is skipped. The attestation attests those same
+    // signatures, so recomputing it there is the same class of redundant work
+    // assumevalid exists to skip — and it is NOT cheap: a sighash per input
+    // (which the base code does not compute at all in this window), SHA3 over
+    // every 2,420-byte signature and 1,312-byte key, and an O(n log n) Merkle
+    // build per block. Every historical commitment was verified by the nodes
+    // that ran full checks, the same trust statement assumevalid already makes.
+    //
+    // ⛔ Collection and the enforcement block below are gated TOGETHER. Skipping
+    // only collection would compare a present commitment against an empty batch
+    // and reject valid historical blocks (bad-blk-pat-commitment-empty) during
+    // fast sync.
     patattest::PatBatch patBatch;
     patattest::AttestedSetParams patParams;
     patParams.fUsdsoqActive = (flags & SCRIPT_VERIFY_USDSOQ) != 0;
@@ -3643,18 +3657,21 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     tx.GetHash().ToString(), FormatStateMessage(state));
             control.Add(vChecks);
 
-            // PAT attestation tuple collection. The prevouts consulted here
-            // are exactly the ones this transaction spends (view.HaveInputs
-            // held above, UpdateCoins has not yet run for this transaction),
-            // so in-block chained spends resolve the same way the producer
-            // resolves them.
-            patattest::AppendTuples(patBatch, tx,
-                [&view](const COutPoint& out, CTxOut& txOut) -> bool {
-                    const CCoins* coins = view.AccessCoins(out.hash);
-                    if (coins == nullptr || !coins->IsAvailable(out.n)) return false;
-                    txOut = coins->vout[out.n];
-                    return true;
-                }, patParams);
+            // PAT attestation tuple collection (skipped with fScriptChecks —
+            // see the gate rationale at the batch declaration above). The
+            // prevouts consulted here are exactly the ones this transaction
+            // spends (view.HaveInputs held above, UpdateCoins has not yet run
+            // for this transaction), so in-block chained spends resolve the
+            // same way the producer resolves them.
+            if (fScriptChecks) {
+                patattest::AppendTuples(patBatch, tx,
+                    [&view](const COutPoint& out, CTxOut& txOut) -> bool {
+                        const CCoins* coins = view.AccessCoins(out.hash);
+                        if (coins == nullptr || !coins->IsAvailable(out.n)) return false;
+                        txOut = coins->vout[out.n];
+                        return true;
+                    }, patParams);
+            }
         }
 
         CTxUndo undoDummy;
@@ -5488,8 +5505,15 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // rather than first-match-wins: a first-match scan makes validation depend
     // on coinbase output order and lets a miner place a decoy ahead of the
     // real commitment (spec §6).
+    //
+    // Skipped with fScriptChecks, TOGETHER with the collection above: inside
+    // the assumevalid window the batch was never collected, so enforcing here
+    // would compare any present commitment against an empty batch and reject
+    // valid historical blocks. The trust statement is the one assumevalid
+    // already makes — these commitments were verified by every node that ran
+    // full checks when the blocks were new.
     // =========================================================================
-    {
+    if (fScriptChecks) {
         uint256 committed;
         const int nCommitments = patattest::FindCommitments(*block.vtx[0], committed);
         uint256 computed;


### PR DESCRIPTION
Phase 3 of the PAT completion epic, second stage: the attestation module (#68) becomes a live consensus rule per `doc/PAT_BLOCK_ATTESTATION.md`, with the single deliberate digest re-pin the completion plan prescribed.

## What ships

**Producer.** `GenerateCoinbaseCommitment` appends the 36-byte `PA` `OP_RETURN` when the block contains attested spends, resolving prevouts from in-block outputs first and the chain view second — the same order the validator's view resolves them. One site covers the miner, the AuxPoW template path, and the unit-test block builder, so every fixture block in the suite now exercises the producer.

**Validation.** `ConnectBlock` collects tuples per transaction inside its main loop, where the view still holds that transaction's prevouts, through the same `patattest::AppendTuples` the producer uses — one code path, which is what prevents producer/validator drift. The attested set derives from the same flags that gate v7/v8 fundability, so the two cannot disagree. Enforcement carries the four named reject reasons from the specification, and more than one commitment is invalid rather than first-match-wins.

**Activation.** New `Consensus::Params` field `nPatCommitmentMandatoryHeight`, `0` = never mandatory on every network (the launch posture), the same inert model as the migration fields, with a regtest-only setter for tests.

## Migration interaction, found before it shipped

The genesis-migration rule excluded only a *trailing SegWit* witness commitment from its committed range. The PAT commitment is appended after the SegWit one, so any migration block containing attested spends would have failed `bad-cb-migration-outputs` at the one height that rule fires. The exclusion now walks back over every recognised block-commitment shape (SegWit, LatticeFold, PAT) regardless of order. LatticeFold had the same latent interaction, masked only by its dormancy. The migration suite passes unchanged.

## The digest re-pin: `44962547` → `c4029fd7`

One deliberate event, three inputs, each documented at the pin:

1. `AbsorbConsensus` gains `nPatCommitmentMandatoryHeight`.
2. `AbsorbOpcodeVerdicts` gains duplicate-message PAT batches — the canonical-ordering **tie path**. Until now every absorbed batch had distinct messages, so the digest measured nothing about ordering and did not move when the ordering defect was fixed in #65. This closes the digest half of `pat-canonical-ordering-not-total-97dz`: the F4 sweep now covers ordering.
3. `AbsorbPatAttestation` is new: the attestation pipeline end to end over a distinct-message and a duplicate-message batch, plus the parser round-trip and the empty-batch verdict.

The F4 cross-build sweep is owed against the merge commit per the standing process; the sweep of record re-runs against the tag.

## Tests

`pat_commitment_rule_tests` drives every verdict through real blocks by named string:

| Case | Verdict |
|---|---|
| Honest miner block (producer against validator) | valid |
| Coinbase-only block, no commitment emitted | valid |
| Tampered commitment (byte inside the hash, still parses) | `bad-blk-pat-commitment` |
| Identical duplicate commitment | `bad-blk-pat-commitment-duplicate` |
| Decoy placed **before** the honest commitment | `bad-blk-pat-commitment-duplicate` |
| Commitment on a block with no attested spends | `bad-blk-pat-commitment-empty` |
| Absent commitment, pre-mandatory | valid |
| Absent commitment, mandatory height armed | `bad-blk-missing-pat-commitment` |
| Mandatory height armed, spend-less block | valid |
| Mandatory height in the future | valid |

`qa/rpc-tests/pat-commitment.py` runs the contract end to end through a live regtest node — commitment-less empty blocks, exactly one commitment for mempool-fed spend blocks, one batch per block for several spends. Passed locally against a live node.

## Verification

- Full unit suite: **769 cases, 0 failures** — including the migration suite whose committed-range logic changed, and every existing suite that mines spends, all of which now flow through producer and validator.
- Falsifiability probe: with the producer deliberately emitting a corrupted hash, the validator rejects the miner's own block with `bad-blk-pat-commitment`; exactly the two honest-path cases fail; restored, all green.
- Functional test passed against a live node.

With this merged, phases 1–4 of the completion plan are done except the post-merge F4 sweep; phase 5 (witness pruning, route R1) is next and is not consensus-affecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
