### PR TITLE
doc: retract the 9,661x claim in the PAT header

### DIFF
--- a/src/crypto/pat/logarithmic.h
+++ b/src/crypto/pat/logarithmic.h
@@ -8,8 +8,9 @@
  * prevent rogue-key attacks and ensure message integrity.
  *
  * Instead of verifying n individual Dilithium signatures (each ~2.5KB), verifiers
- * only need to validate a 100-byte proof plus logarithmic witness data. This provides
- * massive savings for batch transaction validation and block verification.
+ * only need to validate a 100-byte proof plus witness data (a logarithmic Merkle
+ * path and a linear set of 96-byte tuples; see WITNESS DATA below). End-to-end
+ * this is a ~25x reduction versus carrying raw signatures.
  *
  * PROOF FORMAT (100 bytes total)
  * ================================
@@ -67,7 +68,9 @@
  * - Verification time (Simple mode): O(1) - < 4µs constant time
  * - Verification time (Full mode): O(log n) - tree traversal + hash computation
  * - Creation time: O(n log n) - sorting + tree construction
- * - Commitment reduction: ~9,661× for n=1024 (100 bytes vs 2.5MB)
+ * - End-to-end reduction: ~25x for n=1024 (~98KB proof+witness vs ~2.5MB raw
+ *   signatures). The 100-byte figure is the commitment alone, not the on-chain
+ *   footprint; the earlier "~9,661x" comparison of the two was retracted.
  *
  * MERKLE TREE CONSTRUCTION
  * ========================


### PR DESCRIPTION
Closes the src-side item of bead `pat-public-claims-correction-pq03`.

The PAT header in `src/crypto/pat/logarithmic.h` carried two stale claims from before the public retraction:

1. A performance line stating a ~9,661x commitment reduction for n=1024, comparing the 100-byte commitment to 2.5MB of raw signatures. The public figure of record is ~25x end-to-end; the header's own WITNESS DATA section already carried the honest arithmetic (~98KB proof plus witness versus ~2.5MB raw signatures).
2. An overview line calling the witness data logarithmic, which the header's own size formula contradicts: the Merkle path is logarithmic and the tuple set is linear (96n bytes).

Both lines now state the corrected figures, and the retracted number is named at the site so an old diff cannot silently reintroduce it.

Comment-only change. The build was compile-checked; no code, no tests, no digest surface is touched.