### PR TITLE
mempool: test the missing coin before reading its height in removeForReorg

### DIFF
--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -3,9 +3,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "coins.h"
 #include "policy/policy.h"
+#include "random.h"
 #include "txmempool.h"
 #include "util.h"
+#include "validation.h"
 
 #include "test/test_bitcoin.h"
 
@@ -613,6 +616,77 @@ BOOST_AUTO_TEST_CASE(MempoolEntryNoCrashOnUsdsoqImbalance)
     // The value is clamped to GetValueOut()+fee so the priority heuristic stays sane.
     BOOST_CHECK_EQUAL(entry.GetInChainInputValue(), CTransaction(tx).GetValueOut() + fee);
     BOOST_CHECK(entry.GetTxSize() > 0);
+}
+
+
+// The attack, not the rule: removeForReorg must survive a mempool entry whose
+// input coin is ABSENT from the coins view. That is not a hypothetical state —
+// it is exactly what a reorg produces when the block containing the input is
+// disconnected, and it is the condition the !coins branch below exists to
+// detect. Before this test, the height-aware maturity lookup dereferenced
+// coins->nHeight one line ABOVE the !coins test, so reaching that state
+// segfaulted the node instead of evicting the transaction.
+//
+// The assert(coins) guard on the line above the lookup does not help: it is
+// conditioned on nCheckFrequency != 0, which is 0 in production.
+BOOST_AUTO_TEST_CASE(removeForReorg_evicts_a_tx_whose_input_coin_is_gone)
+{
+    CTxMemPool pool(CFeeRate(0));
+    TestMemPoolEntryHelper entry;
+
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vin[0].prevout.hash = GetRandHash(); // never present in the view below
+    tx.vin[0].prevout.n = 0;
+    tx.vin[0].scriptSig = CScript() << OP_1;
+    tx.vout.resize(1);
+    tx.vout[0].scriptPubKey = CScript() << OP_1;
+    tx.vout[0].nValue = 10 * COIN;
+
+    // spendsCoinbase must be true or the maturity branch is never entered.
+    pool.addUnchecked(tx.GetHash(), entry.SpendsCoinbase(true).FromTx(tx));
+    BOOST_CHECK_EQUAL(pool.size(), 1U);
+
+    CCoinsView dummy;
+    CCoinsViewCache coins(&dummy); // empty: AccessCoins returns NULL
+
+    {
+        // removeForReorg reaches CheckFinalTx and CheckSequenceLocks, which
+        // AssertLockHeld(cs_main) and AssertLockHeld(mempool.cs). The LOCK(cs)
+        // inside removeForReorg takes the LOCAL pool's mutex, a different object
+        // from the global mempool.cs, so it does not satisfy them. Without these
+        // the case abort()s the whole binary under --enable-debug
+        // (DEBUG_LOCKORDER), which is exactly the build someone debugging
+        // mempool behaviour reaches for. Convention follows miner_tests.cpp.
+        LOCK(cs_main);
+        LOCK(mempool.cs);
+        pool.removeForReorg(&coins, chainActive.Height() + 1, STANDARD_LOCKTIME_VERIFY_FLAGS);
+    }
+
+    // Surviving the call is half the property; evicting the entry is the other
+    // half. A tx whose input the node can no longer find must not stay in the
+    // mempool, or it is offered to peers and mined against nothing.
+    BOOST_CHECK_EQUAL(pool.size(), 0U);
+
+    // ⛔ NEGATIVE CONTROL — without this the case can go vacuous in silence.
+    // size()==0 is also satisfied by eviction from the CheckFinalTx /
+    // CheckSequenceLocks branch ABOVE the one under test. It reaches the
+    // coinbase branch today only because TestMemPoolEntryHelper's default
+    // LockPoints makes TestLockPointValidity true, so CheckSequenceLocks takes
+    // the useExistingLockPoints shortcut and never consults the global mempool
+    // or pcoinsTip for the missing input. Change that default and the tx is
+    // evicted by the FIRST branch instead: the assertion above still passes and
+    // has quietly stopped testing the fix. The same transaction that does NOT
+    // spend a coinbase must therefore SURVIVE.
+    CTxMemPool control(CFeeRate(0));
+    TestMemPoolEntryHelper centry;
+    control.addUnchecked(tx.GetHash(), centry.SpendsCoinbase(false).FromTx(tx));
+    {
+        LOCK(cs_main);
+        LOCK(mempool.cs);
+        control.removeForReorg(&coins, chainActive.Height() + 1, STANDARD_LOCKTIME_VERIFY_FLAGS);
+    }
+    BOOST_CHECK_EQUAL(control.size(), 1U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -560,8 +560,24 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache* pcoins, unsigned int nMem
                     continue;
                 const CCoins* coins = pcoins->AccessCoins(txin.prevout.hash);
                 if (nCheckFrequency != 0) assert(coins);
+                // ⛔ THE NULL TEST MUST STAY ABOVE THE MATURITY LOOKUP. Bitcoin
+                // tested !coins first; the height-aware maturity lookup reads
+                // coins->nHeight and was hoisted ABOVE that test by inherited
+                // Dogecoin commit 7b81f4de0 ("Move COINBASE_MATURITY to the
+                // consensus parameters", 2018), so a missing coin dereferenced
+                // NULL. The same commit got it right in CheckTxInputs, where the
+                // lookup sits inside the IsCoinBase() branch; this was a one-file
+                // slip and upstream still carries it. AccessCoins returning NULL
+                // is the condition this branch exists to detect. The assert above
+                // is no guard: nCheckFrequency is 0 outside regtest.
+                if (!coins) {
+                    txToRemove.insert(it);
+                    break;
+                }
+                // Soqucoin: maturity is switched by height, read from the tier at
+                // the COINBASE's height (matching Consensus::CheckTxInputs).
                 int nCoinbaseMaturity = Params().GetConsensus(coins->nHeight).nCoinbaseMaturity;
-                if (!coins || (coins->IsCoinBase() && ((signed long)nMemPoolHeight) - coins->nHeight < nCoinbaseMaturity)) {
+                if (coins->IsCoinBase() && ((signed long)nMemPoolHeight) - coins->nHeight < nCoinbaseMaturity) {
                     txToRemove.insert(it);
                     break;
                 }


### PR DESCRIPTION
## Summary

`CTxMemPool::removeForReorg` read `coins->nHeight` one line ABOVE the `!coins`
test that exists to catch a missing coin, so a mempool entry whose input coin is
absent from the coins view dereferenced NULL.

```cpp
const CCoins* coins = pcoins->AccessCoins(txin.prevout.hash);
if (nCheckFrequency != 0) assert(coins);
int nCoinbaseMaturity = Params().GetConsensus(coins->nHeight)...;  // deref
if (!coins || (coins->IsCoinBase() && ...)) {                      // too late
```

## Provenance: inherited, not ours

Bitcoin tested `!coins` first. The lookup was hoisted above that test by
Dogecoin commit `7b81f4de0`, "Move COINBASE_MATURITY to the consensus
parameters" (2018-01-08). The same commit got it right in `CheckTxInputs`,
where the lookup sits inside the `IsCoinBase()` branch, so it was a one-file
slip. Upstream Dogecoin Core still carries it today and it is worth reporting
there.

The `assert` on the intervening line is not a guard: it is conditioned on
`nCheckFrequency != 0`, which `setSanityCheck` raises only when `-checkmempool`
is non-zero, and that defaults on regtest alone. Outside regtest it never
evaluates; on regtest it aborts instead. A crash either way.

## Reachability, stated accurately

The routine reorg path does NOT reach this. `DisconnectTip` cleans the mempool
itself before `removeForReorg` runs: for a coinbase, `tx.IsCoinBase()`
short-circuits into `removeRecursive(REORG)`, which evicts the in-mempool
children spending it; for a non-coinbase parent it is either re-accepted, in
which case `removeForReorg`'s `mapTx.find` -> `continue` fires, or
`removeRecursive` takes the descendant out. That is why upstream guards the
branch with an assert under `-checkmempool`: it is defensive.

The path that IS reachable is the `DisconnectTip` failure path. `DisconnectTip`
can return false at `FlushStateToDisk` AFTER `view.Flush()` has erased the
disconnected block's coin entries from `pcoinsTip` and BEFORE the resurrection
loop that would have cleaned the mempool. All three callers of `removeForReorg`
(`ActivateBestChainStep`, and both sites in `InvalidateBlock`) then run it over
exactly that state. So an `invalidateblock` on a node that hits a disk-full or
I/O error mid-reorg segfaults instead of performing the intended clean
`AbortNode` shutdown.

Narrow, but real, and the branch is meant to handle it. `invalidateblock` is the
recovery command in the fleet runbook for a maturity version split, so this
ships in the same fleet binary as #81.

## The fix

Test `!coins` and evict, then do the maturity lookup. Behaviour is otherwise
unchanged: the original condition short-circuited to the same eviction, it just
read the pointer before deciding.

## Test

`removeForReorg` had no test coverage at all.
`removeForReorg_evicts_a_tx_whose_input_coin_is_gone` asserts both halves of
the property: the call survives, and the entry is actually evicted, since a
transaction whose input the node can no longer find must not remain in the
mempool and be relayed.

**Verified to discriminate**, in two independent sessions: with the fix reverted it
fails with `memory access violation at address: 0x20`, the `nHeight` offset on a
NULL `CCoins`.

It carries a **negative control**, because `size()==0` is also satisfied by
eviction from the `CheckFinalTx`/`CheckSequenceLocks` branch above the one under
test. It reaches the intended branch today only because the entry helper's
default `LockPoints` make `CheckSequenceLocks` take its `useExistingLockPoints`
shortcut; change that default and the tx is evicted by the first branch instead,
the assertion still passes, and the case has quietly stopped testing the fix.
The same transaction that does NOT spend a coinbase must therefore survive.

The call sites take `cs_main` and `mempool.cs`. `removeForReorg` reaches
`CheckFinalTx` and `CheckSequenceLocks`, which `AssertLockHeld` both; the
`LOCK(cs)` inside `removeForReorg` takes the local pool's mutex, a different
object. Without the locks the case aborts the whole binary under
`--enable-debug`.

## Provenance tag

`inherited`. Found during review of #81, which reasons about the same reorg
path, and not introduced by it. Closes bead `removeforreorg-null-deref-7qhn`.

## Tests

Full suite green, 779 cases (778 on `main` plus this one). This branch is cut
from `main`, not from the maturity branch, so the count differs from #81's 782.
