### PR TITLE
ci: cache the Windows depends tree between runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,14 +187,29 @@ jobs:
       # recursive hash of its recipe, patches and toolchain, so a stale restore
       # is safe: changed packages rebuild, unchanged ones are reused, and
       # cached sources avoid the upstream fetch either way.
+      #
+      # The key must rotate whenever the package build ids can: actions/cache
+      # never saves on an exact-key hit, so any build-id input missing from the
+      # key degrades to rebuild-every-run-with-no-save. Build ids hash the
+      # meta_depends files (depends/Makefile:111 — Makefile, funcs.mk, hosts/*,
+      # builders/*) and the toolchain's --version output (depends/Makefile:79).
+      # The toolchain half can change with no repo diff (apt installs the
+      # current mingw each run), so it enters the key as a fingerprint step.
+      - name: Toolchain fingerprint for the depends cache key
+        id: toolchain
+        run: |
+          echo "hash=$( (x86_64-w64-mingw32-g++ --version; x86_64-w64-mingw32-ar --version; g++ --version) | sha256sum | cut -c1-12 )" >> "$GITHUB_OUTPUT"
+
       - name: Depends cache
         uses: actions/cache@v5
         with:
           path: |
             depends/built
             depends/sources
-          key: windows-x64-depends-${{ hashFiles('depends/packages/**', 'depends/patches/**') }}
-          restore-keys: windows-x64-depends-
+          key: windows-x64-depends-${{ steps.toolchain.outputs.hash }}-${{ hashFiles('depends/packages/**', 'depends/patches/**', 'depends/Makefile', 'depends/funcs.mk', 'depends/hosts/**', 'depends/builders/**') }}
+          restore-keys: |
+            windows-x64-depends-${{ steps.toolchain.outputs.hash }}-
+            windows-x64-depends-
 
       - name: Build depends
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,22 @@ jobs:
           sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
           sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
 
+      # Without this cache every run rebuilds the whole mingw depends tree from
+      # source, which makes job duration hostage to upstream mirror weather
+      # (measured: 5m46s vs 1h15m on identical inputs, bead
+      # ci-windows-depends-cache-76ug). depends/ keys each package build on a
+      # recursive hash of its recipe, patches and toolchain, so a stale restore
+      # is safe: changed packages rebuild, unchanged ones are reused, and
+      # cached sources avoid the upstream fetch either way.
+      - name: Depends cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            depends/built
+            depends/sources
+          key: windows-x64-depends-${{ hashFiles('depends/packages/**', 'depends/patches/**') }}
+          restore-keys: windows-x64-depends-
+
       - name: Build depends
         run: |
           make -j4 -C depends HOST=x86_64-w64-mingw32 NO_QT=1


### PR DESCRIPTION
## What

Adds an actions/cache step for `depends/built` + `depends/sources` to the Windows x64 job, keyed on `hashFiles('depends/packages/**', 'depends/patches/**')` with a prefix restore-keys fallback.

## Why

The job had no cache step at all, so every run rebuilt the entire mingw cross-compile tree from source. Measured on identical inputs: 5m46s (run 33578282735) vs ~1h15m (runs 33586238431, 33589878739). The slow case looks like a hung job and drags every push during tag-heavy work, which is exactly the workload of the freeze-candidate arc now starting.

## Why a stale restore is safe

The depends build system keys each package on a recursive hash of its recipe, patches and toolchain (its build id). A restore-keys hit therefore rebuilds exactly the packages whose inputs changed and reuses the rest, and cached sources avoid the upstream fetch either way. This mirrors how the Linux job already caches ccache.

Closes bead `ci-windows-depends-cache-76ug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)