### PR TITLE
consensus: mainnet genesis ceremony (FC4) — purpose-built genesis replaces the Dogecoin template

### DIFF
--- a/doc/GENESIS_CEREMONY.md
+++ b/doc/GENESIS_CEREMONY.md
@@ -1,6 +1,15 @@
 # Mainnet Genesis Ceremony (FC4)
 
-The mainnet genesis block currently reuses the Dogecoin genesis template
+> **EXECUTED 2026-09-02.** The ceremony this document prescribes was performed in
+> one sitting: genesis `0d828600816cbd7c23789660b53f90cb6ec7ff85540698e13845eb2d2f0486a8`
+> (nTime 1788365451, nonce 3319596), headline
+> `The Block 26/Aug/2026 First quantum-resistant Bitcoin transaction mined BTC 965186 d3b0f490`,
+> output a bare OP_RETURN. The full-suite gate passed with zero failures and the
+> consensus digest re-pin was observed firing before being updated. The paragraph
+> below describes the pre-ceremony state this procedure replaced; it is kept as
+> the record of why the ceremony happened.
+
+The mainnet genesis block previously reused the Dogecoin genesis template
 (message "Nintondo", nTime 1386325540, nonce 99943, the original ECDSA P2PK
 output). Launch checklist item A1 and bead z9vk ratify replacing it before
 launch with a purpose-built genesis. This document is the complete procedure,

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -120,6 +120,30 @@ static CBlock CreateGenesisBlockStagenet(uint32_t nTime, uint32_t nNonce, uint32
 }
 
 /**
+ * Soqucoin Mainnet Genesis Block - genesis ceremony 2026-09-02 (doc/GENESIS_CEREMONY.md)
+ *
+ * Headline: The Block, 2026-08-26, "First quantum-resistant Bitcoin transaction
+ * successfully executed, StarkWare says" (attribution tail trimmed, verb
+ * compressed to the event's own fact: the transaction was mined in BTC block
+ * 964199, txid 305a24ffea912b9cf428f29ebf952321c96dab5bab284fc0d0801562f5abab07).
+ * Anchor: BTC block 965186, hash
+ * 00000000000000000000d3b0f4905a4d1dc5366526c311004e9468743df764d3 (first
+ * significant 8 hex = d3b0f490), fetched at ceremony start from two independent
+ * explorers. The anchor proves this genesis could not have been mined before
+ * that Bitcoin block existed.
+ *
+ * Output script is a bare OP_RETURN: provably unspendable with no embedded
+ * data, so nothing-up-my-sleeve. The genesis coinbase is excluded from the
+ * UTXO set regardless; this choice is about what decoders display.
+ */
+static CBlock CreateGenesisBlockMainnet(uint32_t nTime, uint32_t nNonce, uint32_t nBits, int32_t nVersion, const CAmount& genesisReward)
+{
+    const char* pszTimestamp = "The Block 26/Aug/2026 First quantum-resistant Bitcoin transaction mined BTC 965186 d3b0f490";
+    const CScript genesisOutputScript = CScript() << OP_RETURN;
+    return CreateGenesisBlock(pszTimestamp, genesisOutputScript, nTime, nNonce, nBits, nVersion, genesisReward);
+}
+
+/**
  * Main network
  */
 /**
@@ -436,16 +460,19 @@ public:
         nDefaultPort = 33388;
         nPruneAfterHeight = 100000;
 
-        genesis = CreateGenesisBlock(1386325540, 99943, 0x1e0ffff0, 1, 88 * COIN);
+        // Genesis ceremony 2026-09-02 (doc/GENESIS_CEREMONY.md): purpose-built
+        // genesis replacing the inherited Dogecoin template. nTime is the
+        // ceremony's UTC epoch; nonce mined in-tree (genesis_remine_tests,
+        // 3,319,596 attempts) and independently recomputed via pure-Python
+        // scrypt/sha256d (ceremony log of record).
+        // Scrypt PoW: 00000e6981993c98a9a7c1e534a8368f6e67f5f2330ab50646c10c477774be3f
+        genesis = CreateGenesisBlockMainnet(1788365451, 3319596, 0x1e0ffff0, 1, 88 * COIN);
 
-        // Phase 4: mainnet genesis re-mined 2026-06-16 (DL-GENESIS-REMINE.md)
-        // Original nonce 99943 is still valid under byte-less CTxOut serialization.
-        // Scrypt PoW: 0000026f3f7874ca0c251314eaed2d2fcf83d7da3acfaacf59417d485310b448
         consensus.hashGenesisBlock = genesis.GetHash();
         digishieldConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
         auxpowConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
-        assert(consensus.hashGenesisBlock == uint256S("0x1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691"));
-        assert(genesis.hashMerkleRoot == uint256S("0x5b2a3f53f605d62c53e62932dac6925e3d74afa5a4b459745c36d42d0ed26a69"));
+        assert(consensus.hashGenesisBlock == uint256S("0x0d828600816cbd7c23789660b53f90cb6ec7ff85540698e13845eb2d2f0486a8"));
+        assert(genesis.hashMerkleRoot == uint256S("0x8c4364d66ab67d746ddf1c5e0a316da5af9bbf7dc27bdd02e06ea77aec88ed28"));
 
         // Genesis-migration allocation constants (DL-GENESIS-MIGRATION-IMPLEMENTATION §A1).
         // Deliberately NOT set here: hashMigrationOutputs stays null, nMigrationTotal 0,

--- a/src/test/consensus_digest_tests.cpp
+++ b/src/test/consensus_digest_tests.cpp
@@ -673,8 +673,19 @@ BOOST_AUTO_TEST_CASE(consensus_digest_is_pinned)
     // The rules themselves (producer, ConnectBlock enforcement) ship in the
     // same commit; their reject paths are driven in pat_commitment_rule_tests.
     // The sweep of record re-runs against the tag as always.
+    //
+    // Moved from c4029fd7... on 2026-09-02 at the mainnet genesis ceremony
+    // (doc/GENESIS_CEREMONY.md, ceremony log of record 2026-09-02) — the move
+    // the 2026-08-29 entry predicted ("the digest moves again at the genesis
+    // ceremony as designed"). A RULE change on mainnet only, made deliberately:
+    // the movers are the mainnet genesis fields (new pszTimestamp/output
+    // script => hashMerkleRoot, plus nTime 1788365451 and nNonce 3319596 =>
+    // hashGenesisBlock) and everything derived from the genesis hash
+    // (latticeBPSeed via ComputeSoquObscuraSeed). Testnet, stagenet and
+    // regtest genesis inputs are untouched. The F4 sweep of record re-runs
+    // against the FC4 tag on the fleet toolchain.
     const std::string expected =
-        "c4029fd7baefc9718ec0ca8a1ae9e4830d82c2bd1e27d240cf34365975936730";
+        "6f4e1b37fd154fd7e845bfaa67b401a64fb3f5bd9b7a2832451c8fde5be8cfe8";
 
     BOOST_CHECK_MESSAGE(digest.ToString() == expected,
         "consensus digest is " + digest.ToString() + ", expected " + expected +

--- a/src/test/genesis_chainparams_tests.cpp
+++ b/src/test/genesis_chainparams_tests.cpp
@@ -64,12 +64,31 @@ BOOST_AUTO_TEST_CASE(stagenet_genesis_pow_valid)
     BOOST_CHECK(CheckAuxPowProofOfWork(genesis, consensus));
 }
 
-// NOTE: Mainnet and testnet3 genesis nonces are not yet final.
-// These tests should be enabled once the serialization format is frozen
-// and genesis nonces are re-mined.
+// Mainnet genesis became final at the 2026-09-02 ceremony (doc/GENESIS_CEREMONY.md),
+// so its PoW test is enabled below. testnet3's nonce is still the inherited one and
+// its test stays disabled until that network is ever re-mined.
 //
-// BOOST_AUTO_TEST_CASE(mainnet_genesis_pow_valid)
 // BOOST_AUTO_TEST_CASE(testnet3_genesis_pow_valid)
+
+BOOST_AUTO_TEST_CASE(mainnet_genesis_pow_valid)
+{
+    SelectParams(CBaseChainParams::MAIN);
+    const CChainParams& params = Params();
+    const CBlock& genesis = params.GenesisBlock();
+    const Consensus::Params& consensus = params.GetConsensus(0);
+
+    // The ceremony pins, asserted here as well as in chainparams.cpp so a
+    // regression is a test failure, not only a startup abort.
+    BOOST_CHECK_EQUAL(genesis.GetHash().ToString(),
+                      "0d828600816cbd7c23789660b53f90cb6ec7ff85540698e13845eb2d2f0486a8");
+    BOOST_CHECK_EQUAL(genesis.hashMerkleRoot.ToString(),
+                      "8c4364d66ab67d746ddf1c5e0a316da5af9bbf7dc27bdd02e06ea77aec88ed28");
+    BOOST_CHECK_EQUAL(genesis.GetHash().ToString(),
+                      consensus.hashGenesisBlock.ToString());
+
+    // PoW is valid (uses scrypt via GetPoWHash)
+    BOOST_CHECK(CheckAuxPowProofOfWork(genesis, consensus));
+}
 
 // ============================================================================
 // Genesis Block Consistency Tests

--- a/src/test/genesis_remine_tests.cpp
+++ b/src/test/genesis_remine_tests.cpp
@@ -125,12 +125,15 @@ BOOST_AUTO_TEST_CASE(mine_stagenet_genesis)
 
 BOOST_AUTO_TEST_CASE(mine_mainnet_genesis)
 {
-    // Reproduce the mainnet genesis block construction
-    // From chainparams.cpp line 320:
-    // genesis = CreateGenesisBlock(1386325540, 99943, 0x1e0ffff0, 1, 88 * COIN);
+    // Reproduce the mainnet genesis block construction — DELIBERATE inline
+    // copy of CreateGenesisBlockMainnet (chainparams.cpp); this test cannot
+    // SelectParams(MAIN) while the pins are stale. The three inputs below
+    // (pszTimestamp, genesisOutputScript, nTime) MUST match chainparams.cpp
+    // exactly or the miner mines the wrong block.
+    // Ceremony 2026-09-02: genesis = CreateGenesisBlockMainnet(1788365451, 3319596, 0x1e0ffff0, 1, 88 * COIN);
 
-    const char* pszTimestamp = "Nintondo";
-    const CScript genesisOutputScript = CScript() << ParseHex("040184710fa689ad5023690c80f3a49c8f13f8d45b8c857fbcbc8bc4a8e4d3eb4b10f4d4604fa08dce601aaf0f470216fe1b51850b4acf21b179c45070ac7b03a9") << OP_CHECKSIG;
+    const char* pszTimestamp = "The Block 26/Aug/2026 First quantum-resistant Bitcoin transaction mined BTC 965186 d3b0f490";
+    const CScript genesisOutputScript = CScript() << OP_RETURN;
 
     CMutableTransaction txNew;
     txNew.nVersion = 1;
@@ -141,7 +144,7 @@ BOOST_AUTO_TEST_CASE(mine_mainnet_genesis)
     txNew.vout[0].scriptPubKey = genesisOutputScript;
 
     CBlock genesis;
-    genesis.nTime = 1386325540;
+    genesis.nTime = 1788365451;
     genesis.nBits = 0x1e0ffff0;
     genesis.nNonce = 0;  // Will be mined
     genesis.nVersion = 1;

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -41,9 +41,12 @@ static inline std::vector<unsigned char> InsecureRandBytes(size_t len) { return 
 struct BasicTestingSetup {
     ECCVerifyHandle globalVerifyHandle;
 
-    // SOQUCOIN: Default to REGTEST — mainnet genesis coinbase uses legacy P2PK
-    // which fails the Dilithium-only coinbase enforcement in ContextualCheckBlock.
-    // REGTEST is exempt from that check and is standard for unit test fixtures.
+    // SOQUCOIN: Default to REGTEST, the standard fixture network, exempt from the
+    // Dilithium-only coinbase enforcement in ContextualCheckBlock. (Historical note:
+    // this default originally also worked around the pre-ceremony mainnet genesis
+    // failing that enforcement via its legacy P2PK output; since the 2026-09-02
+    // ceremony the mainnet genesis is a bare OP_RETURN, but testnet3 still carries
+    // the legacy P2PK genesis and the REGTEST default remains correct regardless.)
     BasicTestingSetup(const std::string& chainName = CBaseChainParams::REGTEST);
     ~BasicTestingSetup();
 };

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -7242,8 +7242,10 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const CB
 
     // Enforce strict Dilithium coinbase output (OP_1 <32-byte hash>)
     // Reject any coinbase output that is not Dilithium bech32m v1 (or OP_RETURN for witness commitment)
-    // SOQ-REINDEX-001: Exempt genesis block (nHeight == 0) — it uses a legacy P2PK output
-    // created by CreateGenesisBlock(). During normal sync, genesis bypasses this check
+    // SOQ-REINDEX-001: Exempt genesis block (nHeight == 0). The exemption is load-bearing
+    // for testnet3 and stagenet, whose geneses carry the legacy P2PK output from
+    // CreateGenesisBlock(); mainnet's ceremony genesis (2026-09-02) is a bare OP_RETURN
+    // and would pass this check anyway. During normal sync, genesis bypasses this check
     // via InitBlockIndex(), but -reindex routes through AcceptBlock → ContextualCheckBlock.
     if (nHeight > 0 && chainParams.NetworkIDString() != CBaseChainParams::REGTEST) {
         for (const auto& txout : block.vtx[0]->vout) {


### PR DESCRIPTION
## What

The mainnet genesis ceremony of doc/GENESIS_CEREMONY.md, executed 2026-09-02. The inherited Dogecoin template (Nintondo, 2013 nTime, ECDSA P2PK output) is replaced with a purpose-built genesis. Closes launch checklist item A1 (bead z9vk). Consensus change on mainnet only; testnet, stagenet and regtest genesis parameters are untouched, pinned by the existing suites.

## The block

```
pszTimestamp: The Block 26/Aug/2026 First quantum-resistant Bitcoin transaction mined BTC 965186 d3b0f490
output:       bare OP_RETURN (provably unspendable)
nTime:        1788365451   nNonce: 3319596   nBits: 0x1e0ffff0
block:        0d828600816cbd7c23789660b53f90cb6ec7ff85540698e13845eb2d2f0486a8
merkle:       8c4364d66ab67d746ddf1c5e0a316da5af9bbf7dc27bdd02e06ea77aec88ed28
scrypt PoW:   00000e6981993c98a9a7c1e534a8368f6e67f5f2330ab50646c10c477774be3f
```

The headline memorializes the first quantum-resistant Bitcoin transaction (BTC block 964,199, 2026-08-26, executed under existing rules with no fork) in the genesis of a chain shipping ML-DSA-44 from height zero. The trailing anchor is BTC block 965186's hash prefix, fetched at ceremony start from two independent explorers, so this genesis provably could not exist before that block did. 91 bytes; the 100-byte scriptSig sits exactly at the consensus bound (validation.cpp coinbase rule).

## Verification chain

- Nonce mined in-tree (genesis_remine_tests), then independently reproduced byte-exact by a pure-Python scrypt/sha256d recomputation that first self-checks against the old pinned genesis.
- Both mainnet pin asserts present and armed with the new values.
- `mainnet_genesis_pow_valid` ENABLED (its disable condition was 'until the nonce is final', which ended at this ceremony).
- Consensus digest re-pinned c4029fd7 → 6f4e1b37 — the move the pin history explicitly predicted for the ceremony; movers are the mainnet genesis fields plus the derived latticeBPSeed, nothing else. The tripwire was observed firing (exactly one failure, naming the move) before the re-pin.
- Full unit suite: 775 cases, zero failures, one known skip (script_PushData).
- nMinimumChainWork / defaultAssumeValid remain 0x00 (launch posture); migration allocation constants remain null/0/0 (inert).

## After merge

Diffval against the tagged build, then the v2.3.0 tag (ceremony step 8) and the fleet deploy that starts the FC4 soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)