### PR TITLE
consensus: raise coinbase maturity to the finality horizon (240 -> 288)

### DIFF
--- a/contrib/solo-miner/bitcoin/soqucoin.go
+++ b/contrib/solo-miner/bitcoin/soqucoin.go
@@ -73,7 +73,12 @@ func (Soqucoin) ValidTestnetAddress(address string) bool {
 }
 
 func (Soqucoin) MinimumConfirmations() uint {
-        // FINDING-10 FIX: Match actual coinbase maturity of 100 confirmations.
-        // Was incorrectly set to 10, risking reward distribution for orphaned blocks.
-        return uint(100)
+        // Mainnet coinbase maturity, raised 240 -> 288 on 2026-09-07 so that it
+        // covers the finality horizon nMaxReorgDepth (bead
+        // mainnet-maturity-240-not-30-mp5o). The prior value of 100 matched no
+        // network on this chain: mainnet is 288 from height 1, testnet 240,
+        // regtest 60, so 288 is conservative on the others rather than wrong.
+        // No caller in this tool invokes it today; it is part of the Chain
+        // interface (chain.go) and exists so the figure is not silently stale.
+        return uint(288)
 }

--- a/doc/api-reference.md
+++ b/doc/api-reference.md
@@ -278,7 +278,7 @@ Gracefully stops the node.
 |-----------|-------|-------|
 | Chain ID | `0x5351` (21329) | Used in AuxPoW header |
 | Block Time | 60 seconds | DigiShield adjustment |
-| Coinbase Maturity | 100 blocks | Before reward spendable |
+| Coinbase Maturity | Mainnet 288 (from height 1; 30 at height 0); testnet 240; regtest 60 | Before reward spendable. On mainnet it equals the finality horizon `nMaxReorgDepth`; testnet is a deliberate exception |
 | **Mainnet P2P** | 33388 | Public P2P connections |
 | **Mainnet RPC** | 33389 | Local RPC only |
 | **Testnet P2P** | 44556 | Testnet P2P connections |

--- a/doc/bridge/SOLANA_BRIDGE_ARCHITECTURE.md
+++ b/doc/bridge/SOLANA_BRIDGE_ARCHITECTURE.md
@@ -109,7 +109,7 @@ The Soqucoin-Solana Gateway enables bidirectional transfer of value between the 
 | **Relayer collusion** | Threshold signature, geographic distribution |
 | **Smart contract bugs** | Audit before launch, timelocked upgrades |
 | **Solana outages** | Queue deposits, process on recovery |
-| **Soqucoin reorgs** | Wait for 240+ confirmations (coinbase maturity) |
+| **Soqucoin reorgs** | Wait for 288+ confirmations. That is the chain's own finality horizon (`nMaxReorgDepth`), and coinbase maturity now equals it (`chainparams.cpp`, `nCoinbaseMaturity = 288`). The horizon is enforced when a header is first accepted and is not re-checked, so treat 288 as the practical bound, not an absolute one: bead `finality-horizon-header-only-8p5y`, `doc/PAT_WITNESS_PRUNING.md` §6 |
 | **Key compromise** | Hardware security modules, rotation procedures |
 
 ### Out of Scope (v1)

--- a/doc/guides/mining-guide.md
+++ b/doc/guides/mining-guide.md
@@ -109,7 +109,8 @@ var SoqucoinNetwork = &AuxChain{
         Password:   "your_secure_password",
     },
     BlockReward:    100000,     // Initial block reward
-    ConfirmBlocks:  100,        // Coinbase maturity
+    ConfirmBlocks:  240,        // Coinbase maturity — TESTNET (this block is
+                                // testnet: Port 44555). Mainnet is 288.
 }
 ```
 
@@ -145,7 +146,9 @@ soqucoin-cli getauxblock "blockhash" "auxpow_data"
 
 - **Target**: 60 seconds
 - **Difficulty Adjustment**: DigiShield (every block)
-- **Coinbase Maturity**: 100 blocks
+- **Coinbase Maturity**: network-dependent, and the two differ on purpose.
+  - **Mainnet**: 288 blocks (~4.8 h), equal to the finality horizon `nMaxReorgDepth`, so a coinbase cannot mature inside the window the chain still accepts reorgs in.
+  - **Testnet** (the network this guide is scoped to, see the header): 240 blocks. Testnet is a deliberate exception and is *not* equal to its 288 horizon; it has no height-gated maturity tier, so raising it in place would retroactively invalidate past spends.
 
 ---
 

--- a/doc/specifications/CONSENSUS_COST_SPEC.md
+++ b/doc/specifications/CONSENSUS_COST_SPEC.md
@@ -454,7 +454,7 @@ Standard Bitcoin witness limits were designed for ECDSA (~72 byte signatures). D
 | **Halving Interval** | 250,000 blocks (~174 days)¹ | Modified (Soqucoin) |
 | **Initial Block Reward** | 100,000 SOQ | Modified (Soqucoin) |
 | **Terminal Reward** | 2,500 SOQ (after block 1,000,000) | Modified (Soqucoin) |
-| **Coinbase Maturity** | 30 blocks | Modified (Soqucoin) |
+| **Coinbase Maturity** | 288 blocks (~4.8h), from height 1 | Modified (Soqucoin) |
 | **Finality Horizon** | 288 blocks (~4.8h), via `nMaxReorgDepth` | Novel (Soqucoin) |
 | **AuxPoW Chain ID** | 0x5351 (21329 decimal) | Novel (Soqucoin) |
 
@@ -652,7 +652,7 @@ All values are defined in the Soqucoin Core source code at the following paths:
 | Proof Bytes per Block | 256 KB | **Consensus** | Novel |
 | Transaction Weight | 800,000 | Policy | Modified (SOQ-ARCH-003) |
 | Script Size | 10,000 bytes | **Consensus** | Inherited |
-| Coinbase Maturity | 30 blocks | **Consensus** | Modified |
+| Coinbase Maturity | 288 blocks (from height 1; 30 at height 0) | **Consensus** | Modified |
 | Min Relay Fee | 0.001 SOQ/kB | Policy | Modified |
 | Dust Limit | 0.01 SOQ | Policy | Modified |
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -431,7 +431,26 @@ public:
         digishieldConsensus.fSimplifiedRewards = true;
         digishieldConsensus.fDigishieldDifficultyCalculation = true;
         digishieldConsensus.nPowTargetTimespan = 60; // post-digishield: 1 minute
-        digishieldConsensus.nCoinbaseMaturity = 240;
+        // Coinbase maturity == the finality horizon (288). Ruled 2026-09-07,
+        // bead mainnet-maturity-240-not-30-mp5o.
+        //
+        // INVARIANT: nCoinbaseMaturity >= nMaxReorgDepth. The horizon rejects a
+        // fork only at depth >= nMaxReorgDepth (validation.cpp, "bad-fork-beyond-
+        // finality"), so every reorg SHALLOWER than 288 is consensus-legal and
+        // accepted. At the inherited value of 240 a coinbase became spendable 48
+        // blocks INSIDE that probabilistic window, and coinbase is the one output
+        // class whose reversal invalidates every descendant spend.
+        //
+        // The 240 came from upstream Dogecoin (it arrived with the height-aware
+        // consensus work in 2017); the 288 horizon was added here on 2026-06-23.
+        // The two constants constrain each other and were set nine years apart by
+        // different projects, so nothing had ever compared them. Do not put this
+        // back to 240 to match Dogecoin: this chain has a finality rule and
+        // Dogecoin does not, which is exactly why the values must differ.
+        //
+        // Cost: ~48 min of additional wait at 60s spacing. Absorbed by the
+        // consensus digest per tier, so this re-pins the digest deliberately.
+        digishieldConsensus.nCoinbaseMaturity = 288;
 
         // AuxPoW + DigiShield from block 1 (merged tier).
         // Both standalone Scrypt blocks (solo miners) and AuxPoW blocks
@@ -1381,8 +1400,12 @@ public:
 
         // Mainnet-maturity mirror from block 100,000 (ruled 2026-08-29, bead
         // maturity-tier-doc-divergence-x48g): coinbases MINED at height >=
-        // 100000 mature at 240 like mainnet's post-genesis tiers, so the soak
-        // exercises launch maturity. HEIGHT-GATED, not retroactive: maturity is
+        // 100000 mature like mainnet's post-genesis tiers, so the soak
+        // exercises launch maturity. Raised 240 -> 288 on 2026-09-07 alongside
+        // the mainnet change (bead mainnet-maturity-240-not-30-mp5o); the mirror
+        // is only useful while it actually mirrors. Safe to edit in place:
+        // stagenet was at height 72,864 when this landed, so the gate at 100,000
+        // had not opened and no coinbase has ever matured under this tier. HEIGHT-GATED, not retroactive: maturity is
         // read from the tier at the COINBASE's height (CheckTxInputs), so every
         // historical spend of a pre-gate coinbase stays valid and the stagenet
         // history replay (differential validation) is unaffected.
@@ -1395,7 +1418,7 @@ public:
         // consensus_digest_tests.cpp).
         maturityMirrorConsensus = auxpowConsensus;
         maturityMirrorConsensus.nHeightEffective = 100000;
-        maturityMirrorConsensus.nCoinbaseMaturity = 240;
+        maturityMirrorConsensus.nCoinbaseMaturity = 288;
         maturityMirrorConsensus.pLeft = NULL;
         maturityMirrorConsensus.pRight = NULL;
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -441,6 +441,18 @@ public:
         // blocks INSIDE that probabilistic window, and coinbase is the one output
         // class whose reversal invalidates every descendant spend.
         //
+        // ⚠ WHAT THIS BUYS, STATED HONESTLY. The horizon is enforced in exactly
+        // one place — ContextualCheckBlockHeader — and only when a header is
+        // FIRST accepted: AcceptBlockHeader returns early for a header already in
+        // mapBlockIndex, so the check never re-runs. An attacker who gets headers
+        // accepted while the fork is still shallow and then WITHHOLDS the blocks
+        // can still force a deep reorg when they are finally released. This
+        // invariant therefore closes the header-arrives-on-time case, which is
+        // the reachable one, and not every case. Do NOT restate it as "finality
+        // is absolute" — the residual is real, is tracked as bead
+        // finality-horizon-header-only-8p5y, and is written up in
+        // doc/PAT_WITNESS_PRUNING.md §6.
+        //
         // The 240 came from upstream Dogecoin (it arrived with the height-aware
         // consensus work in 2017); the 288 horizon was added here on 2026-06-23.
         // The two constants constrain each other and were set nine years apart by
@@ -1405,14 +1417,40 @@ public:
         // the mainnet change (bead mainnet-maturity-240-not-30-mp5o); the mirror
         // is only useful while it actually mirrors. Safe to edit in place:
         // stagenet was at height 72,864 when this landed, so the gate at 100,000
-        // had not opened and no coinbase has ever matured under this tier. HEIGHT-GATED, not retroactive: maturity is
-        // read from the tier at the COINBASE's height (CheckTxInputs), so every
-        // historical spend of a pre-gate coinbase stays valid and the stagenet
-        // history replay (differential validation) is unaffected.
-        // ⚠ OPERATIONAL CONSTRAINT: the FC4 fleet deploy must COMPLETE before
-        // stagenet reaches 100000 (~2026-09-25 at 1440 blocks/day from 61372 on
-        // 08-29). A pre-FC4 node spending a post-gate coinbase at depth < 240
-        // would bake history the FC4 binary rejects, forcing a stagenet reset.
+        // had not opened and no coinbase has ever matured under this tier.
+        //
+        // HEIGHT-GATED, not retroactive: maturity is read from the tier at the
+        // COINBASE's height (CheckTxInputs), so every historical spend of a
+        // pre-gate coinbase stays valid and the stagenet history replay
+        // (differential validation) is unaffected.
+        //
+        // ⚠ OPERATIONAL CONSTRAINT — A FLEET REDEPLOY IS REQUIRED, AND TAG v2.3.0
+        // NO LONGER SATISFIES IT. v2.3.0 carries 240 in this tier, so as of this
+        // change it is the OLD binary: it ACCEPTS a post-gate coinbase spent at
+        // depth 240-287 and a node carrying this change rejects it. Every fleet
+        // node must run a binary carrying 288 before stagenet reaches height
+        // 100000 (~2026-09-25 at 1440 blocks/day from 72,864 on 09-07).
+        //
+        // ⚠ THE REACTION WINDOW IS ~288 BLOCKS (~4.8h), NOT THE HEADROOM TO THE
+        // GATE. The split is soft-fork shaped — the new rule is a strict subset of
+        // the old — so if the 240 binaries hold the hashpower majority it is the
+        // UPGRADED nodes that get partitioned. Once the branches are
+        // nMaxReorgDepth apart (the check is >=, so refusal begins AT 288) each
+        // side refuses the other's NEW headers and they can no longer reconcile by
+        // chainwork.
+        //
+        // THE RECOVERY PROCEDURE IS DELIBERATELY NOT HERE. It lives in the
+        // internal fleet deploy runbook, under "Recovery if a node ends up on the
+        // wrong side of the split", where operations reviews it and it can be
+        // corrected without touching consensus source. Two earlier drafts of that
+        // procedure were written in this comment and both were wrong, which is why
+        // it moved. Do not restate it here; update the runbook.
+        //
+        // The consensus facts it rests on are in this tree and are the part worth
+        // citing: the horizon runs at header acceptance only (see the mainnet
+        // tier); a local reorg is not horizon-gated; witness-pruned blocks cannot
+        // be disconnected; and doc/PAT_WITNESS_PRUNING.md §2 and §6 cover those.
+        //
         // The consensus digest absorbs nCoinbaseMaturity per tier, so this
         // change re-pins the digest deliberately (see the pin history in
         // consensus_digest_tests.cpp).

--- a/src/test/consensus_digest_tests.cpp
+++ b/src/test/consensus_digest_tests.cpp
@@ -684,6 +684,7 @@ BOOST_AUTO_TEST_CASE(consensus_digest_is_pinned)
     // (latticeBPSeed via ComputeSoquObscuraSeed). Testnet, stagenet and
     // regtest genesis inputs are untouched. The F4 sweep of record re-runs
     // against the FC4 tag on the fleet toolchain.
+    //
     // Moved from 6f4e1b37... on 2026-09-07 when coinbase maturity was raised to
     // the finality horizon (240 -> 288) on mainnet and on the stagenet
     // mainnet-maturity mirror tier (bead mainnet-maturity-240-not-30-mp5o).
@@ -701,11 +702,17 @@ BOOST_AUTO_TEST_CASE(consensus_digest_is_pinned)
     // Testnet (still 240) and regtest (still 60) are untouched, and the diff of
     // record is two integer assignments in chainparams.cpp and nothing else.
     //
-    // ⚠ TESTNET CARRIES THE SAME GAP AND IS DELIBERATELY NOT FIXED HERE:
-    // it has nMaxReorgDepth 288 against maturity 240, but unlike stagenet it has
-    // no height-gated tier, so editing it in place would retroactively invalidate
-    // every past spend of a coinbase at depth 240-287. It needs a gated tier or a
-    // reset, tracked on the same bead.
+    // ⚠ TWO NETWORKS STILL CARRY THE GAP AND ARE DELIBERATELY NOT FIXED HERE.
+    // Testnet has nMaxReorgDepth 288 against maturity 240 and, unlike stagenet,
+    // no height-gated tier at all, so editing it in place would retroactively
+    // invalidate every past spend of a coinbase at depth 240-287. It needs a
+    // gated tier or a reset, tracked on the same bead. Stagenet BELOW its gate
+    // carries the wider gap — maturity 30 against the same 288 — and it is the
+    // tier the live soak chain runs on; it stays because stagenet is reset for
+    // mainnet and the gated tier already carries the launch value. Do not read
+    // the fix above as "only testnet is exposed". Both are asserted as named
+    // exceptions in genesis_chainparams_tests.cpp so neither can outlive its
+    // cause silently.
     //
     // ⚠ FLEET DEADLINE THIS CREATES: the stagenet mirror gate opens at height
     // 100000 and stagenet was at 72,864 on 2026-09-07 (~19 days of headroom).

--- a/src/test/consensus_digest_tests.cpp
+++ b/src/test/consensus_digest_tests.cpp
@@ -684,8 +684,36 @@ BOOST_AUTO_TEST_CASE(consensus_digest_is_pinned)
     // (latticeBPSeed via ComputeSoquObscuraSeed). Testnet, stagenet and
     // regtest genesis inputs are untouched. The F4 sweep of record re-runs
     // against the FC4 tag on the fleet toolchain.
+    // Moved from 6f4e1b37... on 2026-09-07 when coinbase maturity was raised to
+    // the finality horizon (240 -> 288) on mainnet and on the stagenet
+    // mainnet-maturity mirror tier (bead mainnet-maturity-240-not-30-mp5o).
+    // A RULE change on both, made deliberately by ruling. The invariant being
+    // restored is nCoinbaseMaturity >= nMaxReorgDepth: the horizon rejects a
+    // fork only at depth >= 288, so at 240 a coinbase became spendable 48 blocks
+    // inside the window the chain still accepts reorgs in.
+    //
+    // The absorbed inputs that move, and only these:
+    //   1. mainnet GetConsensus(h).nCoinbaseMaturity for every sampled h >= 1
+    //      (1, 2, 9, 10, 11, 19, 20, 21, 99, 100, 101, 1000, 1000000), 240 ->
+    //      288. Height 0 is the base tier and stays 30.
+    //   2. stagenet GetConsensus(1000000).nCoinbaseMaturity, 240 -> 288 — the
+    //      only sampled height at or above the mirror gate at 100000.
+    // Testnet (still 240) and regtest (still 60) are untouched, and the diff of
+    // record is two integer assignments in chainparams.cpp and nothing else.
+    //
+    // ⚠ TESTNET CARRIES THE SAME GAP AND IS DELIBERATELY NOT FIXED HERE:
+    // it has nMaxReorgDepth 288 against maturity 240, but unlike stagenet it has
+    // no height-gated tier, so editing it in place would retroactively invalidate
+    // every past spend of a coinbase at depth 240-287. It needs a gated tier or a
+    // reset, tracked on the same bead.
+    //
+    // ⚠ FLEET DEADLINE THIS CREATES: the stagenet mirror gate opens at height
+    // 100000 and stagenet was at 72,864 on 2026-09-07 (~19 days of headroom).
+    // The fleet must run this binary before a coinbase mined at >= 100000 is
+    // spent at depth 240-287, or nodes on the old binary and nodes on this one
+    // will disagree and split stagenet.
     const std::string expected =
-        "6f4e1b37fd154fd7e845bfaa67b401a64fb3f5bd9b7a2832451c8fde5be8cfe8";
+        "a0b1e5777acce071132d36c9bb07ce97f9c7b69b3ed5f13eb9a08f66c9baa00a";
 
     BOOST_CHECK_MESSAGE(digest.ToString() == expected,
         "consensus digest is " + digest.ToString() + ", expected " + expected +

--- a/src/test/consensus_validation_tests.cpp
+++ b/src/test/consensus_validation_tests.cpp
@@ -7,7 +7,8 @@
  * @brief Comprehensive tests for consensus-critical validation rules
  *
  * These tests verify:
- * 1. COINBASE_MATURITY enforcement (240 blocks for Soqucoin)
+ * 1. COINBASE_MATURITY enforcement (288 blocks on Soqucoin mainnet; this file's
+ *    fixture is regtest, where the value is 60)
  * 2. Block timestamp validation (median time past, 2-hour future limit)
  * 3. Integration with mempool and block validation
  *
@@ -50,24 +51,31 @@ BOOST_FIXTURE_TEST_SUITE(consensus_validation_tests, TestingSetup)
 /**
  * Test: Verify COINBASE_MATURITY constant is set appropriately
  *
- * Different networks use different maturity values:
- * - Mainnet: 30 pre-DigiShield, 240 post-DigiShield
- * - Testnet: Same as mainnet
- * - Regtest: 60 for easier testing
- * - Stagenet: 30 (mainnet mirror)
+ * Different networks use different maturity values (chainparams.cpp):
+ * - Mainnet:  30 at height 0, 288 from height 1 (== nMaxReorgDepth)
+ * - Testnet:  30 at height 0, 240 from height 1 — NOT the same as mainnet; a
+ *             known exception, see maturity_below_finality_horizon_testnet_*
+ *             in genesis_chainparams_tests.cpp
+ * - Regtest:  60 for easier testing (the value this fixture actually sees)
+ * - Stagenet: 30, then 288 from the mainnet-maturity mirror gate at 100000
  */
 BOOST_AUTO_TEST_CASE(verify_coinbase_maturity_constant)
 {
     // Get consensus params
     const Consensus::Params& paramsGenesis = Params().GetConsensus(0);
 
-    // Verify maturity is set to a reasonable value (30-240 range)
-    BOOST_CHECK(paramsGenesis.nCoinbaseMaturity >= 30);
-    BOOST_CHECK(paramsGenesis.nCoinbaseMaturity <= 240);
+    // This fixture is TestingSetup, i.e. regtest, so paramsGenesis is regtest's
+    // genesis tier and the value is deterministically 60 — pin it. The previous
+    // form was a range check (>= 30 && <= 240, later 288), which is strictly
+    // weaker: it stayed green for any drift inside the range, and regtest's 60 is
+    // pinned nowhere else in src/test/. This case cannot say anything about
+    // mainnet; the per-network values and the maturity-vs-finality invariant are
+    // asserted for real in genesis_chainparams_tests.cpp.
+    BOOST_CHECK_EQUAL(paramsGenesis.nCoinbaseMaturity, 60u);
 
     // Document network-specific values
-    // Mainnet post-DigiShield: 240 blocks * 60 sec = 4 hours
-    // Stagenet: 30 blocks * 60 sec = 30 minutes
+    // Mainnet from height 1: 288 blocks * 60 sec = 4.8 hours (== nMaxReorgDepth)
+    // Regtest (this fixture): 60 blocks
 }
 
 /**

--- a/src/test/genesis_chainparams_tests.cpp
+++ b/src/test/genesis_chainparams_tests.cpp
@@ -216,26 +216,44 @@ BOOST_AUTO_TEST_CASE(launch_ibd_thresholds_are_zero_on_every_network)
     }
 }
 
-// Stagenet mirrors mainnet's effective coinbase maturity (240) from height
-// 100,000, HEIGHT-GATED so historical spends of pre-gate coinbases stay valid
-// and the stagenet history replay is unaffected (ruled 2026-08-29, bead
+// Stagenet mirrors mainnet's effective coinbase maturity from height 100,000,
+// HEIGHT-GATED so historical spends of pre-gate coinbases stay valid and the
+// stagenet history replay is unaffected (ruled 2026-08-29, bead
 // maturity-tier-doc-divergence-x48g). Maturity is read from the tier at the
 // COINBASE's height, so the boundary below is about when a coinbase was MINED.
+//
+// ⛔ THE MIRROR IS ASSERTED AGAINST MAINNET'S ACTUAL VALUE, NOT AGAINST A SECOND
+// LITERAL. The earlier version of this case pinned 240 independently on both
+// networks. That reads as a coupling but is not one: it is two separate facts
+// that happen to agree, and the failure it cannot catch is the one that matters —
+// somebody changes mainnet, updates the mainnet literal because that is the line
+// the compiler pointed at, and the "mirror" silently stops mirroring. Reading the
+// mainnet value at runtime makes drift impossible to express.
 BOOST_AUTO_TEST_CASE(stagenet_maturity_mirrors_mainnet_from_the_gate_height)
 {
+    // Mainnet's effective maturity from height 1 — the value being mirrored.
+    SelectParams(CBaseChainParams::MAIN);
+    const uint32_t mainnetMaturity = Params().GetConsensus(1).nCoinbaseMaturity;
+    BOOST_CHECK_EQUAL(Params().GetConsensus(1000000).nCoinbaseMaturity, mainnetMaturity);
+
+    // One literal pin, so a silent change to mainnet still fails loudly here and
+    // not only in the consensus digest. 288 == the finality horizon
+    // (bead mainnet-maturity-240-not-30-mp5o); see
+    // maturity_covers_finality_horizon_mainnet for why they must be equal.
+    BOOST_CHECK_EQUAL(mainnetMaturity, 288u);
+
     SelectParams(CBaseChainParams::STAGENET);
+    // Below the gate: the base tier, untouched so replayed history stays valid.
     BOOST_CHECK_EQUAL(Params().GetConsensus(0).nCoinbaseMaturity, 30);
     BOOST_CHECK_EQUAL(Params().GetConsensus(1).nCoinbaseMaturity, 30);
     BOOST_CHECK_EQUAL(Params().GetConsensus(100).nCoinbaseMaturity, 30);
     BOOST_CHECK_EQUAL(Params().GetConsensus(99999).nCoinbaseMaturity, 30);
-    BOOST_CHECK_EQUAL(Params().GetConsensus(100000).nCoinbaseMaturity, 240);
-    BOOST_CHECK_EQUAL(Params().GetConsensus(100001).nCoinbaseMaturity, 240);
-    BOOST_CHECK_EQUAL(Params().GetConsensus(1000000).nCoinbaseMaturity, 240);
+    // At and above the gate: whatever mainnet does, exactly.
+    BOOST_CHECK_EQUAL(Params().GetConsensus(100000).nCoinbaseMaturity, mainnetMaturity);
+    BOOST_CHECK_EQUAL(Params().GetConsensus(100001).nCoinbaseMaturity, mainnetMaturity);
+    BOOST_CHECK_EQUAL(Params().GetConsensus(1000000).nCoinbaseMaturity, mainnetMaturity);
 
-    // The value being mirrored: mainnet's effective maturity from height 1.
     SelectParams(CBaseChainParams::MAIN);
-    BOOST_CHECK_EQUAL(Params().GetConsensus(1).nCoinbaseMaturity, 240);
-    BOOST_CHECK_EQUAL(Params().GetConsensus(1000000).nCoinbaseMaturity, 240);
 }
 
 // ============================================================================
@@ -620,6 +638,82 @@ BOOST_AUTO_TEST_CASE(f8_bip_activation_heights_are_soqucoin_not_dogecoin)
     BOOST_CHECK_EQUAL(mainBIP65, sg.BIP65Height);
     BOOST_CHECK_EQUAL(mainBIP66, sg.BIP66Height);
 
+    SelectParams(CBaseChainParams::MAIN);
+}
+
+// ---------------------------------------------------------------------------
+// Coinbase maturity vs the finality horizon (bead mainnet-maturity-240-not-30-mp5o).
+//
+// THE DEFECT THIS EXISTS TO CATCH, stated as the attack rather than as the rule:
+// the horizon rejects a fork only once it is nMaxReorgDepth blocks DEEP, so every
+// reorg shallower than that is consensus-legal and accepted. If a coinbase becomes
+// spendable before that depth, an attacker who can rent enough hashpower to reorg
+// (say) 260 blocks can un-mine a coinbase that has already matured AND been spent,
+// invalidating every descendant transaction. Coinbase is the one output class where
+// this cascades, and it is the class this chain's own pool creates continuously.
+//
+// This test exists because the two constants were set NINE YEARS APART by different
+// projects — 240 arrived with upstream Dogecoin in 2017, the 288-block horizon was
+// added here on 2026-06-23 — and nothing in the tree ever compared them. A green
+// suite is not evidence; the comparison simply did not exist until this case did.
+//
+// Both values are consensus and both are absorbed by the consensus digest, so a
+// change to either after genesis is a hard fork.
+static void CheckMaturityCoversFinality(const char* net, int sampleHeight)
+{
+    const Consensus::Params& c = Params().GetConsensus(sampleHeight);
+
+    // A disabled horizon (regtest) means there is nothing to cover.
+    if (c.nMaxReorgDepth <= 0) return;
+
+    BOOST_CHECK_MESSAGE(
+        (int64_t)c.nCoinbaseMaturity >= (int64_t)c.nMaxReorgDepth,
+        net << ": coinbase matures at " << c.nCoinbaseMaturity
+            << " blocks but the chain still accepts reorgs up to "
+            << (c.nMaxReorgDepth - 1) << " deep (nMaxReorgDepth "
+            << c.nMaxReorgDepth << "). A matured, spent coinbase can therefore be "
+               "un-mined. Raise nCoinbaseMaturity to at least nMaxReorgDepth, or "
+               "lower the horizon — but note that lowering it also shrinks the "
+               "witness-pruned serving window, which is advertised as "
+               "NODE_NETWORK_LIMITED and promises peers the last 288 blocks.");
+}
+
+BOOST_AUTO_TEST_CASE(maturity_covers_finality_horizon_mainnet)
+{
+    SelectParams(CBaseChainParams::MAIN);
+    // Height 0 is the genesis tier; the genesis coinbase is unspendable, so the
+    // property is asserted from height 1 where real coinbases live.
+    CheckMaturityCoversFinality("mainnet h=1", 1);
+    CheckMaturityCoversFinality("mainnet h=1000000", 1000000);
+}
+
+BOOST_AUTO_TEST_CASE(maturity_covers_finality_horizon_stagenet)
+{
+    SelectParams(CBaseChainParams::STAGENET);
+    // Above the mainnet-maturity mirror gate at 100000, stagenet must reproduce
+    // the mainnet property or the soak is not rehearsing launch maturity.
+    CheckMaturityCoversFinality("stagenet h=1000000", 1000000);
+    SelectParams(CBaseChainParams::MAIN);
+}
+
+// ⛔ TESTNET IS A KNOWN, DELIBERATE EXCEPTION — DO NOT "FIX" IT BY EDITING
+// chainparams IN PLACE. Testnet carries the same gap (maturity 240 against a 288
+// horizon), but it has no height-gated maturity tier, so raising the value in place
+// would retroactively invalidate every past spend of a coinbase at depth 240-287 and
+// split or strand the chain. It needs a height-gated tier or a reset, tracked on
+// bead mainnet-maturity-240-not-30-mp5o.
+//
+// This case asserts the EXCEPTION, so the day testnet is fixed this test fails and
+// says so — the exception cannot outlive its cause silently.
+BOOST_AUTO_TEST_CASE(maturity_below_finality_horizon_testnet_known_exception)
+{
+    SelectParams(CBaseChainParams::TESTNET);
+    const Consensus::Params& c = Params().GetConsensus(1);
+    BOOST_CHECK_MESSAGE(
+        (int64_t)c.nCoinbaseMaturity < (int64_t)c.nMaxReorgDepth,
+        "testnet coinbase maturity now covers the finality horizon. If that was "
+        "done on purpose, delete this case and add testnet to "
+        "maturity_covers_finality_horizon_* instead.");
     SelectParams(CBaseChainParams::MAIN);
 }
 

--- a/src/test/genesis_chainparams_tests.cpp
+++ b/src/test/genesis_chainparams_tests.cpp
@@ -659,12 +659,35 @@ BOOST_AUTO_TEST_CASE(f8_bip_activation_heights_are_soqucoin_not_dogecoin)
 //
 // Both values are consensus and both are absorbed by the consensus digest, so a
 // change to either after genesis is a hard fork.
+//
+// ⚠ SCOPE OF THE PROPERTY, so the next reader does not overclaim it. The horizon
+// is enforced in exactly one place, ContextualCheckBlockHeader, and only when a
+// header is FIRST accepted — AcceptBlockHeader returns early for a header already
+// in mapBlockIndex, so the check never re-runs. Headers accepted while a fork is
+// still shallow, with the blocks withheld and released later, can therefore still
+// drive a deep reorg. Satisfying this invariant closes the header-arrives-on-time
+// case, which is the reachable one, and not every case. Tracked as bead
+// finality-horizon-header-only-8p5y; see doc/PAT_WITNESS_PRUNING.md §6.
 static void CheckMaturityCoversFinality(const char* net, int sampleHeight)
 {
     const Consensus::Params& c = Params().GetConsensus(sampleHeight);
 
-    // A disabled horizon (regtest) means there is nothing to cover.
-    if (c.nMaxReorgDepth <= 0) return;
+    // NO SILENT SKIP. This used to return early when nMaxReorgDepth <= 0,
+    // nominally for regtest — but no caller passes regtest, so the only thing
+    // that escape could ever do is let a zeroed mainnet horizon report SUCCESS
+    // here: the invariant becomes unassertable and the case says nothing is
+    // wrong. The tree was not defenceless — nMaxReorgDepth is an absorbed digest
+    // input (consensus_digest_tests.cpp), so consensus_digest_is_pinned fails on
+    // that mutation regardless — but a case that cannot fail is not a case, and
+    // the digest tells you "something moved", not which invariant broke. Assert
+    // the horizon EXISTS first, then assert it is covered.
+    BOOST_REQUIRE_MESSAGE(c.nMaxReorgDepth > 0,
+        net << ": nMaxReorgDepth is " << c.nMaxReorgDepth << ", so the finality "
+               "horizon is DISABLED on a network that is required to have one. "
+               "Disabling it does not satisfy this invariant, it deletes the "
+               "reason the invariant exists. If a network without a horizon is "
+               "genuinely being added, give it its own case rather than widening "
+               "this helper.");
 
     BOOST_CHECK_MESSAGE(
         (int64_t)c.nCoinbaseMaturity >= (int64_t)c.nMaxReorgDepth,
@@ -692,7 +715,18 @@ BOOST_AUTO_TEST_CASE(maturity_covers_finality_horizon_stagenet)
     SelectParams(CBaseChainParams::STAGENET);
     // Above the mainnet-maturity mirror gate at 100000, stagenet must reproduce
     // the mainnet property or the soak is not rehearsing launch maturity.
+    CheckMaturityCoversFinality("stagenet h=100000 (the gate)", 100000);
     CheckMaturityCoversFinality("stagenet h=1000000", 1000000);
+
+    // ⚠ SCOPE: only the mirror tier is asserted, and a green result here does NOT
+    // mean "stagenet is covered". BELOW the gate stagenet runs maturity 30 against
+    // the same 288 horizon — a 258-block gap, five times wider than the 48-block
+    // testnet gap that gets a named exception case below, and it is the tier the
+    // chain is actually running on today. That is deliberate and deliberately not
+    // fixed: stagenet is a disposable soak chain that is reset for mainnet, the
+    // gated tier already carries the launch value from 100000, and editing the
+    // pre-gate tier in place would retroactively invalidate replayed history for
+    // no benefit. Asserted as an exception below so it cannot outlive its cause.
     SelectParams(CBaseChainParams::MAIN);
 }
 
@@ -714,6 +748,25 @@ BOOST_AUTO_TEST_CASE(maturity_below_finality_horizon_testnet_known_exception)
         "testnet coinbase maturity now covers the finality horizon. If that was "
         "done on purpose, delete this case and add testnet to "
         "maturity_covers_finality_horizon_* instead.");
+    SelectParams(CBaseChainParams::MAIN);
+}
+
+// ⛔ STAGENET BELOW THE MIRROR GATE IS THE SECOND KNOWN EXCEPTION, and the wider
+// one: maturity 30 against the 288 horizon. It is the tier the live soak chain is
+// running on right now. Left alone on purpose — stagenet is reset for mainnet and
+// the gated tier at 100000 already carries the launch value, so editing the
+// pre-gate tier would retroactively invalidate replayed history to protect a
+// throwaway chain. Asserted here so that "stagenet is fine" is never inferred from
+// maturity_covers_finality_horizon_stagenet, which only samples the mirror tier.
+BOOST_AUTO_TEST_CASE(maturity_below_finality_horizon_stagenet_pregate_known_exception)
+{
+    SelectParams(CBaseChainParams::STAGENET);
+    const Consensus::Params& c = Params().GetConsensus(99999);
+    BOOST_CHECK_MESSAGE(
+        (int64_t)c.nCoinbaseMaturity < (int64_t)c.nMaxReorgDepth,
+        "stagenet's pre-gate tier now covers the finality horizon. If that was "
+        "done on purpose, delete this case; if it happened by accident, it "
+        "retroactively invalidated replayed stagenet history.");
     SelectParams(CBaseChainParams::MAIN);
 }
 


### PR DESCRIPTION
## What this is

`c6bec52af` raises coinbase maturity from the inherited 240 to 288, the chain's
finality horizon, on mainnet and on the stagenet mainnet-maturity mirror tier.
The second commit is the review fixes for it.

**No consensus value moves in the review commit.** The digest stays pinned at
`a0b1e577...`; that commit is comments, documentation and test assertions only.

## Why the change is correct

Traced through the code, not taken from the design note:

- Rejection is `nReorgDepth >= nMaxReorgDepth` (`src/validation.cpp:7297`), so
  accepted reorgs top out at depth 287.
- Spend is allowed at `nSpendHeight - coins->nHeight >= nCoinbaseMaturity`
  (`src/validation.cpp:1988`). A coinbase at height C is first spendable in the
  block at C+288, i.e. from tip C+287.
- A fork that un-mines block C forks at C-1, so at tip C+287 its depth is 288
  and it is refused. The last tip from which block C can legally be un-mined is
  C+286.

Earliest spend C+288 against last legal un-mine C+286: correct with one block of
slack. `>=` is the right operator and there is no off-by-one. At the old 240 a
coinbase was spendable 48 blocks inside the window the chain still accepts
reorgs in.

Every consensus consumer reads the tier at the **coinbase's** height
(`validation.cpp:1987`, `txmempool.cpp`), which is what makes the stagenet
height gate genuinely non-retroactive.

## Threat and state pass

**Actors.** Honest miners; a hashpower renter (the threat the horizon exists
for); fleet operators mid-upgrade.

**States and transitions.** A coinbase is (mined) -> (immature) -> (mature) ->
(spent). The new rule moves the second transition from depth 240 to depth 288 on
mainnet, and on stagenet only for coinbases MINED at or above height 100000.
Pre-gate stagenet coinbases keep maturity 30, so replayed history stays valid.

**What input makes this check FAIL.** A spend of a coinbase at depth 240-287,
mined at or above the gate. That transaction is valid to a 240 binary and
invalid to a 288 binary (`bad-txns-premature-spend-of-coinbase`).

**Mixed-version fleet.** The new rule is a strict subset of the old, so the
split is soft-fork shaped: if the 240 binaries hold the hashpower majority it is
the UPGRADED nodes that are partitioned onto the minority chain. Divergence
starts at the first block carrying the premature spend, and `gFailedBlocks`
poisons its descendants on the upgraded side from depth 1. Once the branches are
`nMaxReorgDepth` apart (the check is `>=`) each side refuses the other's **new**
headers, so they can no longer reconcile by chainwork at all. **The reaction
window is ~288 blocks, about 4.8 hours from the first divergent block, not the
headroom to the gate.** The recovery procedure lives in the internal fleet
deploy runbook, not in this tree.

**Mainnet exposure is zero.** The chain has not launched: genesis-only
checkpoint, `chainTxData` all zeros. This is a pre-genesis parameter edit.

**Clocks and concurrency.** None. Both constants are height-derived; nothing in
this path reads a wall clock.

**Restart mid-flow.** Maturity is read from the tier at the coinbase's height on
every evaluation, so there is no cached state to go stale across a restart.

## What the invariant does NOT buy

The horizon is enforced in exactly one place, `ContextualCheckBlockHeader`, and
only when a header is FIRST accepted: `AcceptBlockHeader` returns early for a
header already in `mapBlockIndex`, so the check never re-runs. An attacker who
gets headers accepted while the fork is still shallow and then withholds the
blocks can still force a deep reorg when they are released. The first commit
claimed the property was absolute in three places; that is now scoped, and
cross-referenced to bead `finality-horizon-header-only-8p5y`, which has tracked
the residual since before this change. `doc/PAT_WITNESS_PRUNING.md` §6 already
had it right.

288 is still strictly better than 240. It closes the header-arrives-on-time
case, which is the reachable one.

## Code-cited numbers

| Figure | Source |
|---|---|
| maturity 288, mainnet from height 1 | `src/chainparams.cpp` `digishieldConsensus.nCoinbaseMaturity` |
| maturity 288, stagenet from height 100000 | `src/chainparams.cpp` `maturityMirrorConsensus.nCoinbaseMaturity` |
| horizon 288 | `src/chainparams.cpp` `consensus.nMaxReorgDepth`, all three live networks |
| rejection at depth >= horizon | `src/validation.cpp:7297` |
| spend gate | `src/validation.cpp:1988` |
| tag v2.3.0 carries 240 | `git show v2.3.0:src/chainparams.cpp` |
| digest `a0b1e577...` | `src/test/consensus_digest_tests.cpp`, re-run green |

## Review record

Three clean-room review rounds, one non-nesting agent each, given the diff and
the repo only. The consensus change has been stable since the first round: two
integer assignments, digest pinned, boundary arithmetic verified independently
three times. Every defect found in rounds two and three was in operational prose
or documentation, never in the consensus change.

Defects in `c6bec52af` corrected by the second commit:

1. **Invariant oversold** as absolute. Scoped, with the bead cross-reference.
2. **The operational note named the hazard as the fix.** It said a pre-v2.3.0
   node would "bake history the v2.3.0 binary rejects." v2.3.0 carries 240, so
   it is the binary that ACCEPTS the premature spend. An operator would have
   concluded the constraint was already discharged and skipped the redeploy.
3. **Wrong deadline.** The gate-opening date is not the reaction window.
4. **The mainnet invariant test passed vacuously.** `CheckMaturityCoversFinality`
   returned early when `nMaxReorgDepth <= 0`, nominally for regtest, but no
   caller passes regtest. Zeroing the mainnet horizon reported green in that
   case (the digest pin still caught it at suite scope).

Also corrected: a recovery procedure that had been written into the
`chainparams.cpp` comment and was wrong in two successive drafts. It moved to
the internal runbook; the comment keeps the invariant, the deadline and a
pointer. The mining guide (a Testnet3 document, where maturity deliberately
does not equal the horizon), the API reference, the consensus cost
specification, the bridge mitigation table and the solo-miner `Chain`
implementation (which returned a value matching no network) are now
per-network and correct. A `<= 240` range assertion became an exact pin.

Stagenet's PRE-gate tier (maturity 30 vs the 288 horizon) is asserted as a
second known exception alongside testnet, so a green stagenet coverage case
cannot be misread as "stagenet is covered." It is deliberately not fixed:
stagenet is reset for mainnet and the gated tier already carries the launch
value.

## The first test is the attack

Each mutation rebuilt and run at a scope that includes the consensus digest:

| Mutation | Result |
|---|---|
| mainnet `nMaxReorgDepth` 288 -> 0 | **2 failures**: the invariant case and the digest pin |
| stagenet mirror 288 -> 240 | **fails**, 5 assertions across 2 cases, plus the digest |
| stagenet pre-gate 30 -> 288 | **fails** the new exception case |
| regtest maturity 60 -> 61 | **2 failures**: the exact pin and the digest. Green before, inside the old range check |

No double-literal mirror tests survive; the mirror case reads mainnet's value at
runtime and keeps one literal pin.

## Out of scope, filed as beads

- `removeforreorg-null-deref-7qhn` (P1): fixed in #82, which must ship in the
  same fleet binary as this change.
- `stagenet-mirror-tier-zeroed-genesis-lfll` (P2): the mirror tier is copied
  before `hashGenesisBlock` and `latticeBPSeed` are assigned. Latent behind
  `fCheckBlockIndex`; pre-existing.
- `sdk-exchange-doc-maturity-240-8wky` (P2): the exchange integration doc still
  states 240.
- Testnet keeps 240 deliberately: it has no height-gated tier, so an in-place
  edit would retroactively invalidate past spends. Tracked on
  `mainnet-maturity-240-not-30-mp5o`.

## Provenance

- `introduced-this-session`: the four defects in `c6bec52af`, all fixed here.
- `pre-existing`: the null deref, the zeroed mirror tier, the wallet tip-tier
  read (conservative, benign), the standing doc divergence.
- `inherited`: the 240 itself, from upstream Dogecoin's 2017 height-aware
  consensus work.

## Tests

Full suite green, 782 cases, reproduced in a second independent session before
the PR was marked ready.

## Deploy note

⛔ The fleet must run a binary carrying 288 before stagenet reaches height
100000. Stagenet was at 73,473 on 2026-09-07T17:00Z; at 1440 blocks/day the gate
opens ~2026-09-26. Recompute from the live tip. Tag v2.3.0 carries 240 and no
longer satisfies the constraint. Ship together with #82.
