### PR TITLE
pqwallet: re-derive past the 0xFF invalid-key marker in PQKeyPair::DeriveFromSeed (shared retry rule)

### DIFF
--- a/src/test/pqderive_test.cpp
+++ b/src/test/pqderive_test.cpp
@@ -10,6 +10,8 @@
 #include <iostream>
 #include <sstream>
 
+extern "C" int pqcrystals_dilithium2_ref_seed_keypair(uint8_t* pk, uint8_t* sk, const uint8_t* seed);
+
 using namespace soqucoin::pqwallet;
 
 // Hex encoding helper
@@ -127,6 +129,63 @@ int main(int argc, char* argv[])
 
     std::cout << "=== HD Key Derivation Tests ===" << std::endl;
     std::cout << std::endl;
+
+    // Test 0: the 0xFF invalid-key marker is never returned, and the retry
+    // rule is exactly the documented one (pqderive.h, MAX_DERIVE_RETRIES).
+    // Search paths under a fixed seed until retry-0 derivation hits the marker
+    // (expected once per 256 paths), then check DeriveFromSeed skipped it and
+    // returned the retry-1 key.
+    std::cout << "0. Testing the 0xFF invalid-key marker retry..." << std::endl;
+    {
+        SecureBytes seed(64);
+        for (size_t i = 0; i < 64; ++i) seed.data()[i] = static_cast<uint8_t>(0xA5 ^ i);
+        bool exercised = false;
+        for (uint32_t index = 0; index < 4096 && !exercised; ++index) {
+            DerivationPath path;
+            path.index = index;
+            auto km0 = DeriveKeyMaterial(seed, path, DOMAIN_WALLET, 0);
+            std::array<uint8_t, DILITHIUM_PUBKEY_SIZE> pk0;
+            SecureBytes sk0(DILITHIUM_SECKEY_SIZE);
+            if (pqcrystals_dilithium2_ref_seed_keypair(pk0.data(), sk0.data(), km0.data()) != 0) {
+                std::cerr << "   seed keypair failed: FAIL ✗" << std::endl;
+                return 1;
+            }
+            if (pk0[0] != 0xFF) continue;
+            exercised = true;
+            auto kp = PQKeyPair::DeriveFromSeed(seed, path);
+            if (!kp || kp->GetPublicKey()[0] == 0xFF) {
+                std::cerr << "   DeriveFromSeed returned an invalid-marker key at index " << index << ": FAIL ✗" << std::endl;
+                return 1;
+            }
+            auto km1 = DeriveKeyMaterial(seed, path, DOMAIN_WALLET, 1);
+            std::array<uint8_t, DILITHIUM_PUBKEY_SIZE> pk1;
+            SecureBytes sk1(DILITHIUM_SECKEY_SIZE);
+            pqcrystals_dilithium2_ref_seed_keypair(pk1.data(), sk1.data(), km1.data());
+            if (pk1[0] == 0xFF) {
+                std::cout << "   (retry 1 also carries the marker at index " << index << "; rule continues)" << std::endl;
+            } else if (memcmp(kp->GetPublicKey().data(), pk1.data(), DILITHIUM_PUBKEY_SIZE) != 0) {
+                std::cerr << "   DeriveFromSeed did not return the retry-1 key at index " << index << ": FAIL ✗" << std::endl;
+                return 1;
+            }
+            std::cout << "   Marker path found at index " << index << ", re-derived past it: PASS ✓" << std::endl;
+            // Cross-implementation vector (SoquShield and its SDK assert the same):
+            std::cout << "   vector: seed[i]=0xA5^i, path m/44'/21329'/0'/0/" << index
+                      << ", retry-0 pk[0:8]=" << ToHex(pk0.data(), 8)
+                      << ", returned pk[0:8]=" << ToHex(kp->GetPublicKey().data(), 8) << std::endl;
+        }
+        if (!exercised) {
+            std::cerr << "   No marker path in 4096 indexes (probability ~1e-7): FAIL ✗" << std::endl;
+            return 1;
+        }
+        // Retry 0 is byte-identical to the pre-rule derivation for a clean path.
+        DerivationPath p0;
+        auto a = DeriveKeyMaterial(seed, p0, DOMAIN_WALLET);
+        auto b = DeriveKeyMaterial(seed, p0, DOMAIN_WALLET, 0);
+        if (a != b) {
+            std::cerr << "   retry 0 changed the derivation: FAIL ✗" << std::endl;
+            return 1;
+        }
+    }
 
     // Test 1: HD Derivation Determinism
     std::cout << "1. Testing HD derivation determinism..." << std::endl;

--- a/src/test/pqderive_test.cpp
+++ b/src/test/pqderive_test.cpp
@@ -160,7 +160,10 @@ int main(int argc, char* argv[])
             auto km1 = DeriveKeyMaterial(seed, path, DOMAIN_WALLET, 1);
             std::array<uint8_t, DILITHIUM_PUBKEY_SIZE> pk1;
             SecureBytes sk1(DILITHIUM_SECKEY_SIZE);
-            pqcrystals_dilithium2_ref_seed_keypair(pk1.data(), sk1.data(), km1.data());
+            if (pqcrystals_dilithium2_ref_seed_keypair(pk1.data(), sk1.data(), km1.data()) != 0) {
+                std::cerr << "   seed keypair failed at retry 1: FAIL ✗" << std::endl;
+                return 1;
+            }
             if (pk1[0] == 0xFF) {
                 std::cout << "   (retry 1 also carries the marker at index " << index << "; rule continues)" << std::endl;
             } else if (memcmp(kp->GetPublicKey().data(), pk1.data(), DILITHIUM_PUBKEY_SIZE) != 0) {

--- a/src/wallet/pqwallet/pqderive.cpp
+++ b/src/wallet/pqwallet/pqderive.cpp
@@ -184,7 +184,8 @@ std::vector<uint8_t> PathToBytes(const DerivationPath& path)
 std::array<uint8_t, 32> DeriveKeyMaterial(
     const SecureBytes& masterSeed,
     const DerivationPath& path,
-    const std::string& domain)
+    const std::string& domain,
+    uint8_t retry)
 {
     if (masterSeed.size() < 32) {
         return {};
@@ -197,10 +198,15 @@ std::array<uint8_t, 32> DeriveKeyMaterial(
     saltHasher.Write(masterSeed.data(), masterSeed.size()).Finalize(salt.data());
     memory_cleanse(&saltHasher, sizeof(saltHasher));
 
-    // Info = domain || path_bytes
+    // Info = domain || path_bytes [|| retry], the retry byte only for retry > 0
+    // so that retry 0 stays byte-identical to the original scheme (pqderive.h,
+    // MAX_DERIVE_RETRIES).
     std::vector<uint8_t> info(domain.begin(), domain.end());
     auto pathBytes = PathToBytes(path);
     info.insert(info.end(), pathBytes.begin(), pathBytes.end());
+    if (retry > 0) {
+        info.push_back(retry);
+    }
 
     // HKDF
     auto prk = HKDFExtract(salt.data(), salt.size(), masterSeed.data(), masterSeed.size());
@@ -306,22 +312,33 @@ std::unique_ptr<PQKeyPair> PQKeyPair::DeriveFromSeed(
     const SecureBytes& seed,
     const DerivationPath& path)
 {
-    auto keyMaterial = DeriveKeyMaterial(seed, path, DOMAIN_WALLET);
-
     auto keypair = std::make_unique<PQKeyPair>();
 
     // Get internal access for initialization
     std::array<uint8_t, DILITHIUM_PUBKEY_SIZE> pubkey;
     SecureBytes seckey(DILITHIUM_SECKEY_SIZE);
 
-    int result = pqcrystals_dilithium2_ref_seed_keypair(
-        pubkey.data(),
-        seckey.data(),
-        keyMaterial.data());
-
-    memory_cleanse(keyMaterial.data(), keyMaterial.size());
-
-    if (result != 0) {
+    // Re-derive past the 0xFF invalid-key marker (pqderive.h, MAX_DERIVE_RETRIES).
+    // Without this, one path in 256 produced a key CPubKey::IsValid rejects:
+    // its address received and could never spend.
+    bool found = false;
+    for (uint8_t retry = 0; retry <= MAX_DERIVE_RETRIES; ++retry) {
+        auto keyMaterial = DeriveKeyMaterial(seed, path, DOMAIN_WALLET, retry);
+        int result = pqcrystals_dilithium2_ref_seed_keypair(
+            pubkey.data(),
+            seckey.data(),
+            keyMaterial.data());
+        memory_cleanse(keyMaterial.data(), keyMaterial.size());
+        if (result != 0) {
+            memory_cleanse(pubkey.data(), pubkey.size());
+            return nullptr;
+        }
+        if (pubkey[0] != 0xFF) {
+            found = true;
+            break;
+        }
+    }
+    if (!found) {
         memory_cleanse(pubkey.data(), pubkey.size());
         return nullptr;
     }

--- a/src/wallet/pqwallet/pqderive.cpp
+++ b/src/wallet/pqwallet/pqderive.cpp
@@ -337,6 +337,9 @@ std::unique_ptr<PQKeyPair> PQKeyPair::DeriveFromSeed(
             found = true;
             break;
         }
+        // A rejected marker key must not outlive this iteration.
+        memory_cleanse(pubkey.data(), pubkey.size());
+        memory_cleanse(seckey.data(), seckey.size());
     }
     if (!found) {
         memory_cleanse(pubkey.data(), pubkey.size());

--- a/src/wallet/pqwallet/pqderive.h
+++ b/src/wallet/pqwallet/pqderive.h
@@ -36,17 +36,39 @@ extern const std::string DOMAIN_CHANNEL;    // "soqucoin-v1/channel"
 extern const std::string DOMAIN_WATCHTOWER; // "soqucoin-v1/watchtower"
 
 /**
+ * @brief Upper bound on invalid-marker retries in PQKeyPair::DeriveFromSeed.
+ *
+ * CPubKey treats an ML-DSA-44 public key whose first byte is 0xFF as its
+ * invalid-key sentinel (pubkey.h GetLen), so a deterministically derived key
+ * that happens to start with 0xFF (probability 1/256 per path, rho is uniform)
+ * can receive funds and never spend them. The random generator regenerates
+ * (key.cpp); the deterministic path re-derives with a retry counter:
+ *
+ *   retry 0: info = domain || PathToBytes(path)              (unchanged)
+ *   retry r: info = domain || PathToBytes(path) || byte(r)   (r = 1, 2, ...)
+ *
+ * and the first key whose public key does not start with 0xFF is THE key for
+ * that path. Retry 0 is byte-identical to the scheme before this rule, so every
+ * existing valid key and address is unchanged. The probability of exhausting
+ * this bound is 256^-9. Every wallet deriving Soqucoin keys from a seed
+ * (SoquShield, its SDK) implements the same rule.
+ */
+constexpr uint8_t MAX_DERIVE_RETRIES = 8;
+
+/**
  * @brief Derive raw 32-byte key material using HKDF-SHA256
  *
  * @param masterSeed 64-byte BIP-39 derived seed
  * @param path BIP-44 derivation path
  * @param domain Domain separator string
+ * @param retry Invalid-marker retry counter; 0 appends nothing (see MAX_DERIVE_RETRIES)
  * @return 32-byte derived key material
  */
 std::array<uint8_t, 32> DeriveKeyMaterial(
     const SecureBytes& masterSeed,
     const DerivationPath& path,
-    const std::string& domain);
+    const std::string& domain,
+    uint8_t retry = 0);
 
 /**
  * @brief Derive blinding factor for privacy transactions (GAP-010)


### PR DESCRIPTION
## Scope

Wallet code only (`src/wallet/pqwallet`), no consensus change; the consensus digest is unmoved. Merge, do not deploy: the fleet runs `disablewallet=1` and the soak rule stands. Bead `node-pqderive-0xff-marker-retry-ot6q`.

## The gap

`CPubKey` treats an ML-DSA-44 public key whose first byte is 0xFF as its invalid-key sentinel (`pubkey.h`), and `CheckSig` fails on it. The random generator regenerates when that happens (`key.cpp`). The deterministic HD path did not: `PQKeyPair::DeriveFromSeed` derived the key material once and returned whatever `seed_keypair` produced, so one derivation path in 256 yielded a key whose address receives and can never spend. SoquShield and its SDK derive keys with this exact scheme and inherited the gap; it was found while fixing them.

## The rule

Defined here (`pqderive.h`, `MAX_DERIVE_RETRIES`) and mirrored byte for byte in SoquShield (soqucoin-ops #82) and its SDK (soqushield-sdk #7):

- retry 0: `info = domain || PathToBytes(path)`, unchanged;
- retry r (1 to 8): `info = domain || PathToBytes(path) || byte(r)`;
- the first key whose public key does not start with 0xFF is the key for that path.

Retry 0 is byte-identical to the previous scheme, so every existing valid key and address is unchanged and no migration is needed.

## Test

`pqderive-test` gains a first check: search paths under a fixed seed for one whose retry-0 key carries the marker (found at index 392), assert `DeriveFromSeed` returns the retry-1 key instead, assert retry 0 changed nothing, and print the vector for the other implementations. The SoquShield SDK test reproduces the returned key (`f920b5acf83d9a58…`) through its own HKDF and the same C keygen, which is the cross-implementation proof.

`consensus_digest_tests` pass; full `test_soqucoin` run recorded in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
