### PR TITLE
node: PAT witness pruning stage 1 — compaction, eligibility, crash safety

### DIFF
--- a/doc/PAT_WITNESS_PRUNING.md
+++ b/doc/PAT_WITNESS_PRUNING.md
@@ -36,7 +36,11 @@ coincidence.
   horizon and it has been fully validated by this node
   (`BLOCK_VALID_SCRIPTS`). Consensus already refuses reorganizations deeper
   than the horizon, so an eligible block's witnesses can never again be needed
-  for validation by this node.
+  for validation by this node. The genesis block is exempt from the validity
+  requirement: `ConnectBlock` early-returns for it before validity is raised
+  (its coinbase is unspendable, there is nothing to script-check), it carries
+  no witnesses, and it is final by definition; without the exemption, file 0
+  could never become whole-file eligible.
 - **`BLOCK_WITNESS_PRUNED`**: a new `BlockStatus` flag (bit 256, the next free
   bit after `BLOCK_OPT_WITNESS`) recording per block-index entry that the
   stored data is the stripped form.

--- a/doc/PAT_WITNESS_PRUNING.md
+++ b/doc/PAT_WITNESS_PRUNING.md
@@ -76,13 +76,23 @@ whole trailing files age out together.
 
 Compaction of file *n* writes the stripped data to a **new file number** *m*
 (allocated from the same `blk*.dat` series; nothing requires file numbers to be
-height-ordered, since every read goes through `nFile`/`nDataPos`). The original
-file is never modified in place, which is what removes the crash window
-entirely:
+height-ordered, since every read goes through `nFile`/`nDataPos`). The number
+*m* is **reserved before any I/O** by advancing the append pointer past it
+under the file lock: the block-write path only ever allocates forward from the
+append pointer, so concurrent block-file rotation can never collide with the
+compaction target. The collision is impossible by construction rather than
+detected after the fact; a detection check at commit time would run after the
+disk damage it detects (found in review). The original file is never modified
+in place, which is what removes the crash window entirely:
 
-1. Read every block in file *n*; re-serialize each with
-   `SERIALIZE_TRANSACTION_NO_WITNESS` into file *m*, with fresh per-block
-   offsets. Flush and fsync file *m*.
+1. Reserve *m* (above), then read every block in file *n* and re-serialize
+   each with `SERIALIZE_TRANSACTION_NO_WITNESS` into file *m*, with fresh
+   per-block offsets. Flush and fsync file *m*. The reservation is in-memory
+   until the next index flush; a crash here can lose it, leaving a partial
+   file *m* that a later restart may allocate over — harmless, because block
+   files are position-addressed (stray tail bytes are unreachable) and the
+   orphan sweep removes any partial target whose file info is empty and which
+   no index entry references.
 2. Update every affected `CBlockIndex` entry (`nFile` = *m*, new `nDataPos`,
    `BLOCK_WITNESS_PRUNED`) and the `CBlockFileInfo` records, and flush the
    block index durably.

--- a/qa/rpc-tests/auxpow.py
+++ b/qa/rpc-tests/auxpow.py
@@ -76,6 +76,15 @@ class AuxPOWTest (BitcoinTestFramework):
         # rejected by the parent-side guard in auxpow.cpp. "5153" = 0x5351 LE.)
         assert scrypt_auxpow.mineScryptAux(self.nodes[0], "5153", True) is False
 
+        # Node 0's step-6 auxpow block must reach node 1 BEFORE node 1 mines,
+        # or node 1 extends its own height-19 tip and the 60-block run below
+        # orphans the auxpow block, silently deleting one reward. This race
+        # produced an intermittent failure at the balance assertion
+        # (500000 != 1000000): CI run 33565415466 failed and its re-run passed
+        # on the identical commit. Steps 7 and 8 create no blocks, so this one
+        # sync closes the only window.
+        self.sync_all()
+
         # 9. mine enough blocks to mature all node 0 rewards
         self.nodes[1].generate(self.MATURITY_HEIGHT)
         self.sync_all()

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -177,6 +177,7 @@ BITCOIN_TESTS =\
   test/dilithium_keyhash_committed_tests.cpp \
   test/usdsoq_v7_holding_tests.cpp \
   test/authority_skip_gate_tests.cpp \
+  test/witness_prune_tests.cpp \
   test/witness_version_reservation_tests.cpp \
   test/apo_hashtype_gate_tests.cpp \
   test/dormancy_matrix_tests.cpp \

--- a/src/chain.h
+++ b/src/chain.h
@@ -148,6 +148,14 @@ enum BlockStatus: uint32_t {
     BLOCK_FAILED_MASK        =   BLOCK_FAILED_VALID | BLOCK_FAILED_CHILD,
 
     BLOCK_OPT_WITNESS       =   128, //!< block data in blk*.data was received with a witness-enforcing client
+
+    //! Block data in blk*.dat is stored witness-stripped
+    //! (SERIALIZE_TRANSACTION_NO_WITNESS): PAT witness pruning,
+    //! doc/PAT_WITNESS_PRUNING.md. Base data, undo data and the PAT
+    //! attestation commitment are intact; signatures cannot be re-verified.
+    //! A disconnect of a block carrying this flag is a finality-rule
+    //! violation and halts the node.
+    BLOCK_WITNESS_PRUNED    =   256,
 };
 
 /** The block chain is a tree shaped structure starting with the

--- a/src/chain.h
+++ b/src/chain.h
@@ -154,7 +154,7 @@ enum BlockStatus: uint32_t {
     //! doc/PAT_WITNESS_PRUNING.md. Base data, undo data and the PAT
     //! attestation commitment are intact; signatures cannot be re-verified.
     //! A disconnect of a block carrying this flag is a finality-rule
-    //! violation and halts the node.
+    //! violation; DisconnectBlock refuses it via AbortNode.
     BLOCK_WITNESS_PRUNED    =   256,
 };
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1033,8 +1033,15 @@ public:
 
     void UpdateMaxReorgDepth(int nMaxReorgDepth)
     {
+        // ⚠️ ALL THREE structs, for the same height-indexed-tree reason as the
+        // setters below (bead tofg): GetConsensus resolves heights above the
+        // regtest auxpow boundary to auxpowConsensus, so a caller reading the
+        // horizon at the tip height saw 0 here until 2026-09-01 — found when
+        // witness-prune eligibility became the first consumer to read
+        // nMaxReorgDepth at a high height through this override.
         consensus.nMaxReorgDepth = nMaxReorgDepth;
         digishieldConsensus.nMaxReorgDepth = nMaxReorgDepth;
+        auxpowConsensus.nMaxReorgDepth = nMaxReorgDepth;
     }
 
     void UpdateMigrationParams(const uint256& hashOutputs, CAmount nTotal, int nHeight,

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -368,6 +368,7 @@ std::string HelpMessage(HelpMessageMode mode)
                                                          "Warning: Reverting this setting requires re-downloading the entire blockchain. "
                                                          "(default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, >%u = automatically prune block files to stay under the specified target size in MiB)"),
                                                  MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024));
+    strUsage += HelpMessageOpt("-witnessprune", strprintf(_("Discard raw witness data (signatures) of blocks deeper than the finality horizon, keeping all base data and the PAT block attestation (doc/PAT_WITNESS_PRUNING.md). Incompatible with -prune. -reindex is refused once enabled; reverting requires re-downloading the chain. Stage 1: regtest or -connect=0 only. (default: %u)"), 0));
     strUsage += HelpMessageOpt("-reindex-chainstate", _("Rebuild chain state from the currently indexed blocks"));
     strUsage += HelpMessageOpt("-reindex", _("Rebuild chain state and block index from the blk*.dat files on disk"));
 #ifndef WIN32
@@ -1013,6 +1014,14 @@ bool AppInitParameterInteraction()
         fPruneMode = true;
     }
 
+    // PAT witness pruning (doc/PAT_WITNESS_PRUNING.md §5). The horizon check
+    // runs later, after a regtest -maxreorgdepth override can have applied.
+    fWitnessPrune = GetBoolArg("-witnessprune", false);
+    if (fWitnessPrune && fPruneMode) {
+        return InitError(_("-witnessprune is incompatible with -prune: whole-file pruning "
+                           "deletes the base data witness pruning exists to retain."));
+    }
+
     RegisterAllCoreRPCCommands(tableRPC);
 
     // USDSOQ consensus RPCs (authority, supply, verification)
@@ -1183,6 +1192,28 @@ bool AppInitParameterInteraction()
         }
         UpdateRegtestMaxReorgDepth((int)nDepth);
         LogPrintf("Setting regtest finality horizon (nMaxReorgDepth) to %d\n", (int)nDepth);
+    }
+
+    if (fWitnessPrune) {
+        // Stage 1 (doc/PAT_WITNESS_PRUNING.md §8): storage semantics only. The
+        // network contract (NODE_NETWORK_LIMITED, getdata window rules) is not
+        // implemented yet, so a connected node running this would under-serve
+        // what it advertises — the exact failure the specification forbids.
+        const bool fDisconnected = IsArgSet("-connect") &&
+            mapMultiArgs.count("-connect") &&
+            mapMultiArgs.at("-connect").size() == 1 &&
+            mapMultiArgs.at("-connect")[0] == "0";
+        if (!chainparams.MineBlocksOnDemand() && !fDisconnected) {
+            return InitError(_("-witnessprune is stage 1: regtest or -connect=0 only, "
+                               "until the network service contract lands (doc/PAT_WITNESS_PRUNING.md §8)."));
+        }
+        // The finality horizon is what makes witness pruning safe at all
+        // (spec §6). With the horizon disabled nothing is ever eligible and
+        // the flag would be a silent no-op; refuse instead.
+        if (chainparams.GetConsensus(0).nMaxReorgDepth <= 0) {
+            return InitError(_("-witnessprune requires a finality horizon "
+                               "(nMaxReorgDepth > 0; on regtest set -maxreorgdepth)."));
+        }
     }
 
     if (IsArgSet("-migrationoutputs") || IsArgSet("-migrationheight") || IsArgSet("-migrationtotal")) {
@@ -1570,6 +1601,25 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 delete pcoinscatcher;
                 delete pblocktree;
 
+                if (fReindex) {
+                    // Witness-pruned data cannot re-verify scripts, so a
+                    // reindex would either fail partway or manufacture a node
+                    // that believes without having checked; refuse up front
+                    // (doc/PAT_WITNESS_PRUNING.md §2). The flag must be read
+                    // with a NON-WIPING open: the reindex open below wipes the
+                    // block tree, destroying the very marker that refuses it.
+                    bool fWitnessPruned = false;
+                    {
+                        CBlockTreeDB peek(1 << 20, false, false);
+                        peek.ReadFlag("witnessprunedblocks", fWitnessPruned);
+                    }
+                    if (fWitnessPruned) {
+                        return InitError(_("This datadir has witness-pruned block files and "
+                                           "cannot be reindexed: stripped blocks cannot re-verify "
+                                           "signatures. Re-download the chain into a fresh datadir "
+                                           "(doc/PAT_WITNESS_PRUNING.md)."));
+                    }
+                }
                 pblocktree = new CBlockTreeDB(nBlockTreeDBCache, false, fReindex);
                 pcoinsdbview = new CCoinsViewDB(nCoinDBCache, false, fReindex || fReindexChainState);
                 pcoinscatcher = new CCoinsViewErrorCatcher(pcoinsdbview);
@@ -1858,6 +1908,21 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
             uiInterface.InitMessage(_("Pruning blockstore..."));
             PruneAndFlush();
         }
+    }
+
+    if (fWitnessPrune) {
+        // Stage 1 runs disconnected (regtest / -connect=0, enforced above), so
+        // no service-bit change is needed yet; that is stage 2 with the rest
+        // of the network contract (doc/PAT_WITNESS_PRUNING.md §4, §8).
+        // Compaction runs off the validation hot path on the scheduler, same
+        // cadence class as the flush-driven prune above.
+        scheduler.scheduleEvery([]() {
+            std::string strError;
+            if (!CompactWitnessFiles(strError)) {
+                LogPrintf("witnessprune: compaction pass failed: %s\n", strError);
+            }
+        }, 600);
+        LogPrintf("Witness pruning enabled (stage 1; doc/PAT_WITNESS_PRUNING.md)\n");
     }
 
     if (chainparams.GetConsensus(0).vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout != 0) {

--- a/src/test/witness_prune_tests.cpp
+++ b/src/test/witness_prune_tests.cpp
@@ -16,10 +16,17 @@
 #include "chainparams.h"
 #include "consensus/pat_attestation.h"
 #include "test/dilithium_chain_setup.h"
+#include "init.h"
 #include "txdb.h"
 #include "validation.h"
 
 #include <boost/test/unit_test.hpp>
+
+#include <atomic>
+
+// The process-wide shutdown flag AbortNode sets (init.cpp). Declared here so
+// the disconnect-guard test can clear it after deliberately tripping it.
+extern std::atomic<bool> fRequestShutdown;
 
 namespace {
 
@@ -299,6 +306,47 @@ BOOST_AUTO_TEST_CASE(crash_windows_leave_readable_state_and_converge)
     BOOST_CHECK(!fs::exists(GetBlockPosFilename(CDiskBlockPos(0, 0), "rev")));
     for (CBlockIndex* p : vFile0) BOOST_CHECK_EQUAL(p->nFile, nNewFile);
     allReadable("after the converging pass");
+}
+
+// §6 — the finality assertion. A disconnect request for a witness-pruned
+// block means the finality rule itself failed; DisconnectBlock must refuse via
+// AbortNode rather than improvise. The guard fires before the view is touched,
+// so driving it with the live view is safe. Fails if the guard is removed or
+// reordered after the undo machinery.
+BOOST_AUTO_TEST_CASE(disconnect_of_pruned_block_aborts)
+{
+    RotateBlockFileForTests();
+    ScopedRegtestHorizon horizon(3);
+    for (int i = 0; i < 4; ++i) CreateAndProcessBlock({}, Spk(OP_1));
+    std::string strError;
+    BOOST_REQUIRE_MESSAGE(CompactWitnessFiles(strError), strError);
+
+    LOCK(cs_main);
+    CBlockIndex* pPruned = nullptr;
+    for (const auto& item : mapBlockIndex) {
+        if ((item.second->nStatus & BLOCK_WITNESS_PRUNED) && item.second->nHeight > 0) {
+            pPruned = item.second;
+            break;
+        }
+    }
+    BOOST_REQUIRE(pPruned != nullptr);
+
+    CBlock block;
+    BOOST_REQUIRE(ReadBlockFromDisk(block, pPruned, Params().GetConsensus(pPruned->nHeight)));
+
+    BOOST_REQUIRE(!ShutdownRequested());
+    CValidationState state;
+    CCoinsViewCache view(pcoinsTip);
+    BOOST_CHECK_MESSAGE(!DisconnectBlock(block, state, pPruned, view, nullptr),
+        "DisconnectBlock accepted a witness-pruned block; the finality assertion "
+        "of doc/PAT_WITNESS_PRUNING.md section 6 is gone");
+    BOOST_CHECK_MESSAGE(ShutdownRequested(),
+        "the refusal must go through AbortNode: a quiet error return leaves the "
+        "node running on a chain state the pruning safety argument does not cover");
+
+    // AbortNode sets the process-wide shutdown flag; clear it so later suites
+    // in this binary are unaffected.
+    fRequestShutdown = false;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/witness_prune_tests.cpp
+++ b/src/test/witness_prune_tests.cpp
@@ -1,0 +1,304 @@
+// Copyright (c) 2026 Soqucoin Labs Inc.
+// Distributed under the MIT software license.
+//
+// witness_prune_tests.cpp — PAT witness pruning stage 1, against
+// doc/PAT_WITNESS_PRUNING.md (test plan items 1-4, including the crash-window
+// simulation). Section references are to that document.
+//
+// The fixture mines a real regtest chain (DilithiumChainSetup), rotates the
+// append file so file 0 becomes a candidate, arms a small finality horizon
+// with the regtest setter, and drives the actual compaction code. Reads after
+// compaction go through ReadBlockFromDisk with the real index, so what is
+// asserted is what a node would actually see.
+
+#include "chain.h"
+#include "undo.h"
+#include "chainparams.h"
+#include "consensus/pat_attestation.h"
+#include "test/dilithium_chain_setup.h"
+#include "txdb.h"
+#include "validation.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+//! Arm the regtest finality horizon for a scope; restore disabled (0).
+struct ScopedRegtestHorizon {
+    explicit ScopedRegtestHorizon(int nDepth)
+    {
+        UpdateRegtestMaxReorgDepth(nDepth);
+        SelectParams(CBaseChainParams::REGTEST);
+    }
+    ~ScopedRegtestHorizon()
+    {
+        UpdateRegtestMaxReorgDepth(0);
+        SelectParams(CBaseChainParams::REGTEST);
+    }
+};
+
+} // namespace
+
+struct WitnessPruneSetup : public DilithiumChainSetup {
+    //! A signed v1 spend of coinbase `k`, so mined blocks carry witness data
+    //! and a PAT commitment.
+    CMutableTransaction Spend(int k)
+    {
+        const CTransaction& cb = coinbaseTxns[k];
+        CMutableTransaction tx;
+        tx.nVersion = 2;
+        CTxIn in;
+        in.prevout = COutPoint(cb.GetHash(), 0);
+        in.nSequence = CTxIn::SEQUENCE_FINAL;
+        tx.vin.push_back(in);
+        CTxOut out;
+        out.nValue = cb.vout[0].nValue - 10000;
+        out.scriptPubKey = Spk(OP_1);
+        tx.vout.push_back(out);
+        SignInput(tx, 0, coinbaseSpk, cb.vout[0].nValue);
+        return tx;
+    }
+
+    //! Every block-index entry currently stored in `nFile`.
+    static std::vector<CBlockIndex*> BlocksInFile(int nFile)
+    {
+        LOCK(cs_main);
+        std::vector<CBlockIndex*> v;
+        for (const auto& item : mapBlockIndex) {
+            if (item.second->nFile == nFile && (item.second->nStatus & BLOCK_HAVE_DATA)) {
+                v.push_back(item.second);
+            }
+        }
+        return v;
+    }
+
+    static int TipHeight()
+    {
+        LOCK(cs_main);
+        return chainActive.Height();
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(witness_prune_tests, WitnessPruneSetup)
+
+// §7.1 — the stripping serialization round-trip, in memory. Transaction ids
+// and the merkle root must be unchanged (they exclude witness data by
+// construction); witness stacks must come back empty; the PAT commitment
+// output must survive, because it is base data. Fails if the NO_WITNESS
+// stream flag stops stripping, or if stripping ever reaches base data.
+BOOST_AUTO_TEST_CASE(stripped_serialization_round_trip)
+{
+    const CBlock block = BuildSolvedBlock({Spend(0)}, Spk(OP_1));
+    BOOST_REQUIRE(block.vtx.size() == 2);
+    BOOST_REQUIRE_MESSAGE(!block.vtx[1]->vin[0].scriptWitness.IsNull(),
+        "the spend must carry witness data or this test strips nothing");
+
+    // The block must carry a PAT commitment (an output, which must survive).
+    uint256 patHash;
+    BOOST_REQUIRE_EQUAL(patattest::FindCommitments(*block.vtx[0], patHash), 1);
+
+    CDataStream ss(SER_DISK, CLIENT_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS);
+    ss << block;
+    CBlock stripped;
+    ss >> stripped;
+
+    BOOST_CHECK(stripped.GetHash() == block.GetHash());
+    BOOST_CHECK(stripped.hashMerkleRoot == block.hashMerkleRoot);
+    BOOST_REQUIRE_EQUAL(stripped.vtx.size(), block.vtx.size());
+    for (size_t i = 0; i < block.vtx.size(); ++i) {
+        BOOST_CHECK(stripped.vtx[i]->GetHash() == block.vtx[i]->GetHash());
+        for (const CTxIn& in : stripped.vtx[i]->vin) {
+            BOOST_CHECK_MESSAGE(in.scriptWitness.IsNull(),
+                "witness survived the NO_WITNESS serialization");
+        }
+    }
+    uint256 patHashAfter;
+    BOOST_CHECK_EQUAL(patattest::FindCommitments(*stripped.vtx[0], patHashAfter), 1);
+    BOOST_CHECK(patHashAfter == patHash);
+}
+
+// §7.2 — the eligibility boundary. Depth exactly the horizon is not eligible;
+// strictly deeper is; a disabled horizon makes nothing eligible; the append
+// file is never eligible. Fails if any inequality is off by one, which is the
+// classic way a finality boundary goes wrong.
+BOOST_AUTO_TEST_CASE(eligibility_boundary)
+{
+    // File 0 holds the fixture chain; make it non-append so the append-file
+    // rule stops masking the height rule.
+    RotateBlockFileForTests();
+
+    // With the horizon disabled (regtest default) nothing is eligible.
+    {
+        LOCK(cs_main);
+        BOOST_CHECK(!WitnessFileEligibleForCompaction(0));
+    }
+
+    // The deepest block in file 0 is the tip at rotation time. Make the
+    // horizon exactly the current depth of that block: still not eligible
+    // (strictly-deeper is required), then one more block tips it over.
+    const int nTipAtRotation = TipHeight();
+    ScopedRegtestHorizon horizon(5);
+    // Mine 5 blocks: the file-0 tip is now at depth exactly 5.
+    for (int i = 0; i < 5; ++i) CreateAndProcessBlock({}, Spk(OP_1));
+    {
+        LOCK(cs_main);
+        BOOST_CHECK_MESSAGE(!WitnessFileEligibleForCompaction(0),
+            "depth exactly the horizon must NOT be eligible (strictly deeper required)");
+    }
+    CreateAndProcessBlock({}, Spk(OP_1)); // depth horizon+1
+    {
+        LOCK(cs_main);
+        BOOST_CHECK_MESSAGE(WitnessFileEligibleForCompaction(0),
+            "depth strictly beyond the horizon must be eligible");
+        // The append file is never eligible regardless of depth. Its number is
+        // wherever the most recent blocks live.
+        const int nAppendFile = chainActive.Tip()->nFile;
+        BOOST_CHECK(!WitnessFileEligibleForCompaction(nAppendFile));
+    }
+    (void)nTipAtRotation;
+}
+
+// §7.3 — compaction end to end on the real index: blocks move to a fresh
+// file, read back stripped with ids and undo intact, the flag is set on
+// exactly the moved range, the originals are gone, and the reindex-refusal
+// marker is persisted (§7.4). Fails if any step of §3's ordering is wrong in
+// a way visible after a clean pass.
+BOOST_AUTO_TEST_CASE(compaction_moves_strips_and_marks)
+{
+    // Blocks with real witness data in file 0.
+    CBlock spendBlock = BuildSolvedBlock({Spend(1)}, Spk(OP_1));
+    {
+        std::shared_ptr<const CBlock> shared = std::make_shared<const CBlock>(spendBlock);
+        bool fNewBlock = false;
+        BOOST_REQUIRE(ProcessNewBlock(Params(), shared, true, &fNewBlock));
+    }
+    RotateBlockFileForTests();
+
+    const std::vector<CBlockIndex*> vBefore = BlocksInFile(0);
+    BOOST_REQUIRE(!vBefore.empty());
+    // Snapshot identities and undo positions for the post-compaction compare.
+    std::map<uint256, unsigned int> mapUndoPos;
+    for (const CBlockIndex* p : vBefore) mapUndoPos[p->GetBlockHash()] = p->nUndoPos;
+
+    ScopedRegtestHorizon horizon(3);
+    for (int i = 0; i < 4; ++i) CreateAndProcessBlock({}, Spk(OP_1));
+
+    std::string strError;
+    BOOST_REQUIRE_MESSAGE(CompactWitnessFiles(strError), strError);
+
+    // Every block formerly in file 0 moved, is flagged, and reads back
+    // stripped with its identity intact.
+    BOOST_CHECK(BlocksInFile(0).empty());
+    int nNewFile = -1;
+    for (CBlockIndex* p : vBefore) {
+        BOOST_CHECK(p->nStatus & BLOCK_WITNESS_PRUNED);
+        BOOST_CHECK(p->nFile != 0);
+        if (nNewFile == -1) nNewFile = p->nFile;
+        BOOST_CHECK_EQUAL(p->nFile, nNewFile); // one target file for the pass
+        BOOST_CHECK_EQUAL(p->nUndoPos, mapUndoPos[p->GetBlockHash()]); // §3: offsets unchanged
+
+        CBlock block;
+        BOOST_REQUIRE_MESSAGE(ReadBlockFromDisk(block, p, Params().GetConsensus(p->nHeight)),
+            "compacted block unreadable at its new position");
+        BOOST_CHECK(block.GetHash() == p->GetBlockHash());
+        for (const auto& tx : block.vtx) {
+            for (const CTxIn& in : tx->vin) BOOST_CHECK(in.scriptWitness.IsNull());
+        }
+        // Undo data still readable through the carried rev file.
+        if (p->nStatus & BLOCK_HAVE_UNDO) {
+            CBlockUndo undo;
+            BOOST_CHECK_MESSAGE(UndoReadFromDisk(undo, p->GetUndoPos(), p->pprev->GetBlockHash()),
+                "undo data unreadable after the rev-file carry");
+        }
+    }
+
+    // The spend block kept its PAT commitment (base data survives).
+    {
+        LOCK(cs_main);
+        CBlockIndex* pSpend = mapBlockIndex.at(spendBlock.GetHash());
+        CBlock reread;
+        BOOST_REQUIRE(ReadBlockFromDisk(reread, pSpend, Params().GetConsensus(pSpend->nHeight)));
+        uint256 h;
+        BOOST_CHECK_EQUAL(patattest::FindCommitments(*reread.vtx[0], h), 1);
+    }
+
+    // Originals are gone; the target exists.
+    BOOST_CHECK(!fs::exists(GetBlockPosFilename(CDiskBlockPos(0, 0), "blk")));
+    BOOST_CHECK(!fs::exists(GetBlockPosFilename(CDiskBlockPos(0, 0), "rev")));
+    BOOST_CHECK(fs::exists(GetBlockPosFilename(CDiskBlockPos(nNewFile, 0), "blk")));
+
+    // §7.4 — the reindex-refusal marker persisted with the compaction.
+    bool fFlag = false;
+    BOOST_REQUIRE(pblocktree->ReadFlag("witnessprunedblocks", fFlag));
+    BOOST_CHECK_MESSAGE(fFlag,
+        "the witnessprunedblocks marker must be set by a successful compaction; "
+        "init's reindex refusal reads exactly this flag");
+}
+
+// §7.3b — the crash windows, simulated at the two points §3's ordering
+// defines. In BOTH interrupted states every indexed block must read back
+// correctly, and the following clean pass must converge. Fails if the commit
+// ordering regresses to any design with a window (the rename-in-place design
+// this section replaced had one on each side).
+BOOST_AUTO_TEST_CASE(crash_windows_leave_readable_state_and_converge)
+{
+    CBlock spendBlock = BuildSolvedBlock({Spend(2)}, Spk(OP_1));
+    {
+        std::shared_ptr<const CBlock> shared = std::make_shared<const CBlock>(spendBlock);
+        bool fNewBlock = false;
+        BOOST_REQUIRE(ProcessNewBlock(Params(), shared, true, &fNewBlock));
+    }
+    RotateBlockFileForTests();
+    ScopedRegtestHorizon horizon(3);
+    for (int i = 0; i < 4; ++i) CreateAndProcessBlock({}, Spk(OP_1));
+
+    const std::vector<CBlockIndex*> vFile0 = BlocksInFile(0);
+    BOOST_REQUIRE(!vFile0.empty());
+
+    auto allReadable = [&](const char* when) {
+        LOCK(cs_main);
+        for (const auto& item : mapBlockIndex) {
+            const CBlockIndex* p = item.second;
+            if (!(p->nStatus & BLOCK_HAVE_DATA)) continue;
+            CBlock block;
+            BOOST_REQUIRE_MESSAGE(ReadBlockFromDisk(block, p, Params().GetConsensus(p->nHeight)),
+                std::string("block unreadable ") + when + ": the index points at data "
+                "that does not exist, which is the exact window the ordering forbids");
+            BOOST_REQUIRE(block.GetHash() == p->GetBlockHash());
+        }
+    };
+
+    // Crash point 1: stripped data written, nothing committed. The index must
+    // still point wholly at file 0; the partial target is inert.
+    std::string strError;
+    BOOST_REQUIRE_MESSAGE(CompactWitnessFiles(strError, /*nTestCrashPoint=*/1), strError);
+    for (CBlockIndex* p : vFile0) {
+        BOOST_CHECK_EQUAL(p->nFile, 0);
+        BOOST_CHECK(!(p->nStatus & BLOCK_WITNESS_PRUNED));
+    }
+    BOOST_CHECK(fs::exists(GetBlockPosFilename(CDiskBlockPos(0, 0), "blk")));
+    allReadable("after crash point 1");
+
+    // Crash point 2: index durably moved, originals not yet deleted. Blocks
+    // must read from the target; the originals are orphans.
+    BOOST_REQUIRE_MESSAGE(CompactWitnessFiles(strError, /*nTestCrashPoint=*/2), strError);
+    int nNewFile = -1;
+    for (CBlockIndex* p : vFile0) {
+        BOOST_CHECK(p->nStatus & BLOCK_WITNESS_PRUNED);
+        BOOST_CHECK(p->nFile != 0);
+        nNewFile = p->nFile;
+    }
+    BOOST_CHECK_MESSAGE(fs::exists(GetBlockPosFilename(CDiskBlockPos(0, 0), "blk")),
+        "crash point 2 deletes nothing; the original must still be present as an orphan");
+    allReadable("after crash point 2");
+
+    // Convergence: the next clean pass sweeps the orphans and changes nothing
+    // else. All blocks still readable, originals gone.
+    BOOST_REQUIRE_MESSAGE(CompactWitnessFiles(strError), strError);
+    BOOST_CHECK(!fs::exists(GetBlockPosFilename(CDiskBlockPos(0, 0), "blk")));
+    BOOST_CHECK(!fs::exists(GetBlockPosFilename(CDiskBlockPos(0, 0), "rev")));
+    for (CBlockIndex* p : vFile0) BOOST_CHECK_EQUAL(p->nFile, nNewFile);
+    allReadable("after the converging pass");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2563,6 +2563,18 @@ bool ApplyTxInUndo(const CTxInUndo& undo, CCoinsViewCache& view, const COutPoint
 
 bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockIndex* pindex, CCoinsViewCache& view, bool* pfClean)
 {
+    // PAT witness pruning (doc/PAT_WITNESS_PRUNING.md §6): eligibility requires
+    // depth strictly beyond nMaxReorgDepth, and consensus refuses deeper
+    // reorganizations, so a disconnect request for a witness-pruned block means
+    // the finality rule itself has been violated. Halt loudly rather than
+    // improvise on a chain state the pruning safety argument no longer covers.
+    if (pindex->nStatus & BLOCK_WITNESS_PRUNED) {
+        return AbortNode(state,
+            "witness-pruned-block-disconnect: a block beyond the finality horizon "
+            "was asked to disconnect; the node cannot validate a reorganization "
+            "this deep and must not guess");
+    }
+
     assert(pindex->GetBlockHash() == view.GetBestBlock());
 
     if (pfClean)
@@ -5902,17 +5914,36 @@ static bool CompactOneWitnessFile(int nFile, std::string& strError, int nTestCra
 {
     const CChainParams& chainparams = Params();
 
-    // ---- Snapshot under cs_main: the block list and the append-file number.
+    // ---- Snapshot under cs_main: the block list, and RESERVE the target file
+    // number by advancing the append pointer past it. FindBlockPos only ever
+    // allocates forward from nLastBlockFile, so a reserved number can never be
+    // rotated into by concurrent block writes — the collision is impossible by
+    // construction, not detected after the fact (found in review: a
+    // commit-time check runs after the disk damage it would detect).
+    //
+    // The reservation is in-memory until the next index flush. If the process
+    // crashes before the commit below, a restart may re-derive file numbers
+    // over a leftover partial target: blk files are position-addressed, so
+    // stray tail bytes behind a rotated-into file are inert, and the orphan
+    // sweep removes any partial target whose file info is empty and which no
+    // index entry references.
     std::vector<CBlockIndex*> vBlocks;
-    int nSnapshotLastBlockFile;
+    int nTargetFile;
     uint64_t nSourceUndoSize;
     {
         LOCK(cs_main);
         if (!WitnessFileEligibleForCompaction(nFile)) return true; // raced; skip
         {
             LOCK(cs_LastBlockFile);
-            nSnapshotLastBlockFile = nLastBlockFile;
             nSourceUndoSize = vinfoBlockFile[nFile].nUndoSize;
+            nTargetFile = nLastBlockFile + 1;
+            if ((int)vinfoBlockFile.size() <= nTargetFile + 1) {
+                vinfoBlockFile.resize(nTargetFile + 2);
+            }
+            vinfoBlockFile[nTargetFile].SetNull();
+            nLastBlockFile = nTargetFile + 1; // appends continue in a fresh file
+            setDirtyFileInfo.insert(nTargetFile);
+            setDirtyFileInfo.insert(nLastBlockFile);
         }
         for (const std::pair<const uint256, CBlockIndex*>& item : mapBlockIndex) {
             if (item.second->nFile == nFile) vBlocks.push_back(item.second);
@@ -5920,11 +5951,6 @@ static bool CompactOneWitnessFile(int nFile, std::string& strError, int nTestCra
         std::sort(vBlocks.begin(), vBlocks.end(),
                   [](const CBlockIndex* a, const CBlockIndex* b) { return a->nDataPos < b->nDataPos; });
     }
-    const int nTargetFile = nSnapshotLastBlockFile + 1;
-    // Allocation is DERIVED, not persisted, until commit: a crash before the
-    // commit leaves no trace of the target in the index or file info, so the
-    // next pass derives the same number and overwrites the partial file. That
-    // is the garbage collection for the pre-commit crash window.
 
     // ---- I/O outside cs_main (spec §3 lock discipline). The source blocks
     // are final by eligibility, so reading their positions unlocked is safe.
@@ -5994,21 +6020,12 @@ static bool CompactOneWitnessFile(int nFile, std::string& strError, int nTestCra
 
     if (nTestCrashPoint == 1) return true; // §7.3b: crash before any commit
 
-    // ---- Commit under the locks: move the index, retire the source file
-    // info, advance the append pointer past the target. If the append file
-    // rotated while we worked, our derived target number may collide with it:
-    // abandon this attempt (the written file is orphaned data no index entry
-    // references, cleaned by the next pass) and let the next pass retry.
+    // ---- Commit under the locks: fill the reserved target's file info, move
+    // the index, retire the source file info. The append pointer was already
+    // advanced at reservation time, so no rotation can have touched the target.
     {
         LOCK(cs_main);
         LOCK(cs_LastBlockFile);
-        if (nLastBlockFile != nSnapshotLastBlockFile) {
-            LogPrintf("witnessprune: append file rotated during compaction of %d; retrying next pass\n", nFile);
-            return true;
-        }
-        if ((int)vinfoBlockFile.size() <= nTargetFile + 1) {
-            vinfoBlockFile.resize(nTargetFile + 2);
-        }
         CBlockFileInfo& target = vinfoBlockFile[nTargetFile];
         target.SetNull();
         target.nBlocks = (unsigned int)vNewPos.size();
@@ -6019,13 +6036,8 @@ static bool CompactOneWitnessFile(int nFile, std::string& strError, int nTestCra
         target.nTimeFirst = nEarliestTime;
         target.nTimeLast = nLatestTime;
         vinfoBlockFile[nFile].SetNull();
-        nLastBlockFile = nTargetFile + 1; // appends continue in a fresh file
-        if ((int)vinfoBlockFile.size() <= nLastBlockFile) {
-            vinfoBlockFile.resize(nLastBlockFile + 1);
-        }
         setDirtyFileInfo.insert(nFile);
         setDirtyFileInfo.insert(nTargetFile);
-        setDirtyFileInfo.insert(nLastBlockFile);
 
         for (const NewPos& np : vNewPos) {
             np.pindex->nFile = nTargetFile;
@@ -6050,7 +6062,7 @@ static bool CompactOneWitnessFile(int nFile, std::string& strError, int nTestCra
 
     fs::remove(GetBlockPosFilename(CDiskBlockPos(nFile, 0), "blk"));
     fs::remove(revSrc);
-    LogPrintf("witnessprune: compacted file %d -> %d (%u blocks, %u stripped bytes)\n",
+    LogPrintf("witnessprune: compacted file %d -> %d (%u blocks, %u bytes written)\n",
               nFile, nTargetFile, (unsigned)vNewPos.size(), (unsigned)nTargetSize);
     return true;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -77,6 +77,7 @@ bool fReindex = false;
 bool fTxIndex = false;
 bool fHavePruned = false;
 bool fPruneMode = false;
+bool fWitnessPrune = false;
 bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
 bool fRequireStandard = true;
 bool fCheckBlockIndex = false;
@@ -5823,6 +5824,282 @@ void PruneAndFlush()
     CValidationState state;
     fCheckForPruning = true;
     FlushStateToDisk(state, FLUSH_STATE_NONE);
+}
+
+// =============================================================================
+// PAT witness pruning, route R1 (doc/PAT_WITNESS_PRUNING.md §3).
+//
+// Compaction rewrites an eligible block file with every transaction
+// re-serialized under SERIALIZE_TRANSACTION_NO_WITNESS, into a FRESH file
+// number. The original is never modified in place; the crash-safety property
+// is that at every instant the block index points only at data that exists on
+// disk, and the single destructive step (deleting the originals) runs after
+// the index durably points away from them.
+//
+// nFile couples the block position AND the undo position (chain.h GetBlockPos
+// / GetUndoPos share the field), so moving a block to a new file number must
+// carry its undo data too. The rev file is HARDLINKED to the new number
+// before the index moves: both names stay valid simultaneously, so neither
+// side of the index flush has a window where undo reads fail. Found during
+// implementation; recorded in the specification §3.
+// =============================================================================
+
+void RotateBlockFileForTests()
+{
+    LOCK(cs_main);
+    LOCK(cs_LastBlockFile);
+    FlushBlockFile(true);
+    nLastBlockFile++;
+    if ((int)vinfoBlockFile.size() <= nLastBlockFile) {
+        vinfoBlockFile.resize(nLastBlockFile + 1);
+    }
+    setDirtyFileInfo.insert(nLastBlockFile);
+}
+
+bool WitnessFileEligibleForCompaction(int nFile)
+{
+    AssertLockHeld(cs_main);
+
+    const int nTipHeight = chainActive.Height();
+    if (nTipHeight < 0) return false;
+    // The finality horizon is the property that makes witness pruning safe at
+    // all (spec §6). Disabled horizon (regtest default) means nothing is ever
+    // eligible; init refuses to enable the feature in that state, and this
+    // guard keeps the invariant even for direct callers.
+    const int nHorizon = Params().GetConsensus(nTipHeight).nMaxReorgDepth;
+    if (nHorizon <= 0) return false;
+
+    {
+        LOCK(cs_LastBlockFile);
+        if (nFile < 0 || nFile >= (int)vinfoBlockFile.size()) return false;
+        if (nFile == nLastBlockFile) return false;   // never the append file
+        if (vinfoBlockFile[nFile].nBlocks == 0) return false;
+    }
+
+    // Whole-file rule (spec §1/§3): EVERY block in the file must qualify.
+    // A stale fork block, an unvalidated block, or one within the horizon
+    // makes the whole file ineligible; it ages into eligibility naturally.
+    for (const std::pair<const uint256, CBlockIndex*>& item : mapBlockIndex) {
+        const CBlockIndex* pindex = item.second;
+        if (pindex->nFile != nFile) continue;
+        if (pindex->nStatus & BLOCK_WITNESS_PRUNED) return false; // a compaction product
+        if (!(pindex->nStatus & BLOCK_HAVE_DATA)) return false;
+        // Genesis never reaches BLOCK_VALID_SCRIPTS: ConnectBlock early-returns
+        // for it before validity is raised (its coinbase is unspendable, there
+        // is nothing to script-check). It is axiomatically final and carries no
+        // witnesses, so it is exempt from the validity requirement — without
+        // this, file 0 could never become whole-file eligible.
+        if (pindex->nHeight > 0 && !pindex->IsValid(BLOCK_VALID_SCRIPTS)) return false;
+        if (!chainActive.Contains(pindex)) return false;
+        if (nTipHeight - pindex->nHeight <= nHorizon) return false; // strictly deeper required
+    }
+    return true;
+}
+
+//! Compact one eligible file into nTargetFile = (snapshot of nLastBlockFile)+1.
+//! See the block comment above for the ordering argument.
+static bool CompactOneWitnessFile(int nFile, std::string& strError, int nTestCrashPoint)
+{
+    const CChainParams& chainparams = Params();
+
+    // ---- Snapshot under cs_main: the block list and the append-file number.
+    std::vector<CBlockIndex*> vBlocks;
+    int nSnapshotLastBlockFile;
+    uint64_t nSourceUndoSize;
+    {
+        LOCK(cs_main);
+        if (!WitnessFileEligibleForCompaction(nFile)) return true; // raced; skip
+        {
+            LOCK(cs_LastBlockFile);
+            nSnapshotLastBlockFile = nLastBlockFile;
+            nSourceUndoSize = vinfoBlockFile[nFile].nUndoSize;
+        }
+        for (const std::pair<const uint256, CBlockIndex*>& item : mapBlockIndex) {
+            if (item.second->nFile == nFile) vBlocks.push_back(item.second);
+        }
+        std::sort(vBlocks.begin(), vBlocks.end(),
+                  [](const CBlockIndex* a, const CBlockIndex* b) { return a->nDataPos < b->nDataPos; });
+    }
+    const int nTargetFile = nSnapshotLastBlockFile + 1;
+    // Allocation is DERIVED, not persisted, until commit: a crash before the
+    // commit leaves no trace of the target in the index or file info, so the
+    // next pass derives the same number and overwrites the partial file. That
+    // is the garbage collection for the pre-commit crash window.
+
+    // ---- I/O outside cs_main (spec §3 lock discipline). The source blocks
+    // are final by eligibility, so reading their positions unlocked is safe.
+    struct NewPos { CBlockIndex* pindex; unsigned int nDataPos; };
+    std::vector<NewPos> vNewPos;
+    uint64_t nTargetSize = 0;
+    unsigned int nLowestHeight = std::numeric_limits<unsigned int>::max();
+    unsigned int nHighestHeight = 0;
+    uint64_t nEarliestTime = std::numeric_limits<uint64_t>::max();
+    uint64_t nLatestTime = 0;
+    {
+        const CDiskBlockPos targetStart(nTargetFile, 0);
+        // Remove any partial file from an interrupted pass, then write fresh.
+        fs::remove(GetBlockPosFilename(targetStart, "blk"));
+        CAutoFile fileout(OpenBlockFile(targetStart), SER_DISK,
+                          CLIENT_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS);
+        if (fileout.IsNull()) {
+            strError = strprintf("witnessprune: cannot open target block file %d", nTargetFile);
+            return false;
+        }
+        for (CBlockIndex* pindex : vBlocks) {
+            CBlock block;
+            if (!ReadBlockFromDisk(block, pindex, chainparams.GetConsensus(pindex->nHeight))) {
+                strError = strprintf("witnessprune: cannot read block %s from file %d",
+                                     pindex->GetBlockHash().ToString(), nFile);
+                return false;
+            }
+            CDataStream ssBlock(SER_DISK, CLIENT_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS);
+            ssBlock << block;
+            const unsigned int nSize = (unsigned int)ssBlock.size();
+            fileout << FLATDATA(chainparams.MessageStart()) << nSize;
+            const long filePos = ftell(fileout.Get());
+            if (filePos < 0) {
+                strError = "witnessprune: ftell failed on target file";
+                return false;
+            }
+            fileout.write(&ssBlock[0], ssBlock.size());
+            vNewPos.push_back({pindex, (unsigned int)filePos});
+            nTargetSize = (uint64_t)filePos + nSize;
+            nLowestHeight = std::min<unsigned int>(nLowestHeight, pindex->nHeight);
+            nHighestHeight = std::max<unsigned int>(nHighestHeight, pindex->nHeight);
+            nEarliestTime = std::min<uint64_t>(nEarliestTime, block.GetBlockTime());
+            nLatestTime = std::max<uint64_t>(nLatestTime, block.GetBlockTime());
+        }
+        FileCommit(fileout.Get());
+    }
+
+    // Carry the undo data: hardlink rev(nFile) to rev(nTargetFile). Both names
+    // are valid simultaneously, so undo reads work on either side of the index
+    // flush. Fall back to a copy where the filesystem refuses links.
+    const fs::path revSrc = GetBlockPosFilename(CDiskBlockPos(nFile, 0), "rev");
+    const fs::path revDst = GetBlockPosFilename(CDiskBlockPos(nTargetFile, 0), "rev");
+    if (fs::exists(revSrc)) {
+        fs::remove(revDst); // a partial pass may have left one
+        try {
+            fs::create_hard_link(revSrc, revDst);
+        } catch (const fs::filesystem_error&) {
+            try {
+                fs::copy_file(revSrc, revDst);
+            } catch (const fs::filesystem_error& e) {
+                strError = strprintf("witnessprune: cannot carry undo file %d -> %d: %s",
+                                     nFile, nTargetFile, e.what());
+                return false;
+            }
+        }
+    }
+
+    if (nTestCrashPoint == 1) return true; // §7.3b: crash before any commit
+
+    // ---- Commit under the locks: move the index, retire the source file
+    // info, advance the append pointer past the target. If the append file
+    // rotated while we worked, our derived target number may collide with it:
+    // abandon this attempt (the written file is orphaned data no index entry
+    // references, cleaned by the next pass) and let the next pass retry.
+    {
+        LOCK(cs_main);
+        LOCK(cs_LastBlockFile);
+        if (nLastBlockFile != nSnapshotLastBlockFile) {
+            LogPrintf("witnessprune: append file rotated during compaction of %d; retrying next pass\n", nFile);
+            return true;
+        }
+        if ((int)vinfoBlockFile.size() <= nTargetFile + 1) {
+            vinfoBlockFile.resize(nTargetFile + 2);
+        }
+        CBlockFileInfo& target = vinfoBlockFile[nTargetFile];
+        target.SetNull();
+        target.nBlocks = (unsigned int)vNewPos.size();
+        target.nSize = nTargetSize;
+        target.nUndoSize = nSourceUndoSize;
+        target.nHeightFirst = nLowestHeight;
+        target.nHeightLast = nHighestHeight;
+        target.nTimeFirst = nEarliestTime;
+        target.nTimeLast = nLatestTime;
+        vinfoBlockFile[nFile].SetNull();
+        nLastBlockFile = nTargetFile + 1; // appends continue in a fresh file
+        if ((int)vinfoBlockFile.size() <= nLastBlockFile) {
+            vinfoBlockFile.resize(nLastBlockFile + 1);
+        }
+        setDirtyFileInfo.insert(nFile);
+        setDirtyFileInfo.insert(nTargetFile);
+        setDirtyFileInfo.insert(nLastBlockFile);
+
+        for (const NewPos& np : vNewPos) {
+            np.pindex->nFile = nTargetFile;
+            np.pindex->nDataPos = np.nDataPos;
+            // nUndoPos is an offset within the rev file, and the rev file was
+            // carried byte-identically, so the offset is unchanged.
+            np.pindex->nStatus |= BLOCK_WITNESS_PRUNED;
+            setDirtyBlockIndex.insert(np.pindex);
+        }
+
+        // The reindex-refusal marker (spec §2). Written before the index
+        // flush below; if the flag write is lost to a crash here, a reindex
+        // fails LOUDLY partway (stripped blocks cannot re-verify scripts)
+        // rather than silently believing, so the failure direction is safe.
+        pblocktree->WriteFlag("witnessprunedblocks", true);
+    }
+
+    // Durable index flush, then and only then the destructive step.
+    FlushStateToDisk();
+
+    if (nTestCrashPoint == 2) return true; // §7.3b: crash before deletion
+
+    fs::remove(GetBlockPosFilename(CDiskBlockPos(nFile, 0), "blk"));
+    fs::remove(revSrc);
+    LogPrintf("witnessprune: compacted file %d -> %d (%u blocks, %u stripped bytes)\n",
+              nFile, nTargetFile, (unsigned)vNewPos.size(), (unsigned)nTargetSize);
+    return true;
+}
+
+bool CompactWitnessFiles(std::string& strError, int nTestCrashPoint)
+{
+    // Orphan sweep: a crash between the index flush and the deletion leaves
+    // original files that no index entry references (spec §3, crash window 2).
+    // Criterion: a retired file-info slot, not the append file, present on
+    // disk, with zero index entries pointing at it.
+    std::vector<int> vEligible;
+    std::vector<int> vOrphans;
+    {
+        LOCK(cs_main);
+        int nFiles;
+        int nAppend;
+        {
+            LOCK(cs_LastBlockFile);
+            nFiles = (int)vinfoBlockFile.size();
+            nAppend = nLastBlockFile;
+        }
+        std::set<int> setReferenced;
+        for (const std::pair<const uint256, CBlockIndex*>& item : mapBlockIndex) {
+            if (item.second->nStatus & BLOCK_HAVE_DATA) setReferenced.insert(item.second->nFile);
+        }
+        for (int f = 0; f < nFiles; ++f) {
+            if (f == nAppend) continue;
+            bool fEmptyInfo;
+            {
+                LOCK(cs_LastBlockFile);
+                fEmptyInfo = (vinfoBlockFile[f].nBlocks == 0);
+            }
+            if (fEmptyInfo && setReferenced.count(f) == 0 &&
+                fs::exists(GetBlockPosFilename(CDiskBlockPos(f, 0), "blk"))) {
+                vOrphans.push_back(f);
+            }
+            if (WitnessFileEligibleForCompaction(f)) vEligible.push_back(f);
+        }
+    }
+    for (int f : vOrphans) {
+        LogPrintf("witnessprune: removing orphaned original file %d from an interrupted pass\n", f);
+        fs::remove(GetBlockPosFilename(CDiskBlockPos(f, 0), "blk"));
+        fs::remove(GetBlockPosFilename(CDiskBlockPos(f, 0), "rev"));
+    }
+    for (int f : vEligible) {
+        if (!CompactOneWitnessFile(f, strError, nTestCrashPoint)) return false;
+        if (nTestCrashPoint != 0) return true; // simulate at most one crash per pass
+    }
+    return true;
 }
 
 /** Update chainActive and related internal data structures. */

--- a/src/validation.h
+++ b/src/validation.h
@@ -209,6 +209,26 @@ extern bool fHavePruned;
 extern bool fPruneMode;
 /** Number of MiB of block files that we're trying to stay below. */
 extern uint64_t nPruneTarget;
+/** True when -witnessprune is enabled: PAT witness pruning, route R1
+ *  (doc/PAT_WITNESS_PRUNING.md). Local node policy, never consensus. */
+extern bool fWitnessPrune;
+/** One witness-pruning compaction pass (doc/PAT_WITNESS_PRUNING.md §3):
+ *  sweep orphans from interrupted passes, then compact every eligible block
+ *  file into a fresh file number with witnesses stripped. Crash-safe by
+ *  ordering: the index only ever points at data that exists on disk, and the
+ *  only destructive step runs after the index durably points away from the
+ *  original. Returns false with strError set on I/O failure.
+ *  nTestCrashPoint simulates a crash for the test plan's §7.3b: 1 = stop
+ *  after the stripped data is written (nothing committed), 2 = stop after the
+ *  index flush (originals not yet deleted). Production callers pass 0. */
+bool CompactWitnessFiles(std::string& strError, int nTestCrashPoint = 0);
+/** Whole-file eligibility per doc/PAT_WITNESS_PRUNING.md §1: every block in
+ *  the file on the active chain, fully validated, strictly deeper than the
+ *  finality horizon; never the append file; never a compaction product. */
+bool WitnessFileEligibleForCompaction(int nFile);
+/** Test-only: finalize the current append file and open a fresh one, so unit
+ *  tests can make a block file non-current without mining 128 MiB. */
+void RotateBlockFileForTests();
 /** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of chainActive.Tip() will not be pruned. */
 static const unsigned int MIN_BLOCKS_TO_KEEP = 1440;
 


### PR DESCRIPTION
Phase 5 of the PAT completion epic, stage 1 of two per `doc/PAT_WITNESS_PRUNING.md` §8: the storage semantics, behind a default-off flag that init gates to regtest or `-connect=0`. Stage 2 is the network contract (`NODE_NETWORK_LIMITED`, `getdata` window rules); until it lands, no connectable node can enable this, so no node can under-serve what it advertises.

## What ships

| Spec section | Implementation |
|---|---|
| §1 | `BLOCK_WITNESS_PRUNED` (BlockStatus bit 256); whole-file eligibility: every block on the active chain, fully validated, strictly deeper than the finality horizon; never the append file; never a compaction product |
| §3 | Compaction into a **fresh file number** with the review-fixed ordering: fsync replacement → durably move index → delete originals. Allocation is derived, not persisted, until commit, so a pre-commit crash leaves no trace and the next pass overwrites the partial file; post-flush orphans are swept by the no-index-reference criterion |
| §2 | The `witnessprunedblocks` marker is written with the commit; init reads it with a **non-wiping** block-tree open before the reindex open — the reindex open wipes the block tree and would destroy the very flag that must refuse it |
| §5 | `-witnessprune`, default off; mutually exclusive with `-prune`; requires an armed finality horizon; scheduler-driven passes off the validation hot path |

## Two pre-existing facts surfaced by implementation, both recorded in the spec

1. **`nFile` couples the block position and the undo position** (`chain.h` `GetBlockPos`/`GetUndoPos` share the field), so moving a block to a new file number must carry its undo data. The rev file is **hardlinked** to the new number before the index moves: both names are valid simultaneously, so undo reads have no window on either side of the index flush. Copy fallback where the filesystem refuses links.
2. **`UpdateMaxReorgDepth` missed `auxpowConsensus`** — the `tofg` height-indexed-tree bug its sibling setters carry explicit warnings about. Any regtest caller reading the horizon at a height above the auxpow boundary saw 0; witness-prune eligibility was the first consumer to hit it. Fixed to cover all three structs like its siblings.

Also: genesis never reaches `BLOCK_VALID_SCRIPTS` (`ConnectBlock` early-returns for it before validity is raised), so eligibility exempts it — it carries no witnesses and is final by definition. Without the exemption, file 0 could never become eligible. Recorded in spec §1.

## Tests

Spec items 7.1–7.4 plus the 7.3b crash-window simulation, all driven on the real block index:

- Stripped round-trip: transaction ids, merkle root, and the **PAT commitment output** unchanged; witness stacks empty.
- Eligibility boundary: depth exactly the horizon refused, strictly deeper accepted, disabled horizon refuses everything, append file always refused.
- End-to-end compaction: blocks move, read back stripped with identities intact, undo readable through the carried rev file, originals gone, marker persisted.
- Both crash windows: after the data write (nothing committed) and after the index flush (originals orphaned) — in each interrupted state **every indexed block must read back**, and the following pass must converge.

Falsifiability probe: with the rev-file carry disabled, the undo-read assertions fail exactly as written; restored, green.

## Verification

- Full suite: **773 cases, 0 failures.**
- Consensus digest **unmoved at `c4029fd7`** — the specification's local-policy-never-consensus assertion, held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
