### PR TITLE
node: PAT witness pruning stage 2, the network service contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,8 @@ jobs:
       - name: Run functional tests (Soqucoin-specific)
         run: |
           python3 qa/pull-tester/rpc-tests.py \
-            auxpow.py latticefold_basic.py pat_basic.py
+            auxpow.py latticefold_basic.py pat_basic.py \
+            witness-prune-serving.py witness-prune-ibd.py
 
   # ============================================
   # Linux ARM64 (cross-compile)

--- a/doc/PAT_WITNESS_PRUNING.md
+++ b/doc/PAT_WITNESS_PRUNING.md
@@ -1,7 +1,8 @@
 # PAT witness pruning — specification (route R1)
 
-**Status:** SPECIFICATION, pre-implementation. Phase 5 of the PAT completion
-epic (`pat-completion-epic-xlab`), ruled route **R1** (compaction rewrite) on
+**Status:** IMPLEMENTED (stage 1: storage semantics, PR #71; stage 2: network
+contract, this document's §4). Phase 5 of the PAT completion epic
+(`pat-completion-epic-xlab`), ruled route **R1** (compaction rewrite) on
 2026-08-31; route R2 (split witness storage) is a post-launch migration once R1
 proves the semantics.
 
@@ -95,7 +96,12 @@ in place, which is what removes the crash window entirely:
    no index entry references.
 2. Update every affected `CBlockIndex` entry (`nFile` = *m*, new `nDataPos`,
    `BLOCK_WITNESS_PRUNED`) and the `CBlockFileInfo` records, and flush the
-   block index durably.
+   block index durably. Because `nFile` addresses a block's undo data as well
+   as its block data (`GetBlockPos`/`GetUndoPos` share the field), the `rev`
+   file is **hardlinked** to the new number before the index moves — both
+   names are valid simultaneously, so undo reads have no window on either side
+   of the flush (copy fallback where the filesystem refuses links). Found in
+   stage-1 implementation.
 3. Delete file *n*, only after step 2 has succeeded.
 
 Crash analysis, the property this ordering is chosen for: **at every instant
@@ -170,7 +176,17 @@ A node with witness pruning enabled:
   data exists locally. Serving base-only blocks to a peer that will attempt
   script validation manufactures the silent-break failure mode; the stripped
   data is for this node's own RPC and audit trail, not for relay. This matches
-  the BIP159 contract peers already understand.
+  the BIP159 contract peers already understand. The implementation refuses all
+  four block `getdata` types beyond the window (`MSG_FILTERED_BLOCK` and
+  `MSG_CMPCT_BLOCK` included: the compact path falls back to a full block send
+  for old blocks, which would be the stripped block), and it decides by depth
+  alone, not by whether the block happens to be compacted yet — the window
+  must be deterministic to peers, and compaction is whole-file and lazy.
+- On the requesting side, this node never asks a limited peer for a block
+  deeper than the horizon **minus a two-block margin** below that peer's
+  best-known tip: the peer's live tip may be ahead of our view of it, which
+  shrinks its servable window from under a request measured against the stale
+  view.
 - Headers service is unaffected; headers are never pruned.
 
 Fleet, pool, and seed nodes run unpruned. Witness pruning is for operators who
@@ -237,7 +253,15 @@ must halt loudly rather than improvise.
   plus functional tests 5–6 and the digest assertion. The feature is not
   enableable on a network-connected node until stage 2 lands; stage 1 gates
   `-witnessprune` behind `-connect=0`/regtest so the storage semantics can
-  soak without a node ever under-serving what it advertises.
+  soak without a node ever under-serving what it advertises. Stage 2 removes
+  that gate: it exists only because the network contract was missing.
+
+Outbound peer selection deliberately keeps requiring `NODE_NETWORK`
+(`REQUIRED_SERVICES`, and the DNS-seed filter): limited peers serve inbound
+requests and within-window fetches, but a fresh node must never fill its
+outbound slots with peers that cannot serve its initial sync. Relaxing this
+post-launch (dialling limited peers once out of IBD, as later upstream
+versions do) is a possible follow-up, not part of the contract.
 
 ---
 

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -116,6 +116,8 @@ testScripts = [
     'genesis-migration.py',
     'mining-gate.py',
     'pat-commitment.py',
+    'witness-prune-serving.py',
+    'witness-prune-ibd.py',
     'getauxblock.py',
     'wallet.py',
     'wallet-accounts.py',

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -1565,6 +1565,7 @@ class NodeConnCB(object):
         if conn.ver_send > BIP0031_VERSION:
             conn.send_message(msg_pong(message.nonce))
     def on_reject(self, conn, message): pass
+    def on_notfound(self, conn, message): pass
     def on_open(self, conn): pass
     def on_close(self, conn): pass
     def on_mempool(self, conn): pass
@@ -1632,7 +1633,8 @@ class NodeConn(asyncore.dispatcher):
         b"sendcmpct": msg_sendcmpct,
         b"cmpctblock": msg_cmpctblock,
         b"getblocktxn": msg_getblocktxn,
-        b"blocktxn": msg_blocktxn
+        b"blocktxn": msg_blocktxn,
+        b"notfound": msg_notfound
     }
     MAGIC_BYTES = {
         "mainnet": b"\xc0\xc0\xc0\xc0",   # mainnet

--- a/qa/rpc-tests/witness-prune-ibd.py
+++ b/qa/rpc-tests/witness-prune-ibd.py
@@ -14,9 +14,16 @@ which the limited peer answers with notfound.
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    connect_nodes_bi,
+    p2p_port,
+    start_node,
+    sync_blocks,
+)
 
 NODE_NETWORK = 1 << 0
+NODE_WITNESS = 1 << 3
 NODE_NETWORK_LIMITED = 1 << 10
 
 HORIZON = 10
@@ -61,6 +68,7 @@ class WitnessPruneIBDTest(BitcoinTestFramework):
         for p in limited_peers:
             services = int(p['services'], 16)
             assert(services & NODE_NETWORK_LIMITED)
+            assert(services & NODE_WITNESS)
             assert(not (services & NODE_NETWORK))
 
         # The IBD must complete; a wrong request path stalls here on blocks

--- a/qa/rpc-tests/witness-prune-ibd.py
+++ b/qa/rpc-tests/witness-prune-ibd.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Soqucoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+PAT witness pruning, stage 2: sync-from-unpruned (doc/PAT_WITNESS_PRUNING.md
+test plan item 6).
+
+A fresh node performs IBD with both an unpruned peer and a witness-pruned
+(NODE_NETWORK_LIMITED) peer connected, and completes. The limited peer is
+connected first so that a wrong peer-selection or block-request path would
+prefer it and stall the sync: most of the chain is deeper than the horizon,
+which the limited peer answers with notfound.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+NODE_NETWORK = 1 << 0
+NODE_NETWORK_LIMITED = 1 << 10
+
+HORIZON = 10
+CHAIN_LENGTH = 40
+
+
+class WitnessPruneIBDTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+
+    def setup_network(self, split=False):
+        # node 0: unpruned. node 1: witness-pruned. node 2 starts in run_test
+        # so that its whole life is an IBD against the two of them.
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir,
+            ["-maxreorgdepth=%d" % HORIZON]))
+        self.nodes.append(start_node(1, self.options.tmpdir,
+            ["-maxreorgdepth=%d" % HORIZON, "-witnessprune=1"]))
+        connect_nodes_bi(self.nodes, 0, 1)
+        self.is_network_split = False
+
+    def run_test(self):
+        self.nodes[0].generate(CHAIN_LENGTH)
+        sync_blocks(self.nodes)
+        best_hash = self.nodes[0].getbestblockhash()
+        assert_equal(self.nodes[1].getbestblockhash(), best_hash)
+
+        # Fresh node, limited peer connected first.
+        self.nodes.append(start_node(2, self.options.tmpdir,
+            ["-maxreorgdepth=%d" % HORIZON]))
+        connect_nodes_bi(self.nodes, 2, 1)
+        connect_nodes_bi(self.nodes, 2, 0)
+
+        # The pruned peer must be advertising limited, not full, service to
+        # the syncing node — otherwise this test proves nothing.
+        limited_peers = [p for p in self.nodes[2].getpeerinfo()
+                         if "%d" % p2p_port(1) in p['addr']]
+        assert(len(limited_peers) > 0)
+        for p in limited_peers:
+            services = int(p['services'], 16)
+            assert(services & NODE_NETWORK_LIMITED)
+            assert(not (services & NODE_NETWORK))
+
+        # The IBD must complete; a wrong request path stalls here on blocks
+        # the limited peer answers with notfound.
+        sync_blocks(self.nodes, timeout=120)
+        assert_equal(self.nodes[2].getbestblockhash(), best_hash)
+
+        # Steady state with a limited peer connected still works.
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+        assert_equal(self.nodes[2].getblockcount(), CHAIN_LENGTH + 1)
+        assert_equal(self.nodes[1].getblockcount(), CHAIN_LENGTH + 1)
+
+
+if __name__ == '__main__':
+    WitnessPruneIBDTest().main()

--- a/qa/rpc-tests/witness-prune-serving.py
+++ b/qa/rpc-tests/witness-prune-serving.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Soqucoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+PAT witness pruning, stage 2: the serving rules (doc/PAT_WITNESS_PRUNING.md
+test plan item 5).
+
+A node running -witnessprune must:
+- advertise NODE_NETWORK_LIMITED and NODE_WITNESS, and not NODE_NETWORK;
+- serve getdata for blocks within the finality horizon normally, for both
+  MSG_BLOCK and MSG_WITNESS_BLOCK;
+- answer getdata for blocks beyond the horizon with notfound for both message
+  types, even though the (possibly still uncompacted) base data exists locally.
+
+The window rule is enforced from the node's own state, not the compaction
+schedule, so this test needs no compaction to have happened: depth alone
+decides.
+"""
+
+from collections import defaultdict
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.mininode import *
+
+NODE_NETWORK = 1 << 0
+NODE_WITNESS = 1 << 3
+NODE_NETWORK_LIMITED = 1 << 10
+
+HORIZON = 10
+CHAIN_LENGTH = 30
+
+
+class ServingTestNode(SingleNodeConnCB):
+    def __init__(self):
+        SingleNodeConnCB.__init__(self)
+        self.blocks = defaultdict(int)      # sha256 -> times received
+        self.notfound = set()               # (inv type, hash) answered notfound
+        self.lastpong = 0
+        self.nonce = 4919
+
+    def add_connection(self, conn):
+        self.connection = conn
+
+    def on_block(self, conn, message):
+        message.block.calc_sha256()
+        self.blocks[message.block.sha256] += 1
+
+    def on_notfound(self, conn, message):
+        for inv in message.vec:
+            self.notfound.add((inv.type, inv.hash))
+
+    def on_pong(self, conn, message):
+        self.lastpong = message.nonce
+
+    # A ping round-trip after a getdata proves the getdata was fully
+    # processed: any block or notfound it was going to produce has been sent.
+    def ping(self):
+        self.nonce += 1
+        self.connection.send_message(msg_ping(self.nonce))
+        def pong_received():
+            return self.lastpong == self.nonce
+        return wait_until(pong_received, timeout=10)
+
+    def getdata(self, inv_type, block_hash):
+        req = msg_getdata()
+        req.inv.append(CInv(t=inv_type, h=block_hash))
+        self.connection.send_message(req)
+        assert(self.ping())
+
+
+class WitnessPruneServingTest(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self, split=False):
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir,
+            ["-witnessprune=1", "-maxreorgdepth=%d" % HORIZON]))
+
+    def run_test(self):
+        node = self.nodes[0]
+        node.generate(CHAIN_LENGTH)
+        tip_height = node.getblockcount()
+        assert_equal(tip_height, CHAIN_LENGTH)
+
+        # Service bits: limited and witness advertised, full service not.
+        localservices = int(node.getnetworkinfo()['localservices'], 16)
+        assert(localservices & NODE_NETWORK_LIMITED)
+        assert(localservices & NODE_WITNESS)
+        assert(not (localservices & NODE_NETWORK))
+
+        self.testnode = ServingTestNode()
+        conn = NodeConn('127.0.0.1', p2p_port(0), node, self.testnode)
+        self.testnode.add_connection(conn)
+        NetworkThread().start()
+        self.testnode.wait_for_verack()
+
+        # The version handshake must carry the same honest bits.
+        assert(conn.nServices & NODE_NETWORK_LIMITED)
+        assert(not (conn.nServices & NODE_NETWORK))
+
+        MSG_BLOCK_INV = 2
+        MSG_WITNESS_BLOCK_INV = 2 | MSG_WITNESS_FLAG
+
+        def block_hash_at(height):
+            return int(node.getblockhash(height), 16)
+
+        # Within the window: the tip and the boundary block (depth exactly
+        # HORIZON) are served, for both message types.
+        for height in (tip_height, tip_height - HORIZON):
+            for inv_type in (MSG_BLOCK_INV, MSG_WITNESS_BLOCK_INV):
+                h = block_hash_at(height)
+                served_before = self.testnode.blocks[h]
+                self.testnode.getdata(inv_type, h)
+                assert_equal(self.testnode.blocks[h], served_before + 1)
+                assert((inv_type, h) not in self.testnode.notfound)
+
+        # Beyond the window (depth HORIZON + 1 and deeper): notfound for both
+        # message types, and no block message.
+        for height in (tip_height - HORIZON - 1, 1):
+            for inv_type in (MSG_BLOCK_INV, MSG_WITNESS_BLOCK_INV):
+                h = block_hash_at(height)
+                self.testnode.getdata(inv_type, h)
+                assert((inv_type, h) in self.testnode.notfound)
+                assert_equal(self.testnode.blocks[h], 0)
+
+        # The window follows the tip: mine one block and the old boundary
+        # block falls out of the servable set.
+        old_boundary = block_hash_at(tip_height - HORIZON)
+        node.generate(1)
+        self.testnode.getdata(MSG_BLOCK_INV, old_boundary)
+        assert((MSG_BLOCK_INV, old_boundary) in self.testnode.notfound)
+
+
+if __name__ == '__main__':
+    WitnessPruneServingTest().main()

--- a/qa/rpc-tests/witness-prune-serving.py
+++ b/qa/rpc-tests/witness-prune-serving.py
@@ -21,8 +21,17 @@ decides.
 from collections import defaultdict
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from test_framework.mininode import *
+from test_framework.util import assert_equal, p2p_port, start_node
+from test_framework.mininode import (
+    CInv,
+    MSG_WITNESS_FLAG,
+    NetworkThread,
+    NodeConn,
+    SingleNodeConnCB,
+    msg_getdata,
+    msg_ping,
+    wait_until,
+)
 
 NODE_NETWORK = 1 << 0
 NODE_WITNESS = 1 << 3
@@ -102,6 +111,7 @@ class WitnessPruneServingTest(BitcoinTestFramework):
 
         # The version handshake must carry the same honest bits.
         assert(conn.nServices & NODE_NETWORK_LIMITED)
+        assert(conn.nServices & NODE_WITNESS)
         assert(not (conn.nServices & NODE_NETWORK))
 
         MSG_BLOCK_INV = 2

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -368,7 +368,7 @@ std::string HelpMessage(HelpMessageMode mode)
                                                          "Warning: Reverting this setting requires re-downloading the entire blockchain. "
                                                          "(default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, >%u = automatically prune block files to stay under the specified target size in MiB)"),
                                                  MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024));
-    strUsage += HelpMessageOpt("-witnessprune", strprintf(_("Discard raw witness data (signatures) of blocks deeper than the finality horizon, keeping all base data and the PAT block attestation (doc/PAT_WITNESS_PRUNING.md). Incompatible with -prune. -reindex is refused once enabled; reverting requires re-downloading the chain. Stage 1: regtest or -connect=0 only. (default: %u)"), 0));
+    strUsage += HelpMessageOpt("-witnessprune", strprintf(_("Discard raw witness data (signatures) of blocks deeper than the finality horizon, keeping all base data and the PAT block attestation (doc/PAT_WITNESS_PRUNING.md). Incompatible with -prune. -reindex is refused once enabled; reverting requires re-downloading the chain. The node advertises NODE_NETWORK_LIMITED instead of NODE_NETWORK and serves no block deeper than the horizon. (default: %u)"), 0));
     strUsage += HelpMessageOpt("-reindex-chainstate", _("Rebuild chain state from the currently indexed blocks"));
     strUsage += HelpMessageOpt("-reindex", _("Rebuild chain state and block index from the blk*.dat files on disk"));
 #ifndef WIN32
@@ -1195,18 +1195,6 @@ bool AppInitParameterInteraction()
     }
 
     if (fWitnessPrune) {
-        // Stage 1 (doc/PAT_WITNESS_PRUNING.md §8): storage semantics only. The
-        // network contract (NODE_NETWORK_LIMITED, getdata window rules) is not
-        // implemented yet, so a connected node running this would under-serve
-        // what it advertises — the exact failure the specification forbids.
-        const bool fDisconnected = IsArgSet("-connect") &&
-            mapMultiArgs.count("-connect") &&
-            mapMultiArgs.at("-connect").size() == 1 &&
-            mapMultiArgs.at("-connect")[0] == "0";
-        if (!chainparams.MineBlocksOnDemand() && !fDisconnected) {
-            return InitError(_("-witnessprune is stage 1: regtest or -connect=0 only, "
-                               "until the network service contract lands (doc/PAT_WITNESS_PRUNING.md §8)."));
-        }
         // The finality horizon is what makes witness pruning safe at all
         // (spec §6). With the horizon disabled nothing is ever eligible and
         // the flag would be a silent no-op; refuse instead.
@@ -1911,9 +1899,12 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
 
     if (fWitnessPrune) {
-        // Stage 1 runs disconnected (regtest / -connect=0, enforced above), so
-        // no service-bit change is needed yet; that is stage 2 with the rest
-        // of the network contract (doc/PAT_WITNESS_PRUNING.md §4, §8).
+        // Network contract (doc/PAT_WITNESS_PRUNING.md §4): advertise limited
+        // service honestly. Everything within the finality horizon is stored
+        // and served in full (NODE_WITNESS stays set below); nothing beyond it
+        // is served at all, so NODE_NETWORK would be a lie.
+        LogPrintf("Unsetting NODE_NETWORK, setting NODE_NETWORK_LIMITED on witness prune mode\n");
+        nLocalServices = ServiceFlags((nLocalServices & ~NODE_NETWORK) | NODE_NETWORK_LIMITED);
         // Compaction runs off the validation hot path on the scheduler, same
         // cadence class as the flush-driven prune above.
         scheduler.scheduleEvery([]() {
@@ -1922,7 +1913,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 LogPrintf("witnessprune: compaction pass failed: %s\n", strError);
             }
         }, 600);
-        LogPrintf("Witness pruning enabled (stage 1; doc/PAT_WITNESS_PRUNING.md)\n");
+        LogPrintf("Witness pruning enabled (doc/PAT_WITNESS_PRUNING.md)\n");
     }
 
     if (chainparams.GetConsensus(0).vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout != 0) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1595,6 +1595,9 @@ void MapPort(bool)
 static std::string GetDNSHost(const CDNSSeedData& data, ServiceFlags* requiredServiceBits)
 {
     //use default host for non-filter-capable seeds or if we use the default service bits (NODE_NETWORK)
+    //note: witness-pruned (NODE_NETWORK_LIMITED) nodes never match this filter,
+    //deliberately — seeds must only hand out peers that can serve a full sync
+    //(doc/PAT_WITNESS_PRUNING.md §4)
     if (!data.supportsServiceBitsFiltering || *requiredServiceBits == NODE_NETWORK) {
         *requiredServiceBits = NODE_NETWORK;
         return data.host;

--- a/src/net.h
+++ b/src/net.h
@@ -86,6 +86,11 @@ static const bool DEFAULT_FORCEDNSSEED = false;
 static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;
 static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 
+// NODE_NETWORK_LIMITED peers are deliberately never selected for outbound
+// connections (here and in the DNS-seed filter): a fresh node that fills its
+// outbound slots with limited peers cannot complete its initial sync
+// (doc/PAT_WITNESS_PRUNING.md §4). Limited peers still serve us inbound, and
+// the block-request logic knows their window.
 static const ServiceFlags REQUIRED_SERVICES = NODE_NETWORK;
 
 // NOTE: When adjusting this, update rpcnet:setban's help ("24h")
@@ -607,7 +612,7 @@ public:
     bool fFeeler; // If true this node is being used as a short lived feeler.
     bool fOneShot;
     bool fAddnode;
-    bool fClient;
+    bool fClient; // set to true when the peer offers neither NODE_NETWORK nor NODE_NETWORK_LIMITED
     const bool fInbound;
     std::atomic_bool fSuccessfullyConnected;
     std::atomic_bool fDisconnect;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -216,6 +216,9 @@ struct CNodeState {
     bool fProvidesHeaderAndIDs;
     //! Whether this peer can give us witnesses
     bool fHaveWitness;
+    //! Whether this peer is a NODE_NETWORK_LIMITED peer (BIP159): serves only
+    //! blocks within the finality horizon of its tip, never a deep sync.
+    bool fLimitedNode;
     //! Whether this peer wants witnesses in cmpctblocks/blocktxns
     bool fWantsCmpctWitness;
     /**
@@ -244,6 +247,7 @@ struct CNodeState {
         fPreferHeaderAndIDs = false;
         fProvidesHeaderAndIDs = false;
         fHaveWitness = false;
+        fLimitedNode = false;
         fWantsCmpctWitness = false;
         fSupportsDesiredCmpctVersion = false;
     }
@@ -560,6 +564,16 @@ void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<con
             }
             if (!State(nodeid)->fHaveWitness && IsWitnessEnabled(pindex->pprev, consensusParams)) {
                 // We wouldn't download this block or its descendants from this peer.
+                return;
+            }
+            if (state->fLimitedNode &&
+                state->pindexBestKnownBlock->nHeight - pindex->nHeight >= consensusParams.nMaxReorgDepth - 2) {
+                // A limited peer serves only blocks within the finality horizon
+                // of its tip and answers notfound beyond it. Its live tip may be
+                // ahead of pindexBestKnownBlock, shrinking the servable window
+                // from under a request measured against our stale view — hence
+                // the two-block margin. We wouldn't download this block or its
+                // descendants from this peer.
                 return;
             }
             if (pindex->nStatus & BLOCK_HAVE_DATA || chainActive.Contains(pindex)) {
@@ -1113,6 +1127,20 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                     pfrom->fDisconnect = true;
                     send = false;
                 }
+                if (send && fWitnessPrune &&
+                    chainActive.Tip()->nHeight - mi->second->nHeight > consensusParams.nMaxReorgDepth) {
+                    // A witness-pruned node serves only blocks within the
+                    // finality horizon and answers notfound beyond it, for
+                    // every block message type — even MSG_BLOCK, and even when
+                    // this block has not been compacted yet. Serving base-only
+                    // data to a validating peer is the silent sync break the
+                    // contract exists to prevent, and the window must be
+                    // deterministic, so it is enforced from our own state
+                    // rather than the compaction schedule or the advertised
+                    // service bits (doc/PAT_WITNESS_PRUNING.md §4).
+                    send = false;
+                    vNotFound.push_back(inv);
+                }
                 // Pruned nodes may have deleted the block, so check whether
                 // it's available before trying to send.
                 if (send && (mi->second->nStatus & BLOCK_HAVE_DATA))
@@ -1462,7 +1490,10 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             pfrom->cleanSubVer = cleanSubVer;
         }
         pfrom->nStartingHeight = nStartingHeight;
-        pfrom->fClient = !(nServices & NODE_NETWORK);
+        // A NODE_NETWORK_LIMITED peer is not a pure client: it serves blocks
+        // within the finality horizon of its tip (BIP159 shape,
+        // doc/PAT_WITNESS_PRUNING.md §4), just never a deep sync.
+        pfrom->fClient = !(nServices & (NODE_NETWORK | NODE_NETWORK_LIMITED));
         {
             LOCK(pfrom->cs_filter);
             pfrom->fRelayTxes = fRelay; // set to true after we get the first filter* message
@@ -1472,10 +1503,13 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         pfrom->SetSendVersion(nSendVersion);
         pfrom->nVersion = nVersion;
 
-        if((nServices & NODE_WITNESS))
         {
             LOCK(cs_main);
-            State(pfrom->GetId())->fHaveWitness = true;
+            CNodeState* state = State(pfrom->GetId());
+            if (nServices & NODE_WITNESS) {
+                state->fHaveWitness = true;
+            }
+            state->fLimitedNode = (!(nServices & NODE_NETWORK) && (nServices & NODE_NETWORK_LIMITED));
         }
 
         // Potentially mark this peer as a preferred download peer.
@@ -3434,7 +3468,10 @@ bool SendMessages(CNode* pto, CConnman& connman, const std::atomic<bool>& interr
         // Message: getdata (blocks)
         //
         std::vector<CInv> vGetData;
-        if (!pto->fClient && (fFetch || !IsInitialBlockDownload()) && state.nBlocksInFlight < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
+        // Never sync deep history from a limited peer: during IBD it cannot
+        // serve what we need (only the window below its tip); once synced,
+        // anything we fetch is recent and within its window.
+        if (!pto->fClient && ((fFetch && !state.fLimitedNode) || !IsInitialBlockDownload()) && state.nBlocksInFlight < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
             std::vector<const CBlockIndex*> vToDownload;
             NodeId staller = -1;
             FindNextBlocksToDownload(pto->GetId(), MAX_BLOCKS_IN_TRANSIT_PER_PEER - state.nBlocksInFlight, vToDownload, staller, consensusParams);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -567,7 +567,7 @@ void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<con
                 return;
             }
             if (state->fLimitedNode &&
-                state->pindexBestKnownBlock->nHeight - pindex->nHeight >= consensusParams.nMaxReorgDepth - 2) {
+                state->pindexBestKnownBlock->nHeight - pindex->nHeight > std::max<int>(consensusParams.nMaxReorgDepth - 2, 0)) {
                 // A limited peer serves only blocks within the finality horizon
                 // of its tip and answers notfound beyond it. Its live tip may be
                 // ahead of pindexBestKnownBlock, shrinking the servable window

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -274,9 +274,11 @@ enum ServiceFlags : uint64_t {
     // If this is turned off then the node will not service nor make xthin requests
     NODE_XTHIN = (1 << 4),
     // NODE_NETWORK_LIMITED means the same as NODE_NETWORK with the limitation of only
-    // serving the last 288 blocks (BIP159). Advertised by witness-pruned nodes: the
-    // window is exactly nMaxReorgDepth, so everything within it is stored and served
-    // in full, and nothing beyond it is served at all (doc/PAT_WITNESS_PRUNING.md §4).
+    // serving a recent window of blocks (BIP159 specifies the last 288). Advertised by
+    // witness-pruned nodes, whose window is exactly nMaxReorgDepth (288 on the
+    // production networks; regtest opts in via -maxreorgdepth): everything within it is
+    // stored and served in full, nothing beyond it is served at all
+    // (doc/PAT_WITNESS_PRUNING.md §4).
     NODE_NETWORK_LIMITED = (1 << 10),
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -273,6 +273,11 @@ enum ServiceFlags : uint64_t {
     // NODE_XTHIN means the node supports Xtreme Thinblocks
     // If this is turned off then the node will not service nor make xthin requests
     NODE_XTHIN = (1 << 4),
+    // NODE_NETWORK_LIMITED means the same as NODE_NETWORK with the limitation of only
+    // serving the last 288 blocks (BIP159). Advertised by witness-pruned nodes: the
+    // window is exactly nMaxReorgDepth, so everything within it is stored and served
+    // in full, and nothing beyond it is served at all (doc/PAT_WITNESS_PRUNING.md §4).
+    NODE_NETWORK_LIMITED = (1 << 10),
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the


### PR DESCRIPTION
## PAT witness pruning stage 2: the network service contract

This completes phase 5 of the PAT completion epic (`pat-completion-epic-xlab`). Stage 1 (#71) landed the storage semantics behind a regtest/`-connect=0` init gate. That gate existed for one reason: a connected node running stage 1 would have under-served what it advertised. This change implements the contract specified in `doc/PAT_WITNESS_PRUNING.md` §4 and removes the gate. All five touchpoints named in the specification were verified against the tree before implementation.

### The five touchpoints

1. **`protocol.h`**: `NODE_NETWORK_LIMITED = (1 << 10)`, the BIP159 value. The serving window equals `nMaxReorgDepth`. The specification adopts this alignment deliberately.
2. **`init.cpp`**: `-witnessprune` clears `NODE_NETWORK` and sets `NODE_NETWORK_LIMITED` at the same step as the existing `-prune` clearing. `NODE_WITNESS` remains set, since everything within the window is served in full, witness included. The stage-1 gate is removed; the requirement for an armed finality horizon stays.
3. **Peer classification (`net_processing.cpp`)**: `fClient` no longer classifies a limited peer as a pure client; a new `CNodeState.fLimitedNode` records the third state. Two request-side guards follow from it. Block sync ignores limited peers while an initial sync is in progress, and `FindNextBlocksToDownload` never requests a block deeper than the horizon minus a two-block margin below the peer's best-known tip. The margin exists because the peer's live tip may be ahead of the requesting node's view of it, which shrinks the servable window under a request measured against the stale view.
4. **Outbound selection**: deliberately unchanged. `REQUIRED_SERVICES` and the DNS-seed filter continue to require `NODE_NETWORK`, so a fresh node can never fill its outbound slots with peers that cannot serve its initial sync. This posture is documented at both sites and in specification §8. Dialling limited peers after leaving IBD, as later upstream versions do, is recorded as a possible post-launch relaxation.
5. **`getdata` serving**: requests for blocks beyond the window are answered `notfound` for every block message type. This includes `MSG_FILTERED_BLOCK` and `MSG_CMPCT_BLOCK`, because the compact path falls back to a full-block send for old blocks, which would transmit the stripped block. The decision is made by depth from the node's own state, independent of the compaction schedule and of the advertised service bits, so the contract holds even against peers that ignore service flags.

### Tests (specification plan items 5 and 6)

- **`witness-prune-serving.py`** drives the window at the exact boundary for both message types, asserts the service bits over RPC and in the version handshake, and shows the window following the tip. The test was proven load-bearing with a probe build in which the serving guard was disabled: exactly the beyond-window notfound assertions fail, and the restored build is green.
- **`witness-prune-ibd.py`** syncs a fresh node with the limited peer connected first, so a wrong peer-selection or block-request path stalls the sync on notfound. It also asserts the limited peer's advertised bits from the syncing node's view and exercises steady-state relay after the sync.
- Both tests are registered in `rpc-tests.py` and added to the CI functional list. A contract test that never runs in CI provides the appearance of coverage without the substance. The mininode framework gains `notfound` dispatch; the message class existed but was never mapped.

### Verification

- Full suite: **774 cases, 0 failures**.
- **Consensus digest unmoved at `c4029fd7`**, holding the specification's assertion that witness pruning is local policy (§7.7). No F4 sweep is owed.
- Regression functional runs green with this build: `p2p-getdata`, `maxreorgdepth`, `pat-commitment`, `auxpow`. Three further tests (`p2p-acceptblock`, `sendheaders`, `p2p-policy`) fail identically on unmodified main in the local macOS/Python 3.14 environment; they are pre-existing environment failures, absent from CI's list, and untouched by this change.

### Specification updates in the same change

§3 records the stage-1 rev-file hardlink (previously recorded only in the stage-1 commit message). §4 records the four-message-type refusal and the request-side margin. §8 records the outbound posture and the gate removal. The status line reflects implementation.

With this change, item 4 of the ratified definition of done is complete on the node side: a node can discard attested witness data past the finality horizon, retain the attestation, and advertise to the network exactly what it serves.
