### PR TITLE
doc: mainnet launch needs maxtipage on every work-serving node (5p99)

### DIFF
--- a/doc/pool-integration.md
+++ b/doc/pool-integration.md
@@ -67,8 +67,23 @@ txindex=1
 # RPC credentials
 rpcuser=pool_rpc_user
 rpcpassword=<strong_random_password>
-rpcport=38332          # stagenet
-# rpcport=22555        # mainnet (future)
+rpcport=28332          # stagenet
+# rpcport=33389        # mainnet
+
+# Serve mining work over RPC. Default is 1 on every network except mainnet,
+# where the launch-period default is 0; pool and miner-facing nodes opt in.
+enablemining=1
+
+# LAUNCH-PERIOD REQUIREMENT (mainnet). A node whose tip is still genesis is in
+# initial block download once the wall clock is more than maxtipage seconds
+# past the genesis timestamp (1788365451, 2026-09-02T16:10:51Z; default 86400).
+# In that state getblocktemplate and createauxblock refuse to serve work, so
+# with the default no node can mine block 1 on any launch day after 2026-09-03.
+# Every node that serves work at launch must set maxtipage to at least
+# (launch time - 1788365451) plus margin, and keep it until block 1 has
+# propagated. 5184000 covers a launch up to 60 days after genesis. Remove it
+# once the chain has a fresh tip: the 24h default is the right steady state.
+maxtipage=5184000
 
 # Allow pool server to connect
 rpcallowip=127.0.0.1
@@ -90,9 +105,9 @@ zmqpubrawtx=tcp://127.0.0.1:28332
 
 | Network | Format | Prefix | Example |
 |---------|--------|--------|---------|
-| Mainnet | Bech32m (Taproot) | `soq1p` | `soq1pxyz...` |
-| Stagenet | Bech32m (Taproot) | `ssq1p` | `ssq1pxyz...` |
-| Testnet3 | Bech32m (Taproot) | `tsq1p` | `tsq1pxyz...` |
+| Mainnet | Bech32m (witness v1) | `sq1p` | `sq1pxyz...` |
+| Stagenet | Bech32m (witness v1) | `ssq1p` | `ssq1pxyz...` |
+| Testnet / Regtest | Bech32m (witness v1) | `sq1p` | shares the mainnet HRP; select the network by RPC port, not by address prefix |
 
 **Important**: Legacy Base58 addresses (`S...`, `3...`) are supported but deprecated.
 Bech32m is the canonical format. Use `validateaddress` RPC to verify miner addresses.

--- a/doc/pool-integration.md
+++ b/doc/pool-integration.md
@@ -14,7 +14,7 @@ Soqucoin is a Scrypt-based AuxPoW blockchain derived from Dogecoin Core. Pool
 integration is straightforward if you already support Litecoin or Dogecoin.
 
 **Key differences from Dogecoin/Litecoin:**
-- **Bech32m addresses** (`soq1p...` on mainnet, `ssq1p...` on stagenet)
+- **Bech32m addresses** (`sq1p...` on mainnet, `ssq1p...` on stagenet)
 - **60-second block target** (same as Dogecoin)
 - **Dilithium signatures** in witness data (transparent to Stratum — coinbase/header format unchanged)
 - **AuxPoW chain ID**: matches Dogecoin's AuxPoW format
@@ -78,7 +78,8 @@ enablemining=1
 # initial block download once the wall clock is more than maxtipage seconds
 # past the genesis timestamp (1788365451, 2026-09-02T16:10:51Z; default 86400).
 # In that state getblocktemplate and createauxblock refuse to serve work, so
-# with the default no node can mine block 1 on any launch day after 2026-09-03.
+# with the default no node can mine block 1 once the clock is more than 86400 s
+# past that timestamp (from 2026-09-03T16:10:51Z onward).
 # Every node that serves work at launch must set maxtipage to at least
 # (launch time - 1788365451) plus margin, and keep it until block 1 has
 # propagated. 5184000 covers a launch up to 60 days after genesis. Remove it
@@ -218,7 +219,7 @@ soqucoin-cli submitauxblock <hash> <serialized_auxpow>
 ### Common Issues
 
 **Q: Address validation fails for miner-submitted addresses**
-A: Ensure you're accepting bech32m format (`soq1p...` or `ssq1p...`). If your
+A: Ensure you're accepting bech32m format (`sq1p...` or `ssq1p...`). If your
 pool software only validates Base58, you'll need to add bech32m support.
 
 **Q: Block template has large witness data**


### PR DESCRIPTION
## Why

Mainnet genesis nTime is 1788365451 (2026-09-02T16:10:51Z). Under the default `-maxtipage` (86400 s) a node whose tip is still genesis reports `initialblockdownload=true` on any launch day after 2026-09-03, and both work RPCs refuse to serve: `getblocktemplate` exempts only stagenet and regtest (`rpc/mining.cpp`), `createauxblock` exempts only regtest (`rpc/auxpow.cpp`). Merge-mining pools reach the chain through `createauxblock`, so with the default no node can produce block 1.

The fix is configuration, not code, and this PR documents it where pool operators read: the `soqucoin.conf` example in `doc/pool-integration.md` now carries `enablemining=1` and a launch-period `maxtipage` with the reason and the removal condition.

## Verified

Two genesis-only mainnet nodes on the v2.3.0 build, peered with each other only, no DNS seeds. Node A with the default, node B with `maxtipage=5184000`:

| check | node A (default) | node B (maxtipage) |
|---|---|---|
| genesis hash | 0d828600…86a8 | 0d828600…86a8 |
| initialblockdownload | true | false |
| getblocktemplate | refused, error -10 | returns work |
| createauxblock | refused, error -10 | returns work (chainid 21329, prev 0d828600…) |

12 of 12 checks pass. The probe script lives in the operations repository.

## Also corrected in the same example

- RPC ports: stagenet 28332, mainnet 33389 (the example said 38332 and 22555, values no Soqucoin network uses; verified against `chainparamsbase.cpp` and the live fleet).
- Address table HRPs: mainnet `sq`, stagenet `ssq`; testnet and regtest share `sq` with mainnet (`chainparams.cpp`). The example said `soq` and `tsq`.

No code change. Consensus digest unaffected.

Bead: `mainnet-genesis-maxtipage-launch-blocker-5p99`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
