### PR TITLE
witnessprune: reindex/import/IBD gate, durable reservation, -reindex-chainstate refusal, target above populated files (zixc, j5z0, o0bl)

### DIFF
--- a/doc/PAT_WITNESS_PRUNING.md
+++ b/doc/PAT_WITNESS_PRUNING.md
@@ -62,9 +62,13 @@ Lost, per pruned block, accepted deliberately:
 - The ability to re-verify signatures, the SegWit witness commitment, or the
   PAT attestation of that block. The node trusts its own prior validation,
   exactly as whole-file pruning already does upstream. Consequently
-  **`-reindex` on a witness-pruned datadir must refuse to start** with an
-  error naming the redownload path; a reindex that silently skipped script
-  validation would manufacture a node that believes without having checked.
+  **`-reindex` and `-reindex-chainstate` on a witness-pruned datadir must
+  refuse to start** with an error naming the redownload path; a reindex that
+  silently skipped script validation would manufacture a node that believes
+  without having checked. `-reindex-chainstate` is the same hazard by another
+  route: it keeps the block files and replays `ConnectBlock` over them, which
+  fails on the first stripped spend outside an assumevalid window and silently
+  succeeds inside one (found in review, 2026-09-03).
 - The ability to serve that block to peers (see §4).
 
 ## 3. Mechanics — R1 compaction
@@ -86,14 +90,20 @@ detected after the fact; a detection check at commit time would run after the
 disk damage it detects (found in review). The original file is never modified
 in place, which is what removes the crash window entirely:
 
-1. Reserve *m* (above), then read every block in file *n* and re-serialize
-   each with `SERIALIZE_TRANSACTION_NO_WITNESS` into file *m*, with fresh
-   per-block offsets. Flush and fsync file *m*. The reservation is in-memory
-   until the next index flush; a crash here can lose it, leaving a partial
-   file *m* that a later restart may allocate over — harmless, because block
-   files are position-addressed (stray tail bytes are unreachable) and the
-   orphan sweep removes any partial target whose file info is empty and which
-   no index entry references.
+1. Reserve *m* (above) and write the reservation **durably before any I/O**:
+   the advanced append pointer and the two empty file infos, synced to the
+   block index database. The index is otherwise flushed hourly, and a
+   reservation known only in memory could be forgotten by a crash after step
+   2's hardlink; a restart would then rotate appends into *m* and write undo
+   through the link into file *n*'s undo data (found in review, 2026-09-03).
+   Then read every block in file *n* and re-serialize each with
+   `SERIALIZE_TRANSACTION_NO_WITNESS` into file *m*, with fresh per-block
+   offsets. Flush and fsync file *m*. A crash after the reservation leaves a
+   partial file *m* whose file info is empty and which no index entry
+   references; the orphan sweep removes it. As a second line, the block-write
+   path removes any stray `blk`/`rev` pair at a number it rotates into whose
+   file info is empty, so a leftover can never be written through even if the
+   sweep has not run.
 2. Update every affected `CBlockIndex` entry (`nFile` = *m*, new `nDataPos`,
    `BLOCK_WITNESS_PRUNED`) and the `CBlockFileInfo` records, and flush the
    block index durably. Because `nFile` addresses a block's undo data as well
@@ -126,6 +136,15 @@ Compaction runs opportunistically at the same trigger points as
 `FindFilesToPrune` (post-flush, off the validation hot path). It must never
 hold `cs_main` across file I/O for a whole file; take positions under the
 lock, rewrite outside it, retake to commit the index update.
+
+Compaction **never runs while `-reindex` or `-loadblock` is importing, or
+while the node is in initial block download**. The import path writes blocks
+at known positions and moves the append pointer backwards, which breaks the
+forward-only reservation argument above: a pass could reserve, then delete, an
+original file the import has not reached yet. During initial block download
+the finality horizon is not enforced (§6), so a compacted block could still be
+disconnected. `-witnessprune` together with `-reindex` is refused at init for
+the same reason (§5). Found in review, 2026-09-03.
 
 `-reindex` refuses on any datadir whose index carries `BLOCK_WITNESS_PRUNED`
 (§2). `getblock` and transaction RPCs serve the stripped form; witness fields
@@ -198,6 +217,10 @@ choose the trade, which is why the default is off.
 - Mutually exclusive with `-prune`: whole-file pruning already deletes the
   base data this feature exists to retain, so combining them is a
   contradiction; init errors out rather than picking a winner.
+- Mutually exclusive with `-reindex`: the import rewrites the block-file
+  layout that compaction reserves file numbers in (§3). Run the reindex first,
+  then enable. On a datadir that is already witness-pruned a reindex is
+  refused regardless (§2).
 - Mutually exclusive with `-txindex=0`? No: the transaction index is optional
   as always. The stripped block data remains readable either way.
 - No consensus parameter exists for this feature, deliberately. There is
@@ -213,6 +236,13 @@ implemented here. The implementation still asserts it: a request to disconnect
 a `BLOCK_WITNESS_PRUNED` block is a hard failure with a named error, because
 reaching that state means the finality rule itself was violated and the node
 must halt loudly rather than improvise.
+
+One state escapes the finality rule: during initial block download the horizon
+is not enforced, because a node that syncs a minority fork first may
+legitimately be reorganised past it. Compaction is therefore gated off while
+`IsInitialBlockDownload()` is true (§3). Without that gate a node could compact
+a fork block, be reorganised, and then trip the assertion on every restart with
+`-reindex` refused by the marker (found in review, 2026-09-03).
 
 ## 7. Test plan
 
@@ -231,8 +261,16 @@ must halt loudly rather than improvise.
    before the original's deletion; in both states every indexed block reads
    back correctly on restart, and the next pass converges (re-compacts or
    garbage-collects the orphan).
-4. **Reindex refusal**: `-reindex` on a pruned datadir fails with the named
-   error.
+3c. **Durable reservation**: at the first crash point of 3b the block index
+   database already holds the append pointer advanced past the reserved target
+   and the target's empty file info.
+3d. **Fresh-rotation hygiene**: a stray `blk`/`rev` pair at the number the
+   append pointer rotates into (the `rev` a hardlink to a source file's undo)
+   is removed before anything is written; the source's link count returns to
+   one and its bytes are unchanged after the next block connects.
+4. **Reindex refusal**: `-reindex` or `-reindex-chainstate` on a pruned datadir
+   fails with the named error; `-witnessprune` with `-reindex` is refused on
+   any datadir.
 5. **Serving rules, functional**: within-window `getdata` served with witness;
    beyond-window answered `notfound` for both message types; service bits
    advertise `NODE_NETWORK_LIMITED` and not `NODE_NETWORK`.
@@ -243,6 +281,8 @@ must halt loudly rather than improvise.
    that lands it. Local policy must be provably local.
 8. **Disconnect assertion**: driving a disconnect of a pruned block (regtest,
    reorg-depth setter) halts with the named error rather than proceeding.
+9. **Gates**: with the reindex or import flag set, a pass over an eligible
+   file changes nothing; the same pass with the gates released compacts it.
 
 ## 8. Staging
 

--- a/doc/PAT_WITNESS_PRUNING.md
+++ b/doc/PAT_WITNESS_PRUNING.md
@@ -82,10 +82,16 @@ whole trailing files age out together.
 Compaction of file *n* writes the stripped data to a **new file number** *m*
 (allocated from the same `blk*.dat` series; nothing requires file numbers to be
 height-ordered, since every read goes through `nFile`/`nDataPos`). The number
-*m* is **reserved before any I/O** by advancing the append pointer past it
-under the file lock: the block-write path only ever allocates forward from the
-append pointer, so concurrent block-file rotation can never collide with the
-compaction target. The collision is impossible by construction rather than
+*m* is **one above the highest number any index entry or file info uses**, not
+simply the append pointer plus one: after a `-reindex` the append pointer can
+sit behind a populated file (the import writes at known positions and the last
+block it accepts may be a deferred child in an earlier file), and upstream
+keeps such files as ordinary indexed files beyond the pointer (found in review,
+2026-09-03). The current append file is finalized (fsync, truncate) before the
+pointer moves, as on an ordinary rotation. *m* is then **reserved before any
+I/O** by advancing the append pointer past it under the file lock: the
+block-write path only ever allocates forward from the append pointer, so
+concurrent block-file rotation can never collide with the compaction target. The collision is impossible by construction rather than
 detected after the fact; a detection check at commit time would run after the
 disk damage it detects (found in review). The original file is never modified
 in place, which is what removes the crash window entirely:
@@ -103,7 +109,12 @@ in place, which is what removes the crash window entirely:
    references; the orphan sweep removes it. As a second line, the block-write
    path removes any stray `blk`/`rev` pair at a number it rotates into whose
    file info is empty, so a leftover can never be written through even if the
-   sweep has not run.
+   sweep has not run. One residual state is accepted: a crash after the
+   reservation is synced but before file *m* is created leaves the number
+   reserved with no file behind it and no pruning marker set. Nothing is lost
+   and nothing is written through, but a later `-reindex` (permitted, since the
+   marker is unset) stops at the first missing file number and re-downloads the
+   rest of the chain, exactly as upstream behaves for any gap in the series.
 2. Update every affected `CBlockIndex` entry (`nFile` = *m*, new `nDataPos`,
    `BLOCK_WITNESS_PRUNED`) and the `CBlockFileInfo` records, and flush the
    block index durably. Because `nFile` addresses a block's undo data as well
@@ -144,7 +155,9 @@ forward-only reservation argument above: a pass could reserve, then delete, an
 original file the import has not reached yet. During initial block download
 the finality horizon is not enforced (§6), so a compacted block could still be
 disconnected. `-witnessprune` together with `-reindex` is refused at init for
-the same reason (§5). Found in review, 2026-09-03.
+the same reason (§5), both when `-reindex` is on the command line and when an
+interrupted reindex resumes from its persisted flag. Found in review,
+2026-09-03.
 
 `-reindex` refuses on any datadir whose index carries `BLOCK_WITNESS_PRUNED`
 (§2). `getblock` and transaction RPCs serve the stripped form; witness fields
@@ -237,12 +250,18 @@ a `BLOCK_WITNESS_PRUNED` block is a hard failure with a named error, because
 reaching that state means the finality rule itself was violated and the node
 must halt loudly rather than improvise.
 
-One state escapes the finality rule: during initial block download the horizon
-is not enforced, because a node that syncs a minority fork first may
-legitimately be reorganised past it. Compaction is therefore gated off while
-`IsInitialBlockDownload()` is true (§3). Without that gate a node could compact
-a fork block, be reorganised, and then trip the assertion on every restart with
-`-reindex` refused by the marker (found in review, 2026-09-03).
+One state escapes the finality rule: the horizon is enforced when a header is
+accepted, and not during initial block download, because a node that syncs a
+minority fork first must be free to select the most-work chain. Headers
+accepted in that window are never re-checked, so a more-work header chain that
+forks below the horizon can sit in the index after the download completes, and
+the node will reorganise onto it when the blocks arrive. Compaction is therefore
+gated off while `IsInitialBlockDownload()` is true, **and** a pass is skipped
+while the best known header has more work than the tip and forks below the
+horizon (§3). Without both, a node could compact a fork block, be reorganised,
+and then trip the assertion on every restart with `-reindex` refused by the
+marker (found in review, 2026-09-03). The header-acceptance-only enforcement is
+a property of the finality rule itself and is tracked separately.
 
 ## 7. Test plan
 
@@ -264,6 +283,10 @@ a fork block, be reorganised, and then trip the assertion on every restart with
 3c. **Durable reservation**: at the first crash point of 3b the block index
    database already holds the append pointer advanced past the reserved target
    and the target's empty file info.
+3e. **Target above every populated file**: with the append pointer moved behind
+   a populated file (the post-reindex layout), a pass compacts the eligible file
+   into a number above every populated one and the populated file's blocks stay
+   readable and unpruned.
 3d. **Fresh-rotation hygiene**: a stray `blk`/`rev` pair at the number the
    append pointer rotates into (the `rev` a hardlink to a source file's undo)
    is removed before anything is written; the source's link count returns to

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1643,6 +1643,17 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                     break;
                 }
 
+                // A reindex that is RESUMING from the persisted reindexing flag
+                // is folded into fReindex by LoadBlockIndexDB, after the
+                // command-line refusal above ran; refuse the combination here
+                // too (found in review).
+                if (fReindex && fWitnessPrune) {
+                    return InitError(_("-witnessprune cannot be combined with -reindex (an interrupted "
+                                       "reindex is resuming): the import rewrites the block-file layout "
+                                       "that compaction reserves file numbers in. Let the reindex finish "
+                                       "without -witnessprune, then re-enable it (doc/PAT_WITNESS_PRUNING.md)."));
+                }
+
                 // If the loaded chain has a wrong genesis, bail out immediately
                 // (we're likely using a testnet datadir, or the other way around).
                 if (!mapBlockIndex.empty() && mapBlockIndex.count(chainparams.GetConsensus(0).hashGenesisBlock) == 0)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1589,13 +1589,18 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 delete pcoinscatcher;
                 delete pblocktree;
 
-                if (fReindex) {
+                if (fReindex || fReindexChainState) {
                     // Witness-pruned data cannot re-verify scripts, so a
                     // reindex would either fail partway or manufacture a node
                     // that believes without having checked; refuse up front
-                    // (doc/PAT_WITNESS_PRUNING.md §2). The flag must be read
-                    // with a NON-WIPING open: the reindex open below wipes the
-                    // block tree, destroying the very marker that refuses it.
+                    // (doc/PAT_WITNESS_PRUNING.md §2). -reindex-chainstate is
+                    // the same hazard by another route: it keeps the block
+                    // files and replays ConnectBlock over them, which fails on
+                    // the first stripped spend outside an assumevalid window
+                    // and silently succeeds inside one (found in review). The
+                    // flag must be read with a NON-WIPING open: the reindex
+                    // open below wipes the block tree, destroying the very
+                    // marker that refuses it.
                     bool fWitnessPruned = false;
                     {
                         CBlockTreeDB peek(1 << 20, false, false);
@@ -1603,9 +1608,22 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                     }
                     if (fWitnessPruned) {
                         return InitError(_("This datadir has witness-pruned block files and "
-                                           "cannot be reindexed: stripped blocks cannot re-verify "
-                                           "signatures. Re-download the chain into a fresh datadir "
-                                           "(doc/PAT_WITNESS_PRUNING.md)."));
+                                           "cannot be reindexed (-reindex or -reindex-chainstate): "
+                                           "stripped blocks cannot re-verify signatures. Re-download "
+                                           "the chain into a fresh datadir (doc/PAT_WITNESS_PRUNING.md)."));
+                    }
+                    if (fReindex && fWitnessPrune) {
+                        // The import rewrites the block-file layout at known
+                        // positions and moves the append pointer backwards,
+                        // which breaks the forward-only reservation argument
+                        // compaction relies on (doc/PAT_WITNESS_PRUNING.md §3,
+                        // §5). Compaction is also gated off while fReindex is
+                        // set; refusing the combination up front makes the
+                        // rule visible instead of silent.
+                        return InitError(_("-witnessprune cannot be combined with -reindex: the import "
+                                           "rewrites the block-file layout that compaction reserves "
+                                           "file numbers in. Run the reindex without -witnessprune, "
+                                           "then re-enable it (doc/PAT_WITNESS_PRUNING.md)."));
                     }
                 }
                 pblocktree = new CBlockTreeDB(nBlockTreeDBCache, false, fReindex);

--- a/src/test/witness_prune_tests.cpp
+++ b/src/test/witness_prune_tests.cpp
@@ -46,6 +46,17 @@ struct ScopedRegtestHorizon {
     }
 };
 
+//! Set a process-wide import flag for a scope; restored on any exit path so a
+//! failing assertion cannot leak the flag into later suites in this binary.
+struct ScopedReindexFlag {
+    ScopedReindexFlag() { fReindex = true; }
+    ~ScopedReindexFlag() { fReindex = false; }
+};
+struct ScopedImportingFlag {
+    ScopedImportingFlag() { fImporting = true; }
+    ~ScopedImportingFlag() { fImporting = false; }
+};
+
 } // namespace
 
 struct WitnessPruneSetup : public DilithiumChainSetup {
@@ -359,14 +370,16 @@ BOOST_AUTO_TEST_CASE(compaction_is_gated_off_during_reindex_and_import)
     };
 
     std::string strError;
-    fReindex = true;
-    BOOST_REQUIRE_MESSAGE(CompactWitnessFiles(strError), strError);
-    fReindex = false;
+    {
+        ScopedReindexFlag reindexing;
+        BOOST_REQUIRE_MESSAGE(CompactWitnessFiles(strError), strError);
+    }
     untouched("during -reindex");
 
-    fImporting = true;
-    BOOST_REQUIRE_MESSAGE(CompactWitnessFiles(strError), strError);
-    fImporting = false;
+    {
+        ScopedImportingFlag importing;
+        BOOST_REQUIRE_MESSAGE(CompactWitnessFiles(strError), strError);
+    }
     untouched("during -loadblock import");
 
     // Same state, gates released: the file compacts. This proves the
@@ -375,6 +388,47 @@ BOOST_AUTO_TEST_CASE(compaction_is_gated_off_during_reindex_and_import)
     BOOST_REQUIRE_MESSAGE(CompactWitnessFiles(strError), strError);
     LOCK(cs_main);
     for (CBlockIndex* p : vFile0) BOOST_CHECK(p->nStatus & BLOCK_WITNESS_PRUNED);
+}
+
+// §3/§7.3e — the target number must be one nothing occupies. After a -reindex
+// the append pointer can sit BEHIND a populated file (the import writes at
+// known positions and the last block it accepts may be a deferred child in an
+// earlier file). With the target chosen as nLastBlockFile + 1 that populated
+// file is nulled and deleted: the tip blocks here. Fails if the target
+// selection goes back to nLastBlockFile + 1.
+BOOST_AUTO_TEST_CASE(compaction_never_reserves_a_populated_file_number)
+{
+    RotateBlockFileForTests();                 // file 0: the fixture chain
+    CreateAndProcessBlock({}, Spk(OP_1));      // file 1: one block
+    RotateBlockFileForTests();
+    ScopedRegtestHorizon horizon(3);
+    for (int i = 0; i < 4; ++i) CreateAndProcessBlock({}, Spk(OP_1)); // file 2: four blocks, the tip
+    const std::vector<CBlockIndex*> vFile0 = BlocksInFile(0);
+    const std::vector<CBlockIndex*> vFile2 = BlocksInFile(2);
+    BOOST_REQUIRE(!vFile0.empty());
+    BOOST_REQUIRE_EQUAL(vFile2.size(), 4u);
+
+    // The post-reindex layout: append pointer behind a populated file.
+    SetLastBlockFileForTests(1);
+
+    std::string strError;
+    BOOST_REQUIRE_MESSAGE(CompactWitnessFiles(strError), strError);
+
+    BOOST_CHECK_MESSAGE(fs::exists(GetBlockPosFilename(CDiskBlockPos(2, 0), "blk")),
+        "compaction deleted a populated block file: the target was chosen as append pointer + 1");
+    LOCK(cs_main);
+    for (CBlockIndex* p : vFile2) {
+        BOOST_CHECK_EQUAL(p->nFile, 2);
+        BOOST_CHECK(!(p->nStatus & BLOCK_WITNESS_PRUNED));
+        CBlock block;
+        BOOST_CHECK_MESSAGE(ReadBlockFromDisk(block, p, Params().GetConsensus(p->nHeight)),
+            "a tip block is unreadable after compaction of an unrelated file");
+    }
+    // File 0 did compact, into a number above every populated file.
+    for (CBlockIndex* p : vFile0) {
+        BOOST_CHECK(p->nStatus & BLOCK_WITNESS_PRUNED);
+        BOOST_CHECK(p->nFile > 2);
+    }
 }
 
 // §3/§7.3d — fresh-rotation hygiene. A number the append pointer rotates INTO

--- a/src/test/witness_prune_tests.cpp
+++ b/src/test/witness_prune_tests.cpp
@@ -16,8 +16,10 @@
 #include "chainparams.h"
 #include "consensus/pat_attestation.h"
 #include "test/dilithium_chain_setup.h"
+#include "fs.h"
 #include "init.h"
 #include "txdb.h"
+#include "util.h"
 #include "validation.h"
 
 #include <boost/test/unit_test.hpp>
@@ -277,6 +279,9 @@ BOOST_AUTO_TEST_CASE(crash_windows_leave_readable_state_and_converge)
 
     // Crash point 1: stripped data written, nothing committed. The index must
     // still point wholly at file 0; the partial target is inert.
+    FlushStateToDisk(); // so the DB's append pointer is current before the pass
+    int nLastBefore = -1;
+    BOOST_REQUIRE(pblocktree->ReadLastBlockFile(nLastBefore));
     std::string strError;
     BOOST_REQUIRE_MESSAGE(CompactWitnessFiles(strError, /*nTestCrashPoint=*/1), strError);
     for (CBlockIndex* p : vFile0) {
@@ -285,6 +290,23 @@ BOOST_AUTO_TEST_CASE(crash_windows_leave_readable_state_and_converge)
     }
     BOOST_CHECK(fs::exists(GetBlockPosFilename(CDiskBlockPos(0, 0), "blk")));
     allReadable("after crash point 1");
+
+    // §7.3c — the reservation is DURABLE at this crash point (found in
+    // review): the DB already holds the append pointer advanced past the
+    // reserved target, and the target's empty file info. A restart therefore
+    // cannot rotate appends into the partial target and its hardlinked rev
+    // file. Fails if the reservation write before I/O is removed: the DB
+    // would still hold the pre-pass pointer until the hourly index flush.
+    {
+        int nLastInDb = -1;
+        BOOST_REQUIRE(pblocktree->ReadLastBlockFile(nLastInDb));
+        BOOST_CHECK_MESSAGE(nLastInDb == nLastBefore + 2,
+            strprintf("DB append pointer is %d, expected %d (target %d reserved, appends continue in %d)",
+                      nLastInDb, nLastBefore + 2, nLastBefore + 1, nLastBefore + 2));
+        CBlockFileInfo reserved;
+        BOOST_CHECK_MESSAGE(pblocktree->ReadBlockFileInfo(nLastBefore + 1, reserved) && reserved.nBlocks == 0,
+            "the reserved target's empty file info was not persisted with the reservation");
+    }
 
     // Crash point 2: index durably moved, originals not yet deleted. Blocks
     // must read from the target; the originals are orphans.
@@ -306,6 +328,121 @@ BOOST_AUTO_TEST_CASE(crash_windows_leave_readable_state_and_converge)
     BOOST_CHECK(!fs::exists(GetBlockPosFilename(CDiskBlockPos(0, 0), "rev")));
     for (CBlockIndex* p : vFile0) BOOST_CHECK_EQUAL(p->nFile, nNewFile);
     allReadable("after the converging pass");
+}
+
+// §3/§7.9 — the gates. Compaction must not run while the file layout is being
+// rewritten (-reindex / -loadblock). The import writes blocks at KNOWN
+// positions and moves the append pointer backwards, so the forward-only
+// reservation argument does not hold: a pass could reserve, then delete, an
+// original file the import has not reached. Fails if the early return in
+// CompactWitnessFiles is removed. The initial-block-download limb shares the
+// predicate but cannot be driven here: IsInitialBlockDownload latches false
+// for the life of the process once the fixture chain is current.
+BOOST_AUTO_TEST_CASE(compaction_is_gated_off_during_reindex_and_import)
+{
+    RotateBlockFileForTests();
+    ScopedRegtestHorizon horizon(3);
+    for (int i = 0; i < 4; ++i) CreateAndProcessBlock({}, Spk(OP_1));
+    const std::vector<CBlockIndex*> vFile0 = BlocksInFile(0);
+    BOOST_REQUIRE(!vFile0.empty());
+    {
+        LOCK(cs_main);
+        BOOST_REQUIRE(WitnessFileEligibleForCompaction(0));
+    }
+    auto untouched = [&](const char* when) {
+        LOCK(cs_main);
+        for (CBlockIndex* p : vFile0) {
+            BOOST_CHECK_MESSAGE(p->nFile == 0 && !(p->nStatus & BLOCK_WITNESS_PRUNED),
+                std::string("compaction ran ") + when + ": the gate is gone");
+        }
+        BOOST_CHECK(fs::exists(GetBlockPosFilename(CDiskBlockPos(0, 0), "blk")));
+    };
+
+    std::string strError;
+    fReindex = true;
+    BOOST_REQUIRE_MESSAGE(CompactWitnessFiles(strError), strError);
+    fReindex = false;
+    untouched("during -reindex");
+
+    fImporting = true;
+    BOOST_REQUIRE_MESSAGE(CompactWitnessFiles(strError), strError);
+    fImporting = false;
+    untouched("during -loadblock import");
+
+    // Same state, gates released: the file compacts. This proves the
+    // eligibility above was real, so the two skips were the gate at work and
+    // not a pass that had nothing to do.
+    BOOST_REQUIRE_MESSAGE(CompactWitnessFiles(strError), strError);
+    LOCK(cs_main);
+    for (CBlockIndex* p : vFile0) BOOST_CHECK(p->nStatus & BLOCK_WITNESS_PRUNED);
+}
+
+// §3/§7.3d — fresh-rotation hygiene. A number the append pointer rotates INTO
+// must carry no leftovers. The dangerous leftover is a rev file that is a
+// HARDLINK to a source file's undo data, left by a compaction interrupted
+// after the link; appending undo through it would overwrite the source's undo
+// in place. Fails if RemoveStrayFilesAtFreshNumber is dropped from the
+// rotation path: the link count stays at two and the source rev file's bytes
+// change when the next block's undo is written.
+BOOST_AUTO_TEST_CASE(fresh_rotation_clears_stray_target_files)
+{
+    int nAppend;
+    {
+        LOCK(cs_main);
+        nAppend = chainActive.Tip()->nFile; // nothing has rotated yet: the tip is in the append file
+    }
+    const int nNext = nAppend + 1;
+    const fs::path revSrc = GetBlockPosFilename(CDiskBlockPos(nAppend, 0), "rev");
+    const fs::path revStray = GetBlockPosFilename(CDiskBlockPos(nNext, 0), "rev");
+    const fs::path blkStray = GetBlockPosFilename(CDiskBlockPos(nNext, 0), "blk");
+    BOOST_REQUIRE(fs::exists(revSrc));
+    BOOST_REQUIRE(!fs::exists(revStray));
+    BOOST_REQUIRE(!fs::exists(blkStray));
+
+    auto fileBytes = [](const fs::path& path) {
+        std::vector<unsigned char> v;
+        FILE* f = fsbridge::fopen(path, "rb");
+        BOOST_REQUIRE(f != nullptr);
+        unsigned char buf[4096];
+        size_t n;
+        while ((n = fread(buf, 1, sizeof(buf), f)) > 0) v.insert(v.end(), buf, buf + n);
+        fclose(f);
+        return v;
+    };
+    const std::vector<unsigned char> srcBefore = fileBytes(revSrc);
+
+    // Plant the leftovers of an interrupted pass.
+    fs::create_hard_link(revSrc, revStray);
+    {
+        FILE* f = fsbridge::fopen(blkStray, "wb");
+        BOOST_REQUIRE(f != nullptr);
+        fputs("partial stripped target", f);
+        fclose(f);
+    }
+    BOOST_REQUIRE_EQUAL(fs::hard_link_count(revSrc), 2u);
+
+    RotateBlockFileForTests(); // rotates INTO nNext through the same hygiene as FindBlockPos
+    BOOST_CHECK_MESSAGE(!fs::exists(blkStray), "stray blk file survived the rotation");
+    BOOST_CHECK_MESSAGE(fs::hard_link_count(revSrc) == 1,
+        "stray rev hardlink survived the rotation: the next undo write would go through it into the source file");
+
+    // Leaving a file finalizes it: the pre-allocated tail of the source rev
+    // file is truncated away. That is the only change rotation may make, so
+    // the post-rotation bytes must be a prefix of the pre-rotation bytes, and
+    // they are the oracle for the write that follows.
+    const std::vector<unsigned char> srcAfterRotate = fileBytes(revSrc);
+    BOOST_REQUIRE(srcAfterRotate.size() <= srcBefore.size());
+    BOOST_REQUIRE(std::equal(srcAfterRotate.begin(), srcAfterRotate.end(), srcBefore.begin()));
+
+    CreateAndProcessBlock({}, Spk(OP_1)); // block and undo land in nNext
+    {
+        LOCK(cs_main);
+        BOOST_CHECK_EQUAL(chainActive.Tip()->nFile, nNext);
+    }
+    BOOST_CHECK(fs::exists(revStray)); // a fresh rev file for nNext, not a link
+    BOOST_CHECK_EQUAL(fs::hard_link_count(revSrc), 1u);
+    BOOST_CHECK_MESSAGE(fileBytes(revSrc) == srcAfterRotate,
+        "the source file's undo data changed when the next block's undo was written");
 }
 
 // §6 — the finality assertion. A disconnect request for a witness-pruned

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5856,6 +5856,31 @@ void PruneAndFlush()
 // implementation; recorded in the specification §3.
 // =============================================================================
 
+//! A file number the append pointer is about to rotate INTO must carry no
+//! leftovers. The only way a blk/rev pair exists at a number whose file info
+//! is empty is an interrupted witness compaction (doc/PAT_WITNESS_PRUNING.md
+//! §3): a partial stripped target, and a rev file that is a HARDLINK to the
+//! source file's undo data. Appending undo through that link would corrupt
+//! the source. An empty file info means no index entry references the number
+//! (file infos and index entries are written in the same batch), so unlinking
+//! is safe; the source keeps its own link. Second line of defence behind the
+//! durable reservation in CompactOneWitnessFile.
+static void RemoveStrayFilesAtFreshNumber(int nFile)
+{
+    AssertLockHeld(cs_LastBlockFile);
+    if (nFile < 0 || nFile >= (int)vinfoBlockFile.size()) return;
+    const CBlockFileInfo& info = vinfoBlockFile[nFile];
+    if (info.nBlocks != 0 || info.nSize != 0 || info.nUndoSize != 0) return;
+    const CDiskBlockPos pos(nFile, 0);
+    for (const char* prefix : {"blk", "rev"}) {
+        const fs::path path = GetBlockPosFilename(pos, prefix);
+        if (fs::exists(path)) {
+            LogPrintf("Removing stray %s file %d (left by an interrupted compaction) before rotating into it\n", prefix, nFile);
+            fs::remove(path);
+        }
+    }
+}
+
 void RotateBlockFileForTests()
 {
     LOCK(cs_main);
@@ -5865,6 +5890,7 @@ void RotateBlockFileForTests()
     if ((int)vinfoBlockFile.size() <= nLastBlockFile) {
         vinfoBlockFile.resize(nLastBlockFile + 1);
     }
+    RemoveStrayFilesAtFreshNumber(nLastBlockFile); // same hygiene as FindBlockPos
     setDirtyFileInfo.insert(nLastBlockFile);
 }
 
@@ -5944,6 +5970,22 @@ static bool CompactOneWitnessFile(int nFile, std::string& strError, int nTestCra
             nLastBlockFile = nTargetFile + 1; // appends continue in a fresh file
             setDirtyFileInfo.insert(nTargetFile);
             setDirtyFileInfo.insert(nLastBlockFile);
+            // Make the reservation DURABLE before any I/O (found in review).
+            // The index is otherwise flushed hourly, so a reservation known
+            // only in memory can be forgotten by a crash after the rev
+            // hardlink below but before the commit flush. A restart would
+            // then rotate appends into nTargetFile, and FindUndoPos would
+            // write undo through the hardlink into the SOURCE file's undo
+            // data. With the advanced append pointer and the two (empty)
+            // file infos on disk, a restart sees the number as taken and the
+            // orphan sweep reclaims the partial target instead.
+            std::vector<std::pair<int, const CBlockFileInfo*> > vReserve;
+            vReserve.push_back(std::make_pair(nTargetFile, &vinfoBlockFile[nTargetFile]));
+            vReserve.push_back(std::make_pair(nLastBlockFile, &vinfoBlockFile[nLastBlockFile]));
+            if (!pblocktree->WriteBatchSync(vReserve, nLastBlockFile, std::vector<const CBlockIndex*>())) {
+                strError = strprintf("witnessprune: cannot persist the reservation of block file %d", nTargetFile);
+                return false;
+            }
         }
         for (const std::pair<const uint256, CBlockIndex*>& item : mapBlockIndex) {
             if (item.second->nFile == nFile) vBlocks.push_back(item.second);
@@ -6069,6 +6111,18 @@ static bool CompactOneWitnessFile(int nFile, std::string& strError, int nTestCra
 
 bool CompactWitnessFiles(std::string& strError, int nTestCrashPoint)
 {
+    // Never compact while the block-file layout is in flux or the chain is
+    // provisional (spec §3, §6; found in review). During -reindex / -loadblock
+    // the import writes blocks at KNOWN positions and moves the append pointer
+    // backwards, so the forward-only reservation argument below does not hold:
+    // a pass could reserve, then delete, an original file the import has not
+    // reached yet. During initial block download the finality horizon is not
+    // enforced (ContextualCheckBlockHeader skips it), so a minority-fork tip
+    // may legitimately be reorganised past the horizon; a block compacted here
+    // would then have to be disconnected, which is AbortNode on every restart.
+    // Skipping a pass costs nothing: the scheduler retries in ten minutes.
+    if (fReindex || fImporting || IsInitialBlockDownload()) return true;
+
     // Orphan sweep: a crash between the index flush and the deletion leaves
     // original files that no index entry references (spec §3, crash window 2).
     // Criterion: a retired file-info slot, not the append file, present on
@@ -6812,6 +6866,7 @@ bool FindBlockPos(CValidationState& state, CDiskBlockPos& pos, unsigned int nAdd
     if ((int)nFile != nLastBlockFile) {
         if (!fKnown) {
             LogPrintf("Leaving block file %i: %s\n", nLastBlockFile, vinfoBlockFile[nLastBlockFile].ToString());
+            RemoveStrayFilesAtFreshNumber(nFile);
         }
         FlushBlockFile(!fKnown);
         nLastBlockFile = nFile;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5857,14 +5857,16 @@ void PruneAndFlush()
 // =============================================================================
 
 //! A file number the append pointer is about to rotate INTO must carry no
-//! leftovers. The only way a blk/rev pair exists at a number whose file info
-//! is empty is an interrupted witness compaction (doc/PAT_WITNESS_PRUNING.md
-//! §3): a partial stripped target, and a rev file that is a HARDLINK to the
-//! source file's undo data. Appending undo through that link would corrupt
-//! the source. An empty file info means no index entry references the number
-//! (file infos and index entries are written in the same batch), so unlinking
-//! is safe; the source keeps its own link. Second line of defence behind the
-//! durable reservation in CompactOneWitnessFile.
+//! leftovers. A blk/rev pair at a number whose file info is empty is
+//! unreferenced data: the partial target of an interrupted witness compaction
+//! (doc/PAT_WITNESS_PRUNING.md §3), whose rev file may be a HARDLINK to a
+//! source file's undo data, or a tail left by a crash between a rotation and
+//! the next index flush. No index entry can reference such a number: entries
+//! and non-empty file infos are written in the same batch, and the only batch
+//! that writes infos alone (the reservation) writes empty ones. Appending undo
+//! through a hardlinked rev would corrupt the source, so unlink; the source
+//! keeps its own link. Second line of defence behind the durable reservation.
+//! Runs on the block-accept path, so failures are logged, never thrown.
 static void RemoveStrayFilesAtFreshNumber(int nFile)
 {
     AssertLockHeld(cs_LastBlockFile);
@@ -5874,11 +5876,26 @@ static void RemoveStrayFilesAtFreshNumber(int nFile)
     const CDiskBlockPos pos(nFile, 0);
     for (const char* prefix : {"blk", "rev"}) {
         const fs::path path = GetBlockPosFilename(pos, prefix);
-        if (fs::exists(path)) {
-            LogPrintf("Removing stray %s file %d (left by an interrupted compaction) before rotating into it\n", prefix, nFile);
-            fs::remove(path);
+        boost::system::error_code ec;
+        if (!fs::exists(path, ec)) continue;
+        LogPrintf("Removing stray %s file %d (unreferenced leftover) before rotating into it\n", prefix, nFile);
+        fs::remove(path, ec);
+        if (ec) {
+            LogPrintf("ERROR: cannot remove stray %s file %d: %s\n", prefix, nFile, ec.message());
         }
     }
+}
+
+void SetLastBlockFileForTests(int nFile)
+{
+    LOCK(cs_main);
+    LOCK(cs_LastBlockFile);
+    FlushBlockFile(true);
+    if ((int)vinfoBlockFile.size() <= nFile) {
+        vinfoBlockFile.resize(nFile + 1);
+    }
+    nLastBlockFile = nFile;
+    setDirtyFileInfo.insert(nLastBlockFile);
 }
 
 void RotateBlockFileForTests()
@@ -5959,13 +5976,40 @@ static bool CompactOneWitnessFile(int nFile, std::string& strError, int nTestCra
     {
         LOCK(cs_main);
         if (!WitnessFileEligibleForCompaction(nFile)) return true; // raced; skip
+        // The target must be a number NOTHING occupies. nLastBlockFile + 1 is
+        // not enough: after a -reindex the append pointer can sit BEHIND a
+        // populated file (the import writes at known positions, and the last
+        // block it accepts may be a deferred child in an earlier file), and
+        // upstream keeps such files as ordinary indexed files beyond the
+        // pointer. Reserving one of them would null its info and delete it.
+        // Take the highest number any index entry or file info uses (found in
+        // review).
+        int nHighestUsed = -1;
+        for (const std::pair<const uint256, CBlockIndex*>& item : mapBlockIndex) {
+            if (item.second->nFile == nFile) vBlocks.push_back(item.second);
+            if (item.second->nStatus & BLOCK_HAVE_DATA) nHighestUsed = std::max(nHighestUsed, item.second->nFile);
+        }
+        std::sort(vBlocks.begin(), vBlocks.end(),
+                  [](const CBlockIndex* a, const CBlockIndex* b) { return a->nDataPos < b->nDataPos; });
         {
             LOCK(cs_LastBlockFile);
             nSourceUndoSize = vinfoBlockFile[nFile].nUndoSize;
-            nTargetFile = nLastBlockFile + 1;
+            nHighestUsed = std::max(nHighestUsed, nLastBlockFile);
+            for (size_t i = 0; i < vinfoBlockFile.size(); ++i) {
+                const CBlockFileInfo& info = vinfoBlockFile[i];
+                if (info.nBlocks != 0 || info.nSize != 0 || info.nUndoSize != 0) {
+                    nHighestUsed = std::max(nHighestUsed, (int)i);
+                }
+            }
+            nTargetFile = nHighestUsed + 1;
             if ((int)vinfoBlockFile.size() <= nTargetFile + 1) {
                 vinfoBlockFile.resize(nTargetFile + 2);
             }
+            // Leaving the current append file: finalize it (fsync + truncate
+            // of the pre-allocated tail) exactly as FindBlockPos does on a
+            // rotation, so the index can never be synced ahead of block data
+            // that is still in kernel buffers (found in review).
+            FlushBlockFile(true);
             vinfoBlockFile[nTargetFile].SetNull();
             nLastBlockFile = nTargetFile + 1; // appends continue in a fresh file
             setDirtyFileInfo.insert(nTargetFile);
@@ -5982,16 +6026,19 @@ static bool CompactOneWitnessFile(int nFile, std::string& strError, int nTestCra
             std::vector<std::pair<int, const CBlockFileInfo*> > vReserve;
             vReserve.push_back(std::make_pair(nTargetFile, &vinfoBlockFile[nTargetFile]));
             vReserve.push_back(std::make_pair(nLastBlockFile, &vinfoBlockFile[nLastBlockFile]));
-            if (!pblocktree->WriteBatchSync(vReserve, nLastBlockFile, std::vector<const CBlockIndex*>())) {
-                strError = strprintf("witnessprune: cannot persist the reservation of block file %d", nTargetFile);
+            try {
+                pblocktree->WriteBatchSync(vReserve, nLastBlockFile, std::vector<const CBlockIndex*>());
+            } catch (const std::runtime_error& e) {
+                // CDBWrapper reports failure by THROWING (dbwrapper_error), not
+                // by returning false, and an exception escaping the scheduler
+                // thread terminates the process. Skip the pass instead; the
+                // in-memory reservation is harmless, and the next full flush
+                // goes through AbortNode if the database is really broken.
+                strError = strprintf("witnessprune: cannot persist the reservation of block file %d: %s",
+                                     nTargetFile, e.what());
                 return false;
             }
         }
-        for (const std::pair<const uint256, CBlockIndex*>& item : mapBlockIndex) {
-            if (item.second->nFile == nFile) vBlocks.push_back(item.second);
-        }
-        std::sort(vBlocks.begin(), vBlocks.end(),
-                  [](const CBlockIndex* a, const CBlockIndex* b) { return a->nDataPos < b->nDataPos; });
     }
 
     // ---- I/O outside cs_main (spec §3 lock discipline). The source blocks
@@ -6112,15 +6159,17 @@ static bool CompactOneWitnessFile(int nFile, std::string& strError, int nTestCra
 bool CompactWitnessFiles(std::string& strError, int nTestCrashPoint)
 {
     // Never compact while the block-file layout is in flux or the chain is
-    // provisional (spec §3, §6; found in review). During -reindex / -loadblock
-    // the import writes blocks at KNOWN positions and moves the append pointer
-    // backwards, so the forward-only reservation argument below does not hold:
-    // a pass could reserve, then delete, an original file the import has not
-    // reached yet. During initial block download the finality horizon is not
-    // enforced (ContextualCheckBlockHeader skips it), so a minority-fork tip
-    // may legitimately be reorganised past the horizon; a block compacted here
-    // would then have to be disconnected, which is AbortNode on every restart.
-    // Skipping a pass costs nothing: the scheduler retries in ten minutes.
+    // provisional (spec §3, §6; found in review). During -reindex the import
+    // writes blocks at KNOWN positions and moves the append pointer backwards,
+    // so the forward-only reservation argument below does not hold: a pass
+    // could reserve, then delete, an original file the import has not reached
+    // yet. A -loadblock import goes through the ordinary forward path, but the
+    // chain is provisional while it runs, the same reason as initial block
+    // download: the finality horizon is not enforced then (ContextualCheck-
+    // BlockHeader skips it), so a minority-fork tip may legitimately be
+    // reorganised past the horizon, and a block compacted here would have to
+    // be disconnected, which is AbortNode on every restart. Skipping a pass
+    // costs nothing: the scheduler retries in ten minutes.
     if (fReindex || fImporting || IsInitialBlockDownload()) return true;
 
     // Orphan sweep: a crash between the index flush and the deletion leaves
@@ -6131,6 +6180,20 @@ bool CompactWitnessFiles(std::string& strError, int nTestCrashPoint)
     std::vector<int> vOrphans;
     {
         LOCK(cs_main);
+        // The finality horizon is enforced when a HEADER is accepted, and not
+        // while the node is in initial block download. A header chain with
+        // more work than the tip that forks below the horizon can therefore
+        // exist in the index (accepted during the initial sync), and the node
+        // will reorganise onto it when the blocks arrive. Compacting a file
+        // now could strip a block that reorganisation must disconnect, which
+        // is AbortNode on every restart. Wait for it to resolve (found in
+        // review; closes the residual the IsInitialBlockDownload gate leaves).
+        if (pindexBestHeader != NULL && chainActive.Tip() != NULL &&
+            pindexBestHeader->nChainWork > chainActive.Tip()->nChainWork) {
+            const int nHorizon = Params().GetConsensus(chainActive.Height()).nMaxReorgDepth;
+            const CBlockIndex* pfork = chainActive.FindFork(pindexBestHeader);
+            if (pfork == NULL || (nHorizon > 0 && chainActive.Height() - pfork->nHeight > nHorizon)) return true;
+        }
         int nFiles;
         int nAppend;
         {

--- a/src/validation.h
+++ b/src/validation.h
@@ -229,6 +229,9 @@ bool WitnessFileEligibleForCompaction(int nFile);
 /** Test-only: finalize the current append file and open a fresh one, so unit
  *  tests can make a block file non-current without mining 128 MiB. */
 void RotateBlockFileForTests();
+//! Test hook: move the append pointer to nFile (simulates the post-reindex
+//! layout in which the pointer sits behind a populated file).
+void SetLastBlockFileForTests(int nFile);
 /** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of chainActive.Tip() will not be pruned. */
 static const unsigned int MIN_BLOCKS_TO_KEEP = 1440;
 


### PR DESCRIPTION
## Scope

Storage code only. `-witnessprune` is default off and not enabled on any fleet node. **Merge, do not deploy**: the FC4 soak certifies the binary that is soaking (rule x7hb); this fix rides the next candidate. Until then the flag stays documented as do-not-enable.

Three defects from the 2026-09-03 adversarial pass over the witness pruning code, plus one more found by the adversarial review of this PR itself. They share one mechanism, the target-file reservation, so they land together.

## 1. No reindex / import / IBD gate (bead zixc)

During `-reindex` the import writes blocks at known positions and moves the append pointer backwards, which breaks the forward-only reservation argument: a scheduled pass could reserve, then delete, an original block file the import had not reached. During initial block download the finality horizon is not enforced, so a compacted fork block could later need disconnecting, which is `AbortNode` on every restart with `-reindex` refused by the marker.

Fix: `CompactWitnessFiles` returns early while `fReindex`, `fImporting` or `IsInitialBlockDownload()` hold. `-witnessprune` together with `-reindex` is refused at init, both from the command line and when an interrupted reindex resumes from its persisted flag. A pass is also skipped while the best known header out-works the tip and forks below the horizon, because headers accepted during initial download were never checked against it (see the separate bead below).

## 2. Memory-only reservation (bead j5z0)

The reservation lived in memory until the commit flush, and the index is otherwise flushed hourly. A crash after the rev hardlink but before the commit forgot the reservation; a restart could rotate appends into the target number, and `FindUndoPos` would write undo through the hardlink into the source file's undo data, silently.

Fix: the reservation (advanced append pointer plus the two empty file infos) is written with `WriteBatchSync` before any I/O, inside a `try` because `CDBWrapper` reports failure by throwing and an exception escaping the scheduler thread terminates the process. The current append file is finalized before the pointer moves, as on an ordinary rotation. Second line of defence: `FindBlockPos` (non-`fKnown` rotation) and the test rotation helper remove any stray `blk`/`rev` pair at a number they rotate into whose file info is empty, using the error-code overload on the block-accept path.

## 3. `-reindex-chainstate` not refused (bead o0bl)

The `witnessprunedblocks` marker refused only `-reindex`. `-reindex-chainstate` keeps the block files and replays `ConnectBlock` over them, which fails on the first stripped spend outside an assumevalid window and silently succeeds inside one. Both flags are now refused.

## 4. Target could be a populated file (found by the review of this PR; present on main)

After a `-reindex` the append pointer can sit behind a populated file: the import writes at known positions and the last block it accepts may be a deferred child in an earlier file, and upstream keeps such files as ordinary indexed files beyond the pointer. The target was chosen as `nLastBlockFile + 1`, so compaction nulled that file's info and deleted it. The target is now one above the highest number any index entry or file info uses.

## Tests

| test | oracle | fails with fix removed |
|---|---|---|
| `compaction_is_gated_off_during_reindex_and_import` | eligible file untouched with `fReindex` / `fImporting` set; compacts once released | yes |
| durability block in `crash_windows_leave_readable_state_and_converge` | DB append pointer advanced by 2 and reserved slot persisted at crash point 1 | yes |
| `fresh_rotation_clears_stray_target_files` | planted hardlinked rev at the next number; link count back to 1; source bytes unchanged after the next block | yes, and the mutated run reproduced the undo corruption byte for byte |
| `compaction_never_reserves_a_populated_file_number` | append pointer moved behind a populated file; that file's blocks stay readable and unpruned; the eligible file compacts above it | yes, tip blocks became unreadable |

The IBD limb of the gate cannot be driven in a unit test because `IsInitialBlockDownload` latches false for the process lifetime once the fixture chain is current; it shares the predicate with the two tested limbs.

`witness_prune_tests`: 8 of 8. `consensus_digest_tests`: pass, digest unmoved. Full `test_soqucoin`: no errors.

## Review dispositions

An independent adversarial review of the first commit returned nine findings. All were verified against source. Fixed here: populated-file target (4 above), throwing `WriteBatchSync`, resumed-reindex bypass of the init refusal, best-header guard for the IBD residual, error-code removal on the accept path, two comment claims that were no longer true, the `-loadblock` attribution, and a scope guard for the test globals. Documented rather than coded: a crash between the reservation sync and target-file creation leaves a reserved number with no file and no marker, so a later permitted `-reindex` stops at the gap and re-downloads the rest, which is upstream's behaviour for any gap. Lock order, startup after a reservation, the stray-file helper's deletion criterion, the test oracles and the `-reindex-chainstate` refusal came back clean.

Filed separately, consensus side, not this PR: the finality horizon is enforced only at header acceptance and skipped during initial download, so headers accepted then are never re-checked (bead `finality-horizon-header-only-8p5y`).

## Spec

`doc/PAT_WITNESS_PRUNING.md` sections 2, 3, 5, 6 and 7 amended to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
