### PR TITLE
consensus: additive-asset genesis door — only witness v2 stays reserved

### DIFF
--- a/doc/DEPLOYMENT_PRECONDITIONS.md
+++ b/doc/DEPLOYMENT_PRECONDITIONS.md
@@ -97,7 +97,7 @@ PAT, the Practical **Attestation** Technique: Dilithium batch attestation via
 2026-08-31: PAT's attestation is block metadata — a commitment in the coinbase,
 validated in `ConnectBlock` — and not an output type. **Witness v2 is
 permanently unfundable at consensus, unconditionally and not gated on this
-deployment** (`validation.cpp` `versionActive` case 2). Read the flag as "the
+deployment** (the v2 creation rule in `ConnectBlock`). Read the flag as "the
 PAT commitment rules are in force", never as a witness-version gate.
 
 The reason is recorded because it is counter-intuitive: the v2 spend path binds
@@ -205,14 +205,12 @@ Stablecoin authority opcodes, witness v5 (authority) and v7 (holdings).
    is compound-gated on USDSOQ **and** SOQUOBSCURA, and fails closed when both are
    active. Activating both without satisfying the SoquObscura row above turns a
    fail-closed reject into a live confidential path with no verifier.
-5. ☐ **This activation is also a PAT attestation change.** Under
-   `doc/PAT_BLOCK_ATTESTATION.md` §2 (Decision 1, ruled 2026-09-01), v7 holdings
-   join the attested set at this height: every node's recomputed block
-   attestation changes definition at the activation boundary, which is exactly
-   the divergence class the attestation specification exists to prevent. The
-   attested-set tests must pass with the deployment active and withdrawn, and
-   the fleet-coverage requirement of rule 2 applies to the attestation rule as
-   much as to the opcodes.
+5. ☑ **Not an attestation change** (amended 2026-09-07). The PAT attested set
+   is fixed at v0/v1/v7/v8 for every height (`doc/PAT_BLOCK_ATTESTATION.md` §2,
+   Decision 1 as amended), so this activation does not change any node's
+   recomputed block attestation. The earlier "joins at this height" rule was
+   removed with the additive-asset genesis door because an activation-dependent
+   attested set is a hard fork.
 
 ### `DEPLOYMENT_BTCSOQ` (bit 14)
 Bitcoin-backed consensus asset, witness v8 (holding) and v9 (authority).
@@ -226,12 +224,10 @@ Bitcoin-backed consensus asset, witness v8 (holding) and v9 (authority).
    field is 64-byte Ed25519-shaped, which cannot carry ML-DSA-44 (bead `23q1`).
    ⛔ This violates the standing rule: ML-DSA-44 only in the bridge signing path.
 4. ☐ Halborn Phase 2 clearance for the BTCSOQ layer.
-5. ☐ **This activation is also a PAT attestation change.** Under
-   `doc/PAT_BLOCK_ATTESTATION.md` §2 (Decision 1, ruled 2026-09-01), v8 holdings
-   join the attested set at this height. Same obligation as the corresponding
-   USDSOQ precondition: the attested-set tests must pass with the deployment
-   active and withdrawn, and full fleet coverage before the height applies to
-   the attestation rule as much as to the opcodes.
+5. ☑ **Not an attestation change** (amended 2026-09-07). Same as the USDSOQ
+   row: the attested set is fixed at v0/v1/v7/v8, so v8 is attested at every
+   height and this activation leaves every node's recomputed attestation
+   unchanged.
 
 ### `DEPLOYMENT_CTV` (bit 7), `DEPLOYMENT_APO` (bit 8), `DEPLOYMENT_CSFS` (bit 9)
 BIP 119 `OP_CHECKTEMPLATEVERIFY`, BIP 118 `SIGHASH_ANYPREVOUT`, BIP 348

--- a/doc/FOR_AI_REVIEWERS.md
+++ b/doc/FOR_AI_REVIEWERS.md
@@ -44,20 +44,26 @@ Layer 2: script flags. There is no named helper for this; the
 src/validation.cpp:3351 (`unsigned int flags = ...`), one guarded block per
 deployment.
 
-Layer 3: output-creation reservation. Dormant witness versions are
-anyone-can-spend at the script layer, which is the standard soft-fork
-posture (the interpreter returns success for inactive versions, for example
-src/script/interpreter.cpp:1689 and its siblings). But that window cannot
-be funded: `ConnectBlock` consensus-rejects the CREATION of any output
-whose witness version is not active
-(`bad-txns-witness-version-not-active`, src/validation.cpp:3737, the
-SOQ-I009 fix; the versionActive lambda beginning near validation.cpp:3703)
-and rejects any confidential output while SoquObscura is dormant
-(`bad-txns-confidential-not-active`, src/validation.cpp:3663,
-SOQ-ARCH-001).
+Layer 3: relay refusal and the no-wallet-path fact. Dormant witness
+versions are anyone-can-spend at the script layer, which is the standard
+soft-fork posture (the interpreter returns success for inactive versions,
+for example src/script/interpreter.cpp `VerifyScript` and its siblings), and
+outputs of a dormant version are consensus-valid to create. That is
+deliberate: a creation rejection the activation release would have to relax
+is a hard fork, and until 2026-09 the genesis candidate carried exactly that
+(SOQ-I009, SOQ-ARCH-001; retired, record in
+doc/specifications/WITNESS_VERSION_FORK_CLASS.md). What bounds the window is that
+such outputs are NON-STANDARD until their deployment is active
+(src/policy/policy.cpp `IsStandard`, mask from `AcceptToMemoryPoolWorker`)
+and that no wallet or RPC path can construct a non-v1 address
+(src/utiladdress.cpp `DecodeDestination`). Only witness v2 (PAT) is
+consensus-unfundable, because its spend path binds nothing.
 
 If your scan reports "witness v5+ returns set_success, anyone can spend",
-you have read layer 2 without layer 3. Both readings are needed.
+you have read layer 2 without layer 3. Both readings are needed, and the
+finding you may be looking for is a CONSENSUS rule keyed on an asset shape
+that would have to be relaxed at activation — that is the hard-fork class,
+and the fork-class document lists every such site and its disposition.
 
 ## 3. Mainnet activation matrix at genesis
 

--- a/doc/PAT_BLOCK_ATTESTATION.md
+++ b/doc/PAT_BLOCK_ATTESTATION.md
@@ -18,8 +18,8 @@ able to produce identical bytes from this document alone.
 One PAT proof per block, computed over the Dilithium signatures carried by that
 block's attested spends (§2). The proof is committed in the coinbase and
 validated in `ConnectBlock`. The attestation is block metadata. It is not an
-output type: witness v2 is permanently unfundable (`validation.cpp`
-`versionActive` case 2), so no value can be paid into the attestation machinery.
+output type: witness v2 is permanently unfundable (the v2 creation rule in
+`ConnectBlock`), so no value can be paid into the attestation machinery.
 
 The attestation enables witness pruning: nodes may discard attested raw witness
 data past the finality horizon while retaining the attestation (phase 5 of the
@@ -50,22 +50,27 @@ specification today and diverge from it at a future activation height.
 | v4 (confidential SOQ) | No. Witness carries `[range_proof, pubkey_hash, commitment]`; there is no per-input Dilithium signature over a sighash | No | Wrong payload shape; also unfundable while `SOQUOBSCURA` is dormant, and fails closed if activated (no verifier ships) |
 | v5 (USDSOQ authority marker) | Not per-input. Authority transactions carry M-of-N ML-DSA signatures verified whole-transaction in `ConnectBlock`; they skip `VerifyScript` entirely | No — see the authority-signature note below | Not a per-input tuple; a different verification model |
 | v6 (P2WSH-Dilithium) | Sometimes. A witnessScript may perform zero, one, or many signature checks (`OP_CHECKSIGFROMSTACK`, `OP_CHECKDILITHIUMSIG` variants) at positions the block structure does not expose | No — see the v6 note below | No 1:1 spend-to-tuple mapping exists without re-executing scripts |
-| v7 (USDSOQ holding) | Yes, once `USDSOQ` activates. Falls through to the same single-key path as v1; witness is exactly `[sig, pubkey]` | **Yes, from the `USDSOQ` activation height** (Decision 1) | Identical verification to v1; dormant at genesis |
-| v8 (BTCSOQ holding) | Yes, once `BTCSOQ` activates. Same fall-through | **Yes, from the `BTCSOQ` activation height** (Decision 1) | Identical verification to v1; dormant at genesis |
+| v7 (USDSOQ holding) | Yes, once `USDSOQ` activates. Falls through to the same single-key path as v1; witness is exactly `[sig, pubkey]` | **Yes, always** (Decision 1 as amended 2026-09-07) | Identical verification to v1; a dormant two-item spend is attested as bytes |
+| v8 (BTCSOQ holding) | Yes, once `BTCSOQ` activates. Same fall-through | **Yes, always** (Decision 1 as amended 2026-09-07) | Same basis as v7 |
 | v9 (BTCSOQ authority marker) | Not per-input. Same whole-transaction M-of-N model as v5 | No — see the authority-signature note below | Same basis as v5 |
 | v10 (confidential USDSOQ) | No. Same payload shape as v4; compound gate; fails closed if activated | No | Same basis as v4 |
-| v11–v16 | No spend can exist. Unallocated; unfundable under the reservation rule | No | Same basis as v2/v3 |
+| v11–v16 | Unallocated; creatable and anyone-can-spend while unallocated (additive-asset genesis door) | No | No defined tuple |
 
 ### The rule, as ruled (Decision 1, 2026-09-01)
 
 A spend is attested if and only if it is a witness spend whose witness stack is
-exactly two items and whose verification is the single-key Dilithium path. At
-genesis that set is v0 and v1. The set extends to v7 at the `USDSOQ` activation
-height and to v8 at the `BTCSOQ` activation height, from those heights forward.
-Consequently each of those activations is also an attestation change: the
-activation review must confirm full fleet coverage before the height, per
-`doc/DEPLOYMENT_PRECONDITIONS.md` rule 2, and must re-verify the attested-set
-tests with the deployment active and withdrawn.
+exactly two items and whose verification is the single-key Dilithium path:
+v0, v1, v7 and v8, **at every height and independent of deployment state**.
+
+Amended 2026-09-07 (additive-asset genesis door). Decision 1 originally had v7
+join at the `USDSOQ` activation height and v8 at the `BTCSOQ` height. That made
+the block commitment a function of activation state: from the activation height
+on, a genesis-binary node and an upgraded node recompute different attestations
+over the same block and reject each other's commitments in both directions — a
+hard fork by construction, which the additive-asset design forbids. A fixed set
+cannot do that. A dormant v7/v8 spend is an anyone-can-spend two-item spend; its
+tuple is attested as bytes, exactly like every other tuple, and commits to
+nothing about validity.
 
 ### The authority-signature note (v5, v9)
 
@@ -297,13 +302,11 @@ The complete risk surface, collected for review as a single list:
 
 1. **Tie-breaking in the canonical ordering.** Closed by PR #65 and pinned by
    known-answer vectors. This was a measured defect, not a hypothetical.
-2. **The attested set changing under deployment activation** (§2). Ruled
-   (Decision 1): the set extends to v7 and v8 at their activation heights, so
-   the hazard is managed rather than removed. Each such activation is an
-   attestation change, and the activation review must re-verify the
-   attested-set tests with the deployment active and withdrawn. This
-   requirement is carried as a precondition on the `DEPLOYMENT_USDSOQ` and
-   `DEPLOYMENT_BTCSOQ` rows of `doc/DEPLOYMENT_PRECONDITIONS.md`.
+2. **The attested set changing under deployment activation** (§2). Removed
+   (Decision 1 as amended 2026-09-07): the set is fixed at v0/v1/v7/v8 for
+   every height, so no activation changes the commitment and there is no
+   attestation-change review item. The earlier "managed" posture was itself
+   the hard-fork class the additive-asset genesis door exists to remove.
 3. **Public-key encoding duality** (§3). Ruled (Decision 2): `pk` commits to
    the canonical stripped form, so both accepted encodings of a key attest
    identically. Coupled to bead `flpa`: if the duality is later closed by
@@ -347,9 +350,11 @@ coverage.
 
 ## 10. Decisions — RULED 2026-09-01
 
-1. **The attested set (§2): the set extends.** Attestation covers every
-   two-item single-key Dilithium spend, so v7 joins at the `USDSOQ` activation
-   height and v8 at the `BTCSOQ` activation height. Basis for the ruling: the
+1. **The attested set (§2): the set is fixed.** Attestation covers every
+   two-item single-key Dilithium spend of v0/v1/v7/v8 at every height
+   (amended 2026-09-07: v7/v8 originally joined at their activation heights,
+   which made the commitment activation-dependent, i.e. a hard fork). Basis
+   for the original ruling, still the basis for including v7/v8 at all: the
    extension honours the "every single-key Dilithium signature is committed"
    contract and keeps v7/v8 witnesses prunable, and the added process cost is
    one review item on an activation checklist that `DEPLOYMENT_PRECONDITIONS.md`

--- a/doc/specifications/CONSENSUS_COST_SPEC.md
+++ b/doc/specifications/CONSENSUS_COST_SPEC.md
@@ -105,13 +105,16 @@ There is no BIP9 miner-signaling activation.
 > (retired, can never activate), v4 = SoquObscura confidential, v5 = USDSOQ authority,
 > v6 = P2WSH-Dilithium, v7 = USDSOQ holding, v8/v9 = BTCSOQ, v10 = confidential USDSOQ,
 > v11-v16 = unallocated. Each handler pushes the witness stack into `EvalScript()` with the
-> corresponding opcode. Flag gating ensures soft fork safety, and creating an output of a
-> dormant witness version is consensus-rejected in ConnectBlock (SOQ-I009,
-> `bad-txns-witness-version-not-active`).
+> corresponding opcode. Flag gating ensures soft fork safety. Creating an output of any witness
+> version except v2 is consensus-valid at every height; v2 (PAT) is permanently unfundable
+> because its spend path binds nothing (`bad-txns-witness-version-not-active`).
 >
 > **Dormant features**: When the enforcement flag is not set, transactions using that witness version
-> pass as anyone-can-spend (standard BIP141 behavior). This allows future activation at a published
-> flag-day height without a hard fork.
+> pass as anyone-can-spend (standard BIP141 behavior), and outputs of that version are non-standard
+> so they do not relay. Activation only adds the requirement that the spend verify, so activation
+> at a published flag-day height is a soft fork. See `doc/specifications/WITNESS_VERSION_FORK_CLASS.md`
+> for the per-version fork-class record and the additive asset-rule design the asset deployments
+> (USDSOQ, BTCSOQ, SoquObscura) must follow to stay soft forks.
 
 ### LatticeFold+ Performance (ALWAYS_ACTIVE from Genesis)
 
@@ -502,12 +505,16 @@ constituency, and the real activation precondition (audit clearance) is what a h
 
 > [!IMPORTANT]
 > **Pre-activation behavior**: spends of dormant witness versions evaluate as anyone-can-spend
-> per BIP141 at the script layer, but this window cannot be funded: ConnectBlock
-> consensus-rejects the CREATION of any output whose witness version is not active
-> (SOQ-I009, `bad-txns-witness-version-not-active`) and any confidential output while
-> SoquObscura is dormant (SOQ-ARCH-001, `bad-txns-confidential-not-active`). Standardness
-> additionally keeps such transactions out of the mempool. Setting the activation height in
-> a released binary enables full consensus enforcement without a hard fork.
+> per BIP141 at the script layer, and outputs of a dormant version are consensus-valid to
+> create but non-standard, so they do not relay and no wallet path constructs them. This is
+> what makes a flag-day activation a soft fork: the released binary only ADDS the requirement
+> that the spend verify. Until 2026-09 the genesis candidate reserved every dormant version at
+> consensus (SOQ-I009) and rejected confidential outputs while SoquObscura was dormant
+> (SOQ-ARCH-001); both closed a fund-and-sweep hazard at the price of turning every
+> activation into a hard fork, and both were retired (`doc/specifications/WITNESS_VERSION_FORK_CLASS.md`).
+> Only v2 (PAT) remains consensus-unfundable, because its spend path binds nothing.
+> For the asset deployments the creation gate was not the only hard-fork-shaped rule: their
+> value rules must also be additive (same document, §3).
 
 ### Genesis Features (ALWAYS_ACTIVE)
 
@@ -560,7 +567,7 @@ Witness v6 → P2WSH-Dilithium script hash                             [NOT_SCHE
 Witness v7 → USDSOQ holding                                          [NOT_SCHEDULED on mainnet]
 Witness v8/v9 → BTCSOQ holding / authority marker                    [NOT_SCHEDULED on mainnet]
 Witness v10 → Confidential USDSOQ (requires USDSOQ + SOQUOBSCURA)    [NOT_SCHEDULED]
-Witness v11-v16 → Unallocated: output creation consensus-rejected (SOQ-I009)
+Witness v11-v16 → Unallocated: anyone-can-spend, non-standard, creatable (BIP141 posture)
 ```
 
 Each handler pushes the witness stack into `EvalScript()` with the corresponding opcode. Flag gating

--- a/doc/specifications/WITNESS_VERSION_FORK_CLASS.md
+++ b/doc/specifications/WITNESS_VERSION_FORK_CLASS.md
@@ -9,8 +9,9 @@ may therefore **add** a rejection, and may never accept anything the genesis bin
 Two corollaries decide everything below:
 
 1. A consensus rule in the genesis binary that **rejects** a shape is a promise every later
-   release must keep. A rule that **exempts, skips or widens** on a shape is one every later
-   release must keep exempting.
+   release must keep. An **exemption, skip or widening** that is dormant in the genesis binary
+   and switches ON at activation is a loosening, i.e. a hard fork; an exemption the genesis
+   binary applies may be dropped later, since dropping it only tightens.
 2. So the genesis binary carries **no consensus behaviour keyed on a dormant feature's shape**
    unless that behaviour is one every later release will keep verbatim.
 
@@ -28,13 +29,18 @@ switches from reject to accept at activation is a hard fork however it is gated.
 | Undo mirrors for asset supply, authority outpoint, freeze registry and key images | `DisconnectBlock` | state corruption, not fork class: reversed ops ConnectBlock never applied | gated on the deployment exactly as ConnectBlock is |
 | Asset/attestation opcodes inside a v6 script: `BAD_OPCODE` while the asset flag is clear, executed once set | `interpreter.cpp` v6 path | rejection relaxed at asset activation → hard fork for every asset activation after P2WSH-Dilithium | made unconditionally invalid inside v6 (opcodes are dispatched by witness version, never by script) |
 | Coinbase asset bans (`bad-cb-usdsoq-asset`, `bad-cb-btcsoq-asset`) and dual-marker ban | `CheckTransaction` | rejections every release keeps | **kept**, coinbase USDSOQ ban extended to v10 |
+| `HasDilithiumSignatures` (`bad-txns-requires-dilithium`): the LAST witness item of every non-coinbase input must begin `0x00`, with a whole-tx exemption when an `OP_5` output plus an authority-shaped witness is present | `CheckTransaction` via `primitives/transaction.cpp` | the check is a rejection every release keeps; the exemption is applied by the genesis binary (dropping it later only tightens) | **kept**; constrains every future witness layout (§4.8) |
+| PAT attested set: v7/v8 two-item spends joined the set only when their deployment was active | `consensus/pat_attestation.cpp`, `ConnectBlock` commitment check | commitment became a function of activation state → genesis and upgraded nodes reject each other's commitments = **hard fork** | set fixed at v0/v1/v7/v8 for every height |
+| Mempool marker-spend mirrors (`bad-*-marker-spend`) | `AcceptToMemoryPoolWorker` | policy, not fork class, but DoS(100) on a consensus-valid spend of a dormant marker | gated on the deployment like their ConnectBlock twins |
 | Per-asset `nValue` conservation and per-asset fee filter | `CheckTxInputs`, ConnectBlock | rejections/accounting every release keeps | kept; satisfied trivially forever under §4 |
 | Ex-nihilo mint exemption from conservation; authority script skip | `CheckTxInputs`, `CheckInputs` | gated on deployment active and authority initialised; never fire on mainnet in the genesis binary | kept dormant; **the activation release must delete both** (§4) |
 
 Net posture of the genesis binary on mainnet: witness v3–v16 are creatable, anyone-can-spend at
-consensus, worth their `nValue` in SOQ, non-standard until their deployment activates, with no
-asset accounting of any kind. v2 (PAT) is permanently unconstructable because its spend path
-binds neither the witness program nor the sighash.
+consensus and non-standard until their deployment activates. Every `nValue` is plaintext SOQ.
+The asset holding shapes v7/v8/v10 can only be created with `nValue == 0` (the unconditional
+per-asset conservation rule and the coinbase bans); every other shape carries whatever SOQ it is
+paid. v2 (PAT) is permanently unconstructable because its spend path binds neither the witness
+program nor the sighash.
 
 ## 3. Per-version fork class after the change
 
@@ -81,9 +87,18 @@ The genesis binary makes activation *possible* as a soft fork. The activation re
    of spends of listed outpoints. Coinbase and dual-marker bans are rejections. Nothing keyed on
    a shape may exempt, skip, widen, or change how SOQ value is counted.
 6. **SoquObscura uses the shielded-pool model.** Shielding pays visible SOQ into pool outputs,
-   unshielding spends them back to visible SOQ, and only transfers inside the pool hide amounts
-   and links. SOQ conservation holds publicly at every pool boundary. Per-output hidden amounts
-   on the base layer cannot be a soft fork on any UTXO chain.
+   unshielding spends them back to visible SOQ, and only the notes inside the pool (commitments
+   that are not UTXOs) hide amounts and links. Every UTXO's `nValue`, including every pool
+   output's, stays plaintext, so no conservation rule changes. SOQ conservation holds publicly
+   at every pool boundary. Per-output hidden amounts in `nValue` on the base layer cannot be a
+   soft fork on any UTXO chain.
+8. **Witness layout constraint from `HasDilithiumSignatures`.** The genesis binary rejects any
+   non-coinbase transaction whose input witness does not END with a `0x00`-prefixed item, unless
+   the `OP_5`-marker exemption applies (which the activation release deletes with the script
+   skip). Every future layout must satisfy it: the authority M-of-N witness on a v5/v9 marker
+   input must end with a `0x00`-prefixed item (for example a `0x00`-prefixed authority set), and
+   a pool-spend witness for SoquObscura must end with a `0x00`-prefixed item rather than a bare
+   commitment.
 7. **UTXO_COST**, when scheduled, exempts zero-value asset outputs as it already exempts the
    authority markers. It is dormant in the genesis binary, so any version of it is a tightening.
 

--- a/doc/specifications/WITNESS_VERSION_FORK_CLASS.md
+++ b/doc/specifications/WITNESS_VERSION_FORK_CLASS.md
@@ -1,0 +1,104 @@
+# DL — Witness-version fork class and the additive asset-rule posture
+
+Status: ratified 2026-09-07. Applies to the mainnet genesis binary and every later release.
+
+## 1. The rule
+
+A release is a soft fork iff every block it accepts, the genesis binary also accepts. A release
+may therefore **add** a rejection, and may never accept anything the genesis binary rejects.
+Two corollaries decide everything below:
+
+1. A consensus rule in the genesis binary that **rejects** a shape is a promise every later
+   release must keep. A rule that **exempts, skips or widens** on a shape is one every later
+   release must keep exempting.
+2. So the genesis binary carries **no consensus behaviour keyed on a dormant feature's shape**
+   unless that behaviour is one every later release will keep verbatim.
+
+"Dormant in the binary" is necessary for a later flag-day activation to be a soft fork. It is not
+sufficient. The *shape* of the dormant feature's rules decides the fork class, and a rule that
+switches from reject to accept at activation is a hard fork however it is gated.
+
+## 2. What was in the genesis candidate and what changed (2026-09)
+
+| rule | where | class before | disposition |
+|---|---|---|---|
+| SOQ-I009 creation reservation: a block may not create an output of a dormant witness version | `validation.cpp` ConnectBlock | rejection relaxed at activation → **hard fork per version** | retired for every version except v2 |
+| SOQ-ARCH-001: confidential (v4/v10) outputs rejected while SoquObscura dormant | ConnectBlock | same | retired |
+| `bad-*-authority-not-active`: authority-shaped tx rejected while the asset deployment is dormant | `CheckInputs` | same (the activation release accepts the shape) | replaced by fall-through to ordinary per-input script verification |
+| Undo mirrors for asset supply, authority outpoint, freeze registry and key images | `DisconnectBlock` | state corruption, not fork class: reversed ops ConnectBlock never applied | gated on the deployment exactly as ConnectBlock is |
+| Asset/attestation opcodes inside a v6 script: `BAD_OPCODE` while the asset flag is clear, executed once set | `interpreter.cpp` v6 path | rejection relaxed at asset activation → hard fork for every asset activation after P2WSH-Dilithium | made unconditionally invalid inside v6 (opcodes are dispatched by witness version, never by script) |
+| Coinbase asset bans (`bad-cb-usdsoq-asset`, `bad-cb-btcsoq-asset`) and dual-marker ban | `CheckTransaction` | rejections every release keeps | **kept**, coinbase USDSOQ ban extended to v10 |
+| Per-asset `nValue` conservation and per-asset fee filter | `CheckTxInputs`, ConnectBlock | rejections/accounting every release keeps | kept; satisfied trivially forever under §4 |
+| Ex-nihilo mint exemption from conservation; authority script skip | `CheckTxInputs`, `CheckInputs` | gated on deployment active and authority initialised; never fire on mainnet in the genesis binary | kept dormant; **the activation release must delete both** (§4) |
+
+Net posture of the genesis binary on mainnet: witness v3–v16 are creatable, anyone-can-spend at
+consensus, worth their `nValue` in SOQ, non-standard until their deployment activates, with no
+asset accounting of any kind. v2 (PAT) is permanently unconstructable because its spend path
+binds neither the witness program nor the sighash.
+
+## 3. Per-version fork class after the change
+
+| ver | owner | activation class | note |
+|---|---|---|---|
+| v0/v1 | Dilithium | active | base forms |
+| v2 | PAT | n/a | not an output type; permanently unfundable |
+| v3 | LatticeFold (retired) | soft, if ever revived with a sound verifier | creatable, anyone-can-spend |
+| v4 | SoquObscura pool (confidential SOQ) | **soft**, provided the activation release follows §4 (shielded-pool value model) | |
+| v5 / v7 | USDSOQ authority / holding | **soft**, provided the activation release follows §4 | |
+| v6 | P2WSH-Dilithium | **soft** | spend binds `SHA256(witnessScript)` to the program and the sighash inside the script; the covenant opcodes (CTV, CSFS, CDKH, V6_CONTROLFLOW) are NOP-when-clear inside v6 scripts and can activate with it or after it |
+| v8 / v9 | BTCSOQ holding / authority | **soft**, provided the activation release follows §4 | |
+| v10 | confidential USDSOQ | **soft**, provided the activation release follows §4 | the USDSOQ-gated backstop `bad-txns-usdsoq-confidential-not-active` stays: it is a tightening |
+| v11–v16 | unallocated | soft for any future version whose rules are additive | allocation-time review applies §1 |
+
+Out of scope here and tracked separately: `DEPLOYMENT_APO` gates SIGHASH_ANYPREVOUT at consensus
+on the v1/v7/v8 path, so its activation is a rejection relaxed = hard fork; the additive fix is
+to reject those hashtypes on v1/v7/v8 permanently and reach APO only inside v6 scripts.
+
+## 4. The additive asset-rule design the activation releases must follow
+
+The genesis binary makes activation *possible* as a soft fork. The activation release makes it
+*actual* only if every rule it adds is a rejection. Concretely:
+
+1. **Asset amounts live outside `nValue`.** Every v7/v8/v10 output carries `nValue = 0`. The
+   asset amount is committed in a per-transaction ledger output (`OP_RETURN`, tag, version,
+   `(vout, amount)` pairs) that old nodes ignore and new nodes parse. An asset output without a
+   ledger entry has amount 0. Pre-activation asset-shaped outputs have amount 0 by definition.
+2. **SOQ conservation stays asset-blind.** `in ≥ out` and `fee = in − out` over every output.
+   The genesis binary's per-asset conservation and fee-filter rules only ever see zeros for
+   asset outputs and are therefore satisfied trivially forever; they are not relaxed, and they
+   need not be.
+3. **Asset conservation is an added rule** over ledger amounts, with an outpoint-keyed asset
+   index in the coins database (no wire-format change). Mint and burn are additional checks that
+   permit a ledger imbalance iff the authority check passes; they are never exemptions from (2).
+4. **Authority verification is additive.** The authority transaction's fee input is an ordinary
+   v1 spend with an ordinary signature; the M-of-N ML-DSA-44 signatures ride in the witness of
+   the v5/v9 marker input it spends (the authority UTXO chain). The genesis binary sees that
+   marker spend as anyone-can-spend; the activation release requires the M-of-N. **The
+   whole-transaction script-verification skip and the conservation exemption in the genesis
+   binary must be deleted by the activation release**; inheriting either would accept
+   transactions the genesis binary rejects.
+5. **Every asset rule is gated on its deployment and only ever rejects.** Freeze is a rejection
+   of spends of listed outpoints. Coinbase and dual-marker bans are rejections. Nothing keyed on
+   a shape may exempt, skip, widen, or change how SOQ value is counted.
+6. **SoquObscura uses the shielded-pool model.** Shielding pays visible SOQ into pool outputs,
+   unshielding spends them back to visible SOQ, and only transfers inside the pool hide amounts
+   and links. SOQ conservation holds publicly at every pool boundary. Per-output hidden amounts
+   on the base layer cannot be a soft fork on any UTXO chain.
+7. **UTXO_COST**, when scheduled, exempts zero-value asset outputs as it already exempts the
+   authority markers. It is dormant in the genesis binary, so any version of it is a tightening.
+
+## 5. Why the retired rules existed, and what bounds the hazard now
+
+SOQ-I009 (2026-08-24) closed two hazards: fund-and-sweep of a dormant shape, and asset markers
+buying consensus exemptions while the verifier was dormant. The second is closed at its source:
+every exemption is gated on the deployment being active *and* the authority initialised, so the
+shape alone buys nothing, and the activation release deletes the exemptions outright. The first
+is bounded, not closed, exactly as it is on Bitcoin: dormant-version outputs are non-standard
+(`policy.cpp`, mask from `AcceptToMemoryPoolWorker`), no wallet or RPC path constructs a
+non-v1 address (`utiladdress.cpp`), and a stock miner builds blocks from its mempool. Reaching
+the anyone-can-spend window takes raw construction plus a miner running modified policy, and
+the only funds at risk are the constructor's own.
+
+Tests: `witness_version_reservation_tests` (creation posture, the steal, relay refusal,
+activation-tightens, the value premise on both paths, reorg over dormant shapes),
+`v6_asset_opcode_ban_tests`, `authority_skip_gate_tests`, `usdsoq_v10_reject_path_tests`.

--- a/doc/specifications/WITNESS_VERSION_FORK_CLASS.md
+++ b/doc/specifications/WITNESS_VERSION_FORK_CLASS.md
@@ -92,6 +92,8 @@ The genesis binary makes activation *possible* as a soft fork. The activation re
    output's, stays plaintext, so no conservation rule changes. SOQ conservation holds publicly
    at every pool boundary. Per-output hidden amounts in `nValue` on the base layer cannot be a
    soft fork on any UTXO chain.
+7. **UTXO_COST**, when scheduled, exempts zero-value asset outputs as it already exempts the
+   authority markers. It is dormant in the genesis binary, so any version of it is a tightening.
 8. **Witness layout constraint from `HasDilithiumSignatures`.** The genesis binary rejects any
    non-coinbase transaction whose input witness does not END with a `0x00`-prefixed item, unless
    the `OP_5`-marker exemption applies (which the activation release deletes with the script
@@ -99,8 +101,6 @@ The genesis binary makes activation *possible* as a soft fork. The activation re
    input must end with a `0x00`-prefixed item (for example a `0x00`-prefixed authority set), and
    a pool-spend witness for SoquObscura must end with a `0x00`-prefixed item rather than a bare
    commitment.
-7. **UTXO_COST**, when scheduled, exempts zero-value asset outputs as it already exempts the
-   authority markers. It is dormant in the genesis binary, so any version of it is a tightening.
 
 ## 5. Why the retired rules existed, and what bounds the hazard now
 

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -179,6 +179,7 @@ BITCOIN_TESTS =\
   test/authority_skip_gate_tests.cpp \
   test/witness_prune_tests.cpp \
   test/witness_version_reservation_tests.cpp \
+  test/v6_asset_opcode_ban_tests.cpp \
   test/apo_hashtype_gate_tests.cpp \
   test/dormancy_matrix_tests.cpp \
   test/usdsoq_reorg_tests.cpp \

--- a/src/consensus/pat_attestation.cpp
+++ b/src/consensus/pat_attestation.cpp
@@ -48,8 +48,16 @@ bool IsAttestedVersion(int version, const AttestedSetParams& params)
 {
     switch (version) {
     case 0: case 1: return true;                  // base forms, active from genesis
-    case 7: return params.fUsdsoqActive;          // USDSOQ holding, joins at activation
-    case 8: return params.fBtcsoqActive;          // BTCSOQ holding, joins at activation
+    // v7/v8 are attested UNCONDITIONALLY (additive-asset genesis door,
+    // 2026-09). They used to join at their deployment's activation height,
+    // which made the block commitment a function of activation state: a
+    // genesis node and an upgraded node would recompute different
+    // attestations over the same block from the activation height onward and
+    // reject each other's commitments — a hard fork by construction. A set
+    // that never changes cannot do that. Dormant v7/v8 spends are anyone-
+    // can-spend two-item spends; attesting their (unverified) tuples commits
+    // to bytes, not to validity, exactly as for every other tuple.
+    case 7: case 8: return true;                  // USDSOQ / BTCSOQ holding, fixed
     default: return false;                        // spec §2 disposition table
     }
 }

--- a/src/consensus/pat_attestation.cpp
+++ b/src/consensus/pat_attestation.cpp
@@ -46,6 +46,7 @@ int WitnessVersionOf(const CScript& scriptPubKey)
 
 bool IsAttestedVersion(int version, const AttestedSetParams& params)
 {
+    (void)params;   // retained for interface shape; the set no longer depends on it
     switch (version) {
     case 0: case 1: return true;                  // base forms, active from genesis
     // v7/v8 are attested UNCONDITIONALLY (additive-asset genesis door,

--- a/src/consensus/pat_attestation.h
+++ b/src/consensus/pat_attestation.h
@@ -27,13 +27,16 @@
 
 namespace patattest {
 
-//! Which fall-through witness versions are in the attested set at this block's
-//! height (spec §2, Decision 1: v7 joins at USDSOQ activation, v8 at BTCSOQ
-//! activation). The caller derives these from DeploymentActiveAtHeight; this
-//! module takes facts, not chain state.
+//! Parameters of the attested-set rule. Since the additive-asset genesis door
+//! (2026-09) the set is FIXED — v0/v1/v7/v8 two-item spends, independent of
+//! any deployment — because a set that changes at an activation height makes
+//! the block commitment disagree between a genesis node and an upgraded one
+//! (a hard fork). The two flags are retained so the collector's interface and
+//! the spec's disposition-table tests keep their shape; IsAttestedVersion no
+//! longer consults them.
 struct AttestedSetParams {
-    bool fUsdsoqActive = false;
-    bool fBtcsoqActive = false;
+    bool fUsdsoqActive = false;   // no longer consulted
+    bool fBtcsoqActive = false;   // no longer consulted
 };
 
 //! Witness version of the one canonical Soqucoin shape, OP_N <32 bytes>
@@ -42,9 +45,9 @@ struct AttestedSetParams {
 //! dispatch; those three must never diverge.
 int WitnessVersionOf(const CScript& scriptPubKey);
 
-//! The attested-set rule of spec §2: v0/v1 always; v7/v8 per params. Every
-//! other version is never attested, each for the reason recorded in the
-//! spec's disposition table.
+//! The attested-set rule of spec §2: v0/v1/v7/v8 always (the two-item
+//! single-key shapes). Every other version is never attested, each for the
+//! reason recorded in the spec's disposition table.
 bool IsAttestedVersion(int version, const AttestedSetParams& params);
 
 //! One block's batch, as the three parallel vectors CreateLogarithmicProof

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1610,8 +1610,8 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
     // NOTE: v6 (P2WSH-Dilithium), v7 (USDSOQ holding), v8 (BTCSOQ holding)
     // and v9 (BTCSOQ authority marker) are carved out above.
     // Witness v10 is ALLOCATED: confidential USDSOQ (SOQ-ARCH-004), gated on
-    // DEPLOYMENT_USDSOQ and DEPLOYMENT_SOQUOBSCURA together (validation.cpp
-    // versionActive case 10). It is not a generic future version (bead jzg0).
+    // DEPLOYMENT_USDSOQ and DEPLOYMENT_SOQUOBSCURA together (the compound gate
+    // in the dispatch below). It is not a generic future version (bead jzg0).
     bool is_confidential_usdsoq_witness = (scriptPubKey.size() == 34 &&
                                            scriptPubKey[0] == OP_10 &&
                                            scriptPubKey[1] == 32);
@@ -1694,10 +1694,14 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
 
     // Dormant witness versions (v4-v10 allocated, v11-v16 unallocated):
     // spends are anyone-can-spend at the script layer until each version's
-    // deployment activates. This window cannot be funded: creating an output
-    // of an inactive witness version is consensus-rejected in ConnectBlock
-    // (SOQ-I009, bad-txns-witness-version-not-active), and standardness
-    // (policy/policy.cpp) keeps such transactions out of the mempool.
+    // deployment activates. That is BIP141's posture and it is what makes each
+    // activation a soft fork: the activation only ADDS the requirement that the
+    // spend verify. Outputs of a dormant version are consensus-valid to create
+    // (ConnectBlock reserves only v2, whose spend path binds nothing) but
+    // NON-STANDARD (policy/policy.cpp gates v2-v16 on the live activation
+    // mask), and no wallet path can construct one, so the anyone-can-spend
+    // window is reachable only by raw construction plus a miner running
+    // modified policy, with only the constructor's own funds at risk.
     if (is_latticebp_witness) {
         if (!(flags & SCRIPT_VERIFY_SOQUOBSCURA)) {
             return set_success(serror);  // Not active yet — anyone-can-spend
@@ -1813,6 +1817,35 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
 
         // Deserialize the witnessScript
         CScript witnessScript(witnessScriptBytes.begin(), witnessScriptBytes.end());
+
+        // Asset and attestation opcodes are dispatched by WITNESS VERSION (v2,
+        // v3, v4, v5 above), never from inside a script, and a v6 script may
+        // not contain one. This is UNCONDITIONAL — not gated on the asset
+        // deployments — because EvalScript answers BAD_OPCODE for these while
+        // their flag is clear and executes them once it is set. Reachable from
+        // a v6 script, that is a rule that FAILS before an asset activation and
+        // SUCCEEDS after it, i.e. a loosening, which would make every asset
+        // activation that follows P2WSH-Dilithium a hard fork. Rejecting the
+        // opcode's presence in every state is a rule the activation release
+        // keeps, so it stays a soft fork. Scanned with GetOp so bytes inside
+        // pushes are not mistaken for opcodes; a script that fails to parse is
+        // rejected here rather than half-executed.
+        {
+            CScript::const_iterator pc = witnessScript.begin();
+            opcodetype op;
+            std::vector<unsigned char> pushIgnored;
+            while (pc < witnessScript.end()) {
+                if (!witnessScript.GetOp(pc, op, pushIgnored)) {
+                    return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
+                }
+                if (op == OP_USDSOQ_MINT || op == OP_USDSOQ_BURN ||
+                    op == OP_USDSOQ_FREEZE || op == OP_USDSOQ_ROTATE ||
+                    op == OP_SOQUOBSCURA_RANGEPROOF || op == OP_CHECKFOLDPROOF ||
+                    op == OP_CHECKPATAGG) {
+                    return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
+                }
+            }
+        }
 
         // Execute the witnessScript via EvalScript.
         // SECURITY NOTE: The witnessScript is used as the scriptCode for sighash

--- a/src/test/authority_skip_gate_tests.cpp
+++ b/src/test/authority_skip_gate_tests.cpp
@@ -21,10 +21,14 @@
 // has (mainnet defines no authority keys either, and additionally ships the
 // deployment NOT_SCHEDULED). So regtest reproduces the mainnet gap exactly.
 //
-// FIXED by SOQ-I009 (see validation.cpp): the skip is now gated on the same
-// deployment flag + initialised authority as the verifier that replaces it,
-// and the v5/v7/v8/v9 shapes are reserved from genesis. Every case below now
-// asserts the SAFE outcome, so the file is a regression guard, not a repro.
+// FIXED by SOQ-I009 (see validation.cpp): the skip is now granted only when
+// the deployment is active AND the authority is initialised — the same two
+// guards as the verifier that replaces it. With the deployment DORMANT an
+// authority-shaped tx is an ordinary tx and every input runs ordinary script
+// verification (the additive-asset genesis door, 2026-09, replaced the
+// earlier outright rejection of that shape: a rejection the activation
+// release would have to relax is a hard fork). Every case below asserts the
+// SAFE outcome, so the file is a regression guard, not a repro.
 //
 // The cases below are byte-identical except for ONE opcode in one output:
 // OP_1 (control) vs OP_5 (attack). Both carry the same deliberately invalid
@@ -286,20 +290,31 @@ BOOST_AUTO_TEST_CASE(op5_marker_does_not_skip_script_verification)
 }
 
 // Same forgery under MAINNET posture: DEPLOYMENT_USDSOQ withdrawn, exactly as
-// CMainParams ships it. Here the deployment gate is what must catch it.
-BOOST_AUTO_TEST_CASE(op5_marker_rejected_when_usdsoq_not_scheduled)
+// CMainParams ships it. No skip is granted while the deployment is dormant, so
+// the forged 6-item witness on someone else's coin is verified like any other
+// input and fails in VerifyScript — the same path as the control, and like the
+// control it has no reject string to pin. (Until 2026-09 this was an outright
+// "bad-usdsoq-authority-not-active" rejection; that rejection would have been
+// relaxed by the activation release, which is a hard fork, so it became a
+// fall-through to ordinary verification.)
+BOOST_AUTO_TEST_CASE(op5_marker_does_not_skip_scripts_when_usdsoq_not_scheduled)
 {
     UpdateRegtestActivationHeight(Consensus::DEPLOYMENT_USDSOQ,
                                   Consensus::BIP9Deployment::NOT_SCHEDULED);
     SelectParams(CBaseChainParams::REGTEST);
 
-    const std::string why = RejectReasonFor({ BuildForgedAuthoritySteal(coinbaseTxns[1], 5) });
+    const int heightBefore = chainActive.Height();
+    std::vector<CMutableTransaction> txns{ BuildForgedAuthoritySteal(coinbaseTxns[1], 5) };
+    CBlock b = CreateAndProcessBlock(txns, victimSpk);
 
     UpdateRegtestActivationHeight(Consensus::DEPLOYMENT_USDSOQ, 0);  // restore
     SelectParams(CBaseChainParams::REGTEST);
 
-    BOOST_TEST_MESSAGE("reject: '" << why << "'");
-    BOOST_CHECK_EQUAL(why, "bad-usdsoq-authority-not-active");
+    BOOST_CHECK_MESSAGE(chainActive.Tip()->GetBlockHash() != b.GetHash(),
+        "STEAL CONNECTED: with DEPLOYMENT_USDSOQ dormant, an OP_5 marker plus an "
+        "authority-shaped witness skipped script verification and spent someone "
+        "else's coin. The skip must never be granted without the verifier.");
+    BOOST_CHECK_EQUAL(chainActive.Height(), heightBefore);
 }
 
 // The BTCSOQ twin, with BTCSOQ ACTIVE (stock regtest). Unlike USDSOQ, the
@@ -316,23 +331,28 @@ BOOST_AUTO_TEST_CASE(op9_marker_caught_when_btcsoq_deployment_active)
 }
 
 // The BTCSOQ twin under MAINNET posture: DEPLOYMENT_BTCSOQ withdrawn, exactly
-// as CMainParams ships it. SCRIPT_VERIFY_BTCSOQ is then never set, so the
-// entire ConnectBlock BTCSOQ block — default-deny included — is skipped, while
-// the CheckInputs skip is unchanged.
-BOOST_AUTO_TEST_CASE(op9_marker_skips_scripts_when_btcsoq_not_scheduled)
+// as CMainParams ships it. SCRIPT_VERIFY_BTCSOQ is never set, so no skip is
+// granted and the forged witness fails ordinary script verification, exactly
+// as in the USDSOQ case above.
+BOOST_AUTO_TEST_CASE(op9_marker_does_not_skip_scripts_when_btcsoq_not_scheduled)
 {
     UpdateRegtestActivationHeight(Consensus::DEPLOYMENT_BTCSOQ,
                                   Consensus::BIP9Deployment::NOT_SCHEDULED);
     SelectParams(CBaseChainParams::REGTEST);
 
-    const std::string why = RejectReasonFor({
-        BuildForgedAuthoritySteal(coinbaseTxns[2], 9, BTCSOQ_OP_MINT) });
+    const int heightBefore = chainActive.Height();
+    std::vector<CMutableTransaction> txns{
+        BuildForgedAuthoritySteal(coinbaseTxns[2], 9, BTCSOQ_OP_MINT) };
+    CBlock b = CreateAndProcessBlock(txns, victimSpk);
 
     UpdateRegtestActivationHeight(Consensus::DEPLOYMENT_BTCSOQ, 0);  // restore
     SelectParams(CBaseChainParams::REGTEST);
 
-    BOOST_TEST_MESSAGE("reject: '" << why << "'");
-    BOOST_CHECK_EQUAL(why, "bad-btcsoq-authority-not-active");
+    BOOST_CHECK_MESSAGE(chainActive.Tip()->GetBlockHash() != b.GetHash(),
+        "STEAL CONNECTED: with DEPLOYMENT_BTCSOQ dormant, a v9 marker plus an "
+        "authority-shaped witness skipped script verification and spent someone "
+        "else's coin. The skip must never be granted without the verifier.");
+    BOOST_CHECK_EQUAL(chainActive.Height(), heightBefore);
 }
 
 // Positive control: SOQ-I009 must not break ordinary spending. A correctly

--- a/src/test/btcsoq_lifecycle_harness_tests.cpp
+++ b/src/test/btcsoq_lifecycle_harness_tests.cpp
@@ -558,11 +558,11 @@ BOOST_AUTO_TEST_CASE(connectblock_rejects_exotic_input_in_btcsoq_transfer)
 // where supply is auditable, and a hidden amount there breaks the invariant
 // outright (GENIUS Act 4(a)(2)).
 //
-// SoquObscura has to be ACTIVE for this to be the rule that fires. While it is
-// dormant, SOQ-ARCH-001 rejects every confidential output block-wide, earlier in
-// the same ConnectBlock, and would shadow this. That ordering is itself worth
-// pinning: the assertion below is what tells us which of the two is doing the
-// work at any given time.
+// SoquObscura is activated here so the confidential output is a real
+// confidential output rather than a dormant anyone-can-spend shape. (Until
+// 2026-09 SOQ-ARCH-001 rejected every confidential output block-wide while
+// SoquObscura was dormant and would have shadowed this rule; it was retired
+// with the additive-asset genesis door.)
 BOOST_AUTO_TEST_CASE(connectblock_rejects_confidential_output_in_btcsoq_authority_tx)
 {
     ScopedRegtestActivation on(Consensus::DEPLOYMENT_SOQUOBSCURA, 0);

--- a/src/test/pat_attestation_tests.cpp
+++ b/src/test/pat_attestation_tests.cpp
@@ -147,23 +147,24 @@ BOOST_AUTO_TEST_CASE(find_commitments_counts_every_match)
 
 // Fails if the version rule drifts from the spec's disposition table in either
 // direction: a version wrongly attested changes every affected block's
-// commitment; a version wrongly excluded breaks the Decision 1 extension.
+// commitment; a version wrongly excluded changes it the other way. The set is
+// FIXED and must not depend on deployment state: a set that changed at an
+// activation height would make the genesis binary and the activation release
+// recompute different commitments over the same block (a hard fork).
 BOOST_AUTO_TEST_CASE(attested_set_matches_the_disposition_table)
 {
-    patattest::AttestedSetParams off;                 // genesis posture
-    patattest::AttestedSetParams on;                  // both deployments active
+    patattest::AttestedSetParams off;                 // flags clear
+    patattest::AttestedSetParams on;                  // flags set (must be ignored)
     on.fUsdsoqActive = true;
     on.fBtcsoqActive = true;
 
     for (int v = -1; v <= 17; ++v) {
-        const bool baseForm = (v == 0 || v == 1);
-        BOOST_CHECK_MESSAGE(patattest::IsAttestedVersion(v, off) == baseForm,
-            "genesis attested set must be exactly {v0, v1}; disagreed at v" << v);
+        const bool attested = (v == 0 || v == 1 || v == 7 || v == 8);
+        BOOST_CHECK_MESSAGE(patattest::IsAttestedVersion(v, off) == attested,
+            "attested set must be exactly {v0, v1, v7, v8}; disagreed at v" << v);
 
-        const bool extended = baseForm || v == 7 || v == 8;
-        BOOST_CHECK_MESSAGE(patattest::IsAttestedVersion(v, on) == extended,
-            "fully-activated attested set must be exactly {v0, v1, v7, v8}; "
-            "disagreed at v" << v);
+        BOOST_CHECK_MESSAGE(patattest::IsAttestedVersion(v, on) == patattest::IsAttestedVersion(v, off),
+            "the attested set must not depend on deployment flags; disagreed at v" << v);
     }
 }
 
@@ -226,17 +227,18 @@ BOOST_AUTO_TEST_CASE(both_pubkey_encodings_attest_identically)
         "of the canonical stripped form (spec section 3, Decision 2).");
 }
 
-// The Decision 1 activation boundary. Fails in one direction if v7 spends are
-// attested at genesis posture (the set silently widened), and in the other if
-// activation does not extend the set (the ruling not implemented).
-BOOST_AUTO_TEST_CASE(v7_joins_the_attested_set_only_at_activation)
+// A v7 two-item spend is attested in EVERY deployment state. Fails if the
+// collector starts consulting the flags again: a genesis node (flags clear)
+// and an activation-release node (flags set) would then build different
+// batches over the same block and reject each other's commitments.
+BOOST_AUTO_TEST_CASE(v7_is_attested_regardless_of_activation_state)
 {
     CTxOut prevout;
     const CBlock block = BlockSpending(coinbaseTxns[2], Spk(OP_7), prevout);
 
     patattest::AttestedSetParams genesis;
     BOOST_CHECK_EQUAL(
-        patattest::CollectBatch(block, LookupReturning(prevout), genesis).size(), 0u);
+        patattest::CollectBatch(block, LookupReturning(prevout), genesis).size(), 1u);
 
     patattest::AttestedSetParams activated;
     activated.fUsdsoqActive = true;

--- a/src/test/usdsoq_v10_reject_path_tests.cpp
+++ b/src/test/usdsoq_v10_reject_path_tests.cpp
@@ -17,9 +17,12 @@
 //     opcodes. Empty set, so the rule could not fire (bead don9).
 //   * bad-txns-usdsoq-conf-input — the identical defect in the authority BURN
 //     input loop, left behind when the output loop was widened (bead n1vf).
-//   * bad-txns-usdsoq-confidential-not-active — reachable in principle but
-//     SHADOWED by SOQ-ARCH-001, which runs earlier in the same ConnectBlock on
-//     the same flags. Pinned below so the shadowing cannot change silently.
+//   * bad-txns-usdsoq-confidential-not-active — until 2026-09 SHADOWED by
+//     SOQ-ARCH-001, a generic all-assets rejection of confidential outputs that
+//     ran earlier in the same ConnectBlock. SOQ-ARCH-001 was retired with the
+//     additive-asset genesis door (rejecting a dormant shape's CREATION made
+//     SoquObscura activation a hard fork), so this asset-specific, USDSOQ-gated
+//     backstop is now the rule that fires. Pinned below.
 //
 // Two things had to exist before any of this could be tested at all, and their
 // absence is why it never was:
@@ -234,14 +237,16 @@ BOOST_AUTO_TEST_CASE(authority_burn_of_transparent_usdsoq_input_is_accepted)
 }
 
 // ---------------------------------------------------------------------------
-// n1vf — THE SHADOWED RULE, PINNED.
-// bad-txns-usdsoq-confidential-not-active is unreachable: SOQ-ARCH-001 runs
-// earlier in the same ConnectBlock, on the same flags, and rejects EVERY
-// confidential output with bad-txns-confidential-not-active. This test does not
-// pretend the asset-specific rule fires; it records WHICH rule does, so the
-// shadowing relationship cannot change without a test changing with it.
+// n1vf — THE FORMERLY SHADOWED RULE, NOW LIVE.
+// With SOQ-ARCH-001 retired (additive-asset genesis door, 2026-09), a v10
+// output created on a chain where USDSOQ is active but SoquObscura is not is
+// rejected by the asset-specific backstop. This rule is gated on USDSOQ being
+// active, so it is a tightening the activation release keeps; the Tier A path
+// stays fail-closed until the privacy layer is live. On a chain where USDSOQ
+// is ALSO dormant (mainnet), a v10 shape is plain anyone-can-spend SOQ and its
+// creation is valid — see witness_version_reservation_tests.
 // ---------------------------------------------------------------------------
-BOOST_AUTO_TEST_CASE(preactivation_v10_output_is_rejected_by_soq_arch_001_not_the_usdsoq_rule)
+BOOST_AUTO_TEST_CASE(preactivation_v10_output_is_rejected_by_the_usdsoq_rule)
 {
     // Deliberately NO ScopedRegtestActivation — this is the shipped dormant state.
     const int h = chainActive.Height() + 1;
@@ -262,11 +267,15 @@ BOOST_AUTO_TEST_CASE(preactivation_v10_output_is_rejected_by_soq_arch_001_not_th
     CTxOut o; o.nValue = val; o.scriptPubKey = Spk(OP_10); tx.vout.push_back(o);
     SignInput(tx, 0, Spk(OP_7), val);
 
+    // USDSOQ is active on regtest, so the USDSOQ-gated backstop is reachable.
+    BOOST_REQUIRE(Consensus::DeploymentActiveAtHeight(h, Params().GetConsensus(h),
+                                                      Consensus::DEPLOYMENT_USDSOQ));
     const std::string why = RejectReasonFor({tx});
-    BOOST_CHECK_EQUAL(why, "bad-txns-confidential-not-active");
-    BOOST_CHECK_MESSAGE(why != "bad-txns-usdsoq-confidential-not-active",
-        "if the asset-specific rule starts firing, SOQ-ARCH-001 has been narrowed and "
-        "the Tier A pre-activation posture must be re-derived, not assumed");
+    BOOST_CHECK_EQUAL(why, "bad-txns-usdsoq-confidential-not-active");
+    BOOST_CHECK_MESSAGE(why != "bad-txns-confidential-not-active",
+        "SOQ-ARCH-001 is back: a generic rejection of dormant confidential shapes makes "
+        "SoquObscura activation a hard fork. Read the additive-asset genesis door design "
+        "before reintroducing it.");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/test/v6_asset_opcode_ban_tests.cpp
+++ b/src/test/v6_asset_opcode_ban_tests.cpp
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Soqucoin Labs Inc.
+// Distributed under the MIT software license.
+//
+// v6_asset_opcode_ban_tests.cpp — asset and attestation opcodes may not appear
+// inside a P2WSH-Dilithium (witness v6) script, in ANY flag state.
+//
+// Why this is a consensus rule and why it is unconditional. OP_USDSOQ_*,
+// OP_SOQUOBSCURA_RANGEPROOF, OP_CHECKFOLDPROOF and OP_CHECKPATAGG are
+// dispatched by WITNESS VERSION (v5, v4, v3, v2): VerifyScript builds a
+// one-opcode script and evaluates it with the version's own witness layout.
+// Inside EvalScript each of them answers SCRIPT_ERR_BAD_OPCODE while its
+// deployment flag is clear and executes once the flag is set. Reachable from
+// a v6 script, that is a rule that FAILS before the asset activation and
+// SUCCEEDS after it — a loosening — so every asset activation that followed
+// P2WSH-Dilithium would have been a hard fork. Rejecting the opcode's presence
+// in a v6 script in every state is a rule the activation release keeps, so
+// P2WSH-Dilithium and the assets can each activate as soft forks in any order.
+//
+// Pinned by exact ScriptError, with a positive control (an innocuous v6 script
+// verifies) and a push-data control (the banned byte values inside a data push
+// are data, not opcodes).
+
+#include "script/interpreter.h"
+#include "script/script.h"
+#include "script/script_error.h"
+#include "crypto/sha256.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+typedef std::vector<unsigned char> valtype;
+
+CScript V6ProgramFor(const CScript& witnessScript)
+{
+    uint256 h;
+    CSHA256().Write(witnessScript.data(), witnessScript.size()).Finalize(h.begin());
+    CScript spk;
+    spk << OP_6 << valtype(h.begin(), h.end());
+    return spk;
+}
+
+//! Witness layout for v6: [satisfaction items...] [witnessScript] [0x00-prefixed pubkey].
+ScriptError VerdictFor(const CScript& witnessScript, unsigned int flags)
+{
+    CScriptWitness w;
+    w.stack.push_back(valtype(witnessScript.begin(), witnessScript.end()));
+    w.stack.push_back(valtype(1313, 0x00));
+    BaseSignatureChecker checker;
+    ScriptError serr = SCRIPT_ERR_OK;
+    VerifyScript(CScript(), V6ProgramFor(witnessScript), &w, flags, checker, &serr);
+    return serr;
+}
+
+const unsigned int P2WSH = SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2WSH_DILITHIUM;
+
+//! Every flag state that could change an asset opcode's EvalScript behaviour.
+const unsigned int FLAG_STATES[] = {
+    P2WSH,
+    P2WSH | SCRIPT_VERIFY_USDSOQ,
+    P2WSH | SCRIPT_VERIFY_BTCSOQ,
+    P2WSH | SCRIPT_VERIFY_SOQUOBSCURA,
+    P2WSH | SCRIPT_VERIFY_USDSOQ | SCRIPT_VERIFY_SOQUOBSCURA,
+    P2WSH | SCRIPT_VERIFY_PAT,
+    P2WSH | SCRIPT_VERIFY_LATTICEFOLD,
+    P2WSH | SCRIPT_VERIFY_USDSOQ | SCRIPT_VERIFY_BTCSOQ | SCRIPT_VERIFY_SOQUOBSCURA |
+        SCRIPT_VERIFY_PAT | SCRIPT_VERIFY_LATTICEFOLD | SCRIPT_VERIFY_V6_CONTROLFLOW,
+};
+
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(v6_asset_opcode_ban_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(control_innocuous_v6_script_verifies)
+{
+    // OP_TRUE leaves exactly one truthy item: the clean-stack rule is satisfied.
+    for (unsigned int flags : FLAG_STATES) {
+        BOOST_CHECK_MESSAGE(VerdictFor(CScript() << OP_TRUE, flags) == SCRIPT_ERR_OK,
+            "the harness must be able to verify a v6 script at all (flags=" << flags << ")");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(asset_and_attestation_opcodes_are_invalid_in_v6_in_every_flag_state)
+{
+    const opcodetype banned[] = {
+        OP_USDSOQ_MINT, OP_USDSOQ_BURN, OP_USDSOQ_FREEZE, OP_USDSOQ_ROTATE,
+        OP_SOQUOBSCURA_RANGEPROOF, OP_CHECKFOLDPROOF, OP_CHECKPATAGG,
+    };
+    for (opcodetype op : banned) {
+        for (unsigned int flags : FLAG_STATES) {
+            // Alone, and buried after an innocuous prefix: the scan must cover
+            // the whole script, not just its first opcode.
+            BOOST_CHECK_MESSAGE(VerdictFor(CScript() << op, flags) == SCRIPT_ERR_BAD_OPCODE,
+                "opcode " << GetOpName(op) << " must be BAD_OPCODE inside v6 (flags=" << flags << ")");
+            BOOST_CHECK_MESSAGE(VerdictFor(CScript() << OP_TRUE << op, flags) == SCRIPT_ERR_BAD_OPCODE,
+                "opcode " << GetOpName(op) << " after a prefix must be BAD_OPCODE inside v6 (flags=" << flags << ")");
+        }
+    }
+}
+
+// The verdict must not depend on the asset flags: if it did, the ban would be
+// the very loosening it exists to prevent. Same script, all states, one answer.
+BOOST_AUTO_TEST_CASE(verdict_is_identical_across_flag_states)
+{
+    const CScript s = CScript() << OP_USDSOQ_MINT;
+    const ScriptError first = VerdictFor(s, FLAG_STATES[0]);
+    for (unsigned int flags : FLAG_STATES) {
+        BOOST_CHECK_EQUAL((int)VerdictFor(s, flags), (int)first);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(banned_byte_values_inside_a_push_are_data_not_opcodes)
+{
+    // A single push whose bytes are the banned opcode values. It leaves one
+    // truthy item (non-zero bytes), so a clean-stack verify must SUCCEED: the
+    // scan uses GetOp and never looks inside push data.
+    valtype data;
+    data.push_back((unsigned char)OP_USDSOQ_MINT);
+    data.push_back((unsigned char)OP_SOQUOBSCURA_RANGEPROOF);
+    data.push_back((unsigned char)OP_CHECKPATAGG);
+    for (unsigned int flags : FLAG_STATES) {
+        BOOST_CHECK_MESSAGE(VerdictFor(CScript() << data, flags) == SCRIPT_ERR_OK,
+            "banned opcode values inside push data must not trip the ban (flags=" << flags << ")");
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/witness_version_allocation_tests.cpp
+++ b/src/test/witness_version_allocation_tests.cpp
@@ -127,7 +127,7 @@ const Row TABLE[] = {
     {  8, "is_btcsoq_holding",      SCRIPT_VERIFY_BTCSOQ,             true,         true  },
     {  9, "is_btcsoq_authority",    SCRIPT_VERIFY_BTCSOQ,             true,         true  },
     // v10 is ALLOCATED (confidential USDSOQ) with a COMPOUND gate: both
-    // deployments must be active (bead jzg0; validation versionActive case 10).
+    // deployments must be active (bead jzg0; interpreter.cpp is_confidential_usdsoq_witness).
     { 10, "is_confidential_usdsoq_witness",
           SCRIPT_VERIFY_USDSOQ | SCRIPT_VERIFY_SOQUOBSCURA,           true,         false },
     { 11, "is_future_witness",      0,                                true,         false },
@@ -342,7 +342,7 @@ BOOST_AUTO_TEST_CASE(free_witness_versions_are_v11_through_v16)
     const std::vector<int> expected = {11, 12, 13, 14, 15, 16};
     BOOST_CHECK_MESSAGE(free_ == expected,
         "the free witness-version range has moved. v10 is TAKEN (confidential USDSOQ, Tier A) "
-        "in every layer: transaction.h, validation.cpp versionActive, and since FC4 the "
+        "in every layer: transaction.h, the activation mask in validation.cpp, and since FC4 the "
         "interpreter's own is_confidential_usdsoq_witness dispatch (bead jzg0 closed the "
         "half-allocation). Derive this list from the code before allocating anything, never "
         "from a design document");

--- a/src/test/witness_version_reservation_tests.cpp
+++ b/src/test/witness_version_reservation_tests.cpp
@@ -1,30 +1,51 @@
 // Copyright (c) 2026 Soqucoin Labs Inc.
 // Distributed under the MIT software license.
 //
-// witness_version_reservation_tests.cpp — SOQ-I009 consensus reservation of
-// witness versions whose deployment is not active.
+// witness_version_reservation_tests.cpp — the witness-version CREATION posture
+// at consensus, after the additive-asset genesis door (2026-09).
 //
-// witness_version_allocation_tests.cpp pins the POLICY side: a dormant version
-// is relay-nonstandard, and its comment is explicit that this is only
-// "containment for the anyone-can-spend posture". Containment at the policy
-// layer does not bind a miner. This file pins the CONSENSUS side: a block that
-// CREATES such an output is rejected outright, so the anyone-can-spend posture
-// is unreachable rather than merely unrelayable.
+// The posture is BIP141's: an output of any witness version except v2 may be
+// created in a block. A dormant version is anyone-can-spend at the script
+// layer and non-standard at the relay layer, and its activation only ADDS the
+// requirement that the spend verify — which is what makes every activation a
+// SOFT fork. Until 2026-09 this file pinned the opposite (SOQ-I009: every
+// dormant version consensus-reserved), which closed a fund-and-sweep hazard
+// at the price of making every activation a hard fork. The hazard is bounded
+// instead by the relay layer (policy.cpp gates v2-v16 on the live activation
+// mask; witness_standardness_tests) and by the fact that no wallet path can
+// construct a non-v1 address (utiladdress.cpp DecodeDestination).
 //
-// Why it matters, concretely: with SCRIPT_VERIFY_P2WSH_DILITHIUM unset a v6
-// program short-circuits to success in VerifyScript, so a v6 HTLC funded on a
-// mainnet that has not activated the deployment confirms and is then spendable
-// by anybody. That is loss of funds, not a safe no-op — bead
-// premature-witness-standardness-m9mr, and the reason BIP141's
-// "anyone-can-spend until activated" default is wrong for a chain that has not
-// launched yet.
+// What this file pins, in order:
+//   1. only v2 is reserved; every other version is creatable while dormant;
+//   2. the STEAL: a dormant-version output is swept with a garbage witness and
+//      the sweep CONNECTS. Expected. It is the price of soft-forkability, and
+//      it is why (3) and (4) are the only defences;
+//   3. the same output is non-standard, so it never relays;
+//   4. ACTIVATION TIGHTENS: the identical garbage sweep is rejected once the
+//      version's deployment is active. That is the soft-fork property as a test;
+//   5. the premise of the additive asset design: no asset-shaped output (v7,
+//      v8, v10) can hold SOQ value before its deployment activates — the
+//      per-asset conservation rule catches the non-coinbase path and
+//      CheckTransaction's coinbase bans catch the coinbase path. This is what
+//      lets the activation release mandate nValue == 0 on asset outputs without
+//      relaxing any rule the genesis binary carries;
+//   6. a reorg over a block that CONTAINS dormant asset shapes must not touch
+//      asset state (supply, authority outpoint, freeze registry), because
+//      ConnectBlock never applied any: the undo mirrors are gated on the
+//      deployment exactly as the apply side is.
 //
-// Regtest has v6 active from height 0, so each case activates or withdraws the
-// deployment explicitly rather than relying on the network default.
+// Regtest runs USDSOQ, BTCSOQ and P2WSH-Dilithium active from height 0, so
+// each case withdraws the deployment it needs dormant rather than relying on
+// the network default; SoquObscura and LatticeFold are dormant everywhere.
 
+#include "consensus/btcsoq.h"
+#include "consensus/merkle.h"
 #include "consensus/params.h"
+#include "consensus/usdsoq.h"
+#include "policy/policy.h"
 #include "test/dilithium_chain_setup.h"
 #include "test/testutil.h"   // ScopedRegtestActivation
+#include "txdb.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -48,6 +69,15 @@ struct ScopedRegtestWithdrawal {
     }
 };
 
+//! A 0x00-prefixed blob: satisfies CheckTransaction's pubkey-prefix shape test
+//! (bad-txns-requires-dilithium) and nothing else. The point of the steal.
+std::vector<unsigned char> GarbageWitnessItem()
+{
+    std::vector<unsigned char> v(33, 0x5a);
+    v[0] = 0x00;
+    return v;
+}
+
 } // namespace
 
 struct WitnessReservationSetup : public DilithiumChainSetup {
@@ -69,45 +99,80 @@ struct WitnessReservationSetup : public DilithiumChainSetup {
         SignInput(tx, 0, coinbaseSpk, inVal);
         return tx;
     }
+
+    // Spend `funding`'s single output back to a v1 form with a witness that
+    // proves nothing: one 0x00-prefixed blob. Connects iff the funded version
+    // is anyone-can-spend right now.
+    CMutableTransaction GarbageSweep(const CTransaction& funding)
+    {
+        CMutableTransaction tx;
+        tx.nVersion = 2;
+        CTxIn in;
+        in.prevout = COutPoint(funding.GetHash(), 0);
+        in.nSequence = CTxIn::SEQUENCE_FINAL;
+        in.scriptWitness.stack.push_back(GarbageWitnessItem());
+        tx.vin.push_back(in);
+        CTxOut out;
+        out.nValue = funding.vout[0].nValue - 10000;
+        out.scriptPubKey = Spk(OP_1);
+        tx.vout.push_back(out);
+        return tx;
+    }
+
+    // Connect a block carrying `tx` and require that it became the tip.
+    void Connect(const CMutableTransaction& tx)
+    {
+        const int before = chainActive.Height();
+        CBlock b = CreateAndProcessBlock({tx}, coinbaseSpk);
+        BOOST_REQUIRE_MESSAGE(chainActive.Height() == before + 1 &&
+                              chainActive.Tip()->GetBlockHash() == b.GetHash(),
+            "funding block did not connect");
+    }
+
+    // Reject reason for a block whose COINBASE pays to `spk` (empty if valid).
+    // CreateNewBlock validates its own template and returns nullptr for a
+    // coinbase CheckTransaction rejects, so the block is solved for the normal
+    // coinbase first and the coinbase output is rewritten afterwards. Only the
+    // coinbase txid changes (its witness hash is zero by convention, so the
+    // witness commitment stays valid); the merkle root and PoW are redone.
+    std::string CoinbaseRejectReason(const CScript& spk)
+    {
+        CBlock B = BuildSolvedBlock({}, coinbaseSpk);
+        {
+            CMutableTransaction cb(*B.vtx[0]);
+            cb.vout[0].scriptPubKey = spk;
+            B.vtx[0] = MakeTransactionRef(std::move(cb));
+        }
+        B.hashMerkleRoot = BlockMerkleRoot(B);
+        const CChainParams& cp = Params();
+        B.nNonce = 0;
+        while (!CheckProofOfWork(B.GetPoWHash(), B.nBits, cp.GetConsensus(0)))
+            ++B.nNonce;
+        CValidationState st;
+        bool ok;
+        {
+            LOCK(cs_main);
+            ok = TestBlockValidity(st, Params(), B, chainActive.Tip(), true, true);
+        }
+        return ok ? std::string() : st.GetRejectReason();
+    }
 };
 
 BOOST_FIXTURE_TEST_SUITE(witness_version_reservation_tests, WitnessReservationSetup)
 
-// The m9mr hazard, at consensus. With P2WSH-Dilithium withdrawn (mainnet's
-// posture), a v6 output is anyone-can-spend — so creating one must be refused.
-BOOST_AUTO_TEST_CASE(v6_output_rejected_while_p2wsh_dilithium_dormant)
-{
-    ScopedRegtestWithdrawal off(Consensus::DEPLOYMENT_P2WSH_DILITHIUM, 0);
-    CMutableTransaction tx = SpendTo(coinbaseTxns[0], Spk(OP_6));
-    BOOST_CHECK_EQUAL(RejectReasonFor({tx}), "bad-txns-witness-version-not-active");
-}
-
-// Reachability control: the identical transaction connects once the deployment
-// is active, so the rejection above is about dormancy and nothing else.
-BOOST_AUTO_TEST_CASE(v6_output_accepted_once_p2wsh_dilithium_active)
-{
-    CMutableTransaction tx = SpendTo(coinbaseTxns[1], Spk(OP_6));
-    BOOST_CHECK_MESSAGE(RejectReasonFor({tx}).empty(),
-        "v6 is ALWAYS_ACTIVE on regtest, so this must connect — otherwise the "
-        "dormancy rejection above proves nothing");
-}
+// ---------------------------------------------------------------------------
+// 1. Only v2 is reserved.
+// ---------------------------------------------------------------------------
 
 // ⛔ THE STEAL TEST for witness v2 (PAT). Bead pat-v2-anyone-can-spend-ae6u.
 //
-// Every other case in this file gates on a DORMANT deployment. v2 is the
-// opposite shape and that is the whole point: DEPLOYMENT_CHECKPATAGG is
-// ALWAYS_ACTIVE on every network, and until 2026-08-31 that made a v2 output
-// fundable — while the v2 spend path binds neither the witness program nor the
-// sighash, so a stranger could sweep any v2 output that confirmed (the spend
-// itself is driven in pat_v2_unfundable_tests.cpp, PIN 1). Nothing could
-// RELAY one, because Solver never names the v2 form, so the exposure was the
-// miner-included path — which is exactly the path this rule exists to close.
-//
-// The rule is now unconditional rather than deployment-gated, because PAT's
-// attestation is a coinbase commitment and not an output type at all. This test
-// asserts the deployment is active first: if the rejection ever starts
-// depending on dormancy, the guarantee has silently weakened to the one that
-// already failed.
+// DEPLOYMENT_CHECKPATAGG is ALWAYS_ACTIVE on every network, and the v2 spend
+// path binds neither the witness program nor the sighash (the spend itself is
+// driven in pat_v2_unfundable_tests.cpp, PIN 1), so a stranger could sweep any
+// v2 output that confirmed. Unfundability is therefore the control, and it is
+// UNCONDITIONAL rather than deployment-gated. This test asserts the deployment
+// is active first: if the rejection ever starts depending on dormancy, the
+// guarantee has silently weakened to the one that already failed.
 BOOST_AUTO_TEST_CASE(v2_output_unfundable_even_though_checkpatagg_is_active)
 {
     const int h = chainActive.Height() + 1;
@@ -117,68 +182,54 @@ BOOST_AUTO_TEST_CASE(v2_output_unfundable_even_though_checkpatagg_is_active)
         "would now be proving dormancy rather than unconditional unfundability. Read "
         "bead pat-v2-anyone-can-spend-ae6u before changing it.");
 
-    CMutableTransaction tx = SpendTo(coinbaseTxns[14], Spk(OP_2));
+    CMutableTransaction tx = SpendTo(coinbaseTxns[0], Spk(OP_2));
     BOOST_CHECK_EQUAL(RejectReasonFor({tx}), "bad-txns-witness-version-not-active");
 }
 
-// v3 (LatticeFold) is retired and never activates on ANY network, so a v3
-// output is permanently anyone-can-spend at the script layer. Consensus must
-// refuse to create one everywhere, not just on mainnet.
-BOOST_AUTO_TEST_CASE(v3_output_rejected_everywhere_latticefold_is_retired)
+// Every other version is creatable while its deployment is dormant. Each row
+// withdraws the deployment regtest runs active (or asserts the version has no
+// active deployment to withdraw), then connects a correctly-signed spend into
+// that shape. A rejection here would mean a consensus rule keyed on the shape
+// survived the door, and every such rule is a future hard fork.
+BOOST_AUTO_TEST_CASE(every_version_but_v2_is_creatable_while_dormant)
 {
-    const int h = chainActive.Height() + 1;
-    BOOST_REQUIRE_MESSAGE(
-        !Consensus::DeploymentActiveAtHeight(h, Params().GetConsensus(h),
-                                             Consensus::DEPLOYMENT_LATTICEFOLD),
-        "LatticeFold must be retired on regtest for this test to mean anything");
-    CMutableTransaction tx = SpendTo(coinbaseTxns[2], Spk(OP_3));
-    BOOST_CHECK_EQUAL(RejectReasonFor({tx}), "bad-txns-witness-version-not-active");
-}
-
-// v11-v16 are unallocated (witness_version_allocation_tests
-// free_witness_versions_are_v11_through_v16). No deployment can activate them,
-// so they must be unconstructable until one is assigned.
-BOOST_AUTO_TEST_CASE(unallocated_versions_v11_to_v16_are_unconstructable)
-{
-    const opcodetype versions[] = {OP_11, OP_12, OP_13, OP_14, OP_15, OP_16};
-    for (size_t i = 0; i < 6; i++) {
-        CMutableTransaction tx = SpendTo(coinbaseTxns[3 + i], Spk(versions[i]));
-        BOOST_CHECK_MESSAGE(
-            RejectReasonFor({tx}) == "bad-txns-witness-version-not-active",
-            "witness v" << (11 + i) << " must be unconstructable while unallocated");
+    struct Row { opcodetype op; const char* name; int deployment; };
+    // deployment == -1: no deployment to withdraw (dormant on regtest already,
+    // or unallocated).
+    const Row rows[] = {
+        { OP_3,  "v3 LatticeFold (retired)",     -1 },
+        { OP_4,  "v4 confidential SOQ",          -1 },
+        { OP_5,  "v5 USDSOQ authority marker",   Consensus::DEPLOYMENT_USDSOQ },
+        { OP_6,  "v6 P2WSH-Dilithium",           Consensus::DEPLOYMENT_P2WSH_DILITHIUM },
+        { OP_9,  "v9 BTCSOQ authority marker",   Consensus::DEPLOYMENT_BTCSOQ },
+        { OP_11, "v11 unallocated",              -1 },
+        { OP_12, "v12 unallocated",              -1 },
+        { OP_13, "v13 unallocated",              -1 },
+        { OP_14, "v14 unallocated",              -1 },
+        { OP_15, "v15 unallocated",              -1 },
+        { OP_16, "v16 unallocated",              -1 },
+    };
+    int cbIdx = 1;
+    for (const Row& r : rows) {
+        std::unique_ptr<ScopedRegtestWithdrawal> off;
+        if (r.deployment >= 0)
+            off.reset(new ScopedRegtestWithdrawal((Consensus::DeploymentPos)r.deployment, 0));
+        const int h = chainActive.Height() + 1;
+        const Consensus::Params& cons = Params().GetConsensus(h);
+        if (r.deployment >= 0) {
+            BOOST_REQUIRE(!Consensus::DeploymentActiveAtHeight(h, cons, (Consensus::DeploymentPos)r.deployment));
+        }
+        CMutableTransaction tx = SpendTo(coinbaseTxns[cbIdx++], Spk(r.op));
+        BOOST_CHECK_MESSAGE(RejectReasonFor({tx}).empty(),
+            r.name << " output must be consensus-valid to create while dormant; a rejection "
+            "keyed on this shape makes the version's activation a hard fork");
     }
-}
-
-// v5/v7 (USDSOQ) and v8/v9 (BTCSOQ) under mainnet posture. These are the shapes
-// whose markers buy consensus exemptions, so their reservation is the part of
-// SOQ-I009 that closes the authority-forgery class at the source.
-BOOST_AUTO_TEST_CASE(usdsoq_shapes_rejected_while_deployment_withdrawn)
-{
-    ScopedRegtestWithdrawal off(Consensus::DEPLOYMENT_USDSOQ, 0);
-    CMutableTransaction marker = SpendTo(coinbaseTxns[9], Spk(OP_5));
-    CMutableTransaction holding = SpendTo(coinbaseTxns[10], Spk(OP_7));
-
-    // The marker carries no asset value, so nothing earlier constrains it and
-    // the reservation rule is what refuses it.
-    BOOST_CHECK_EQUAL(RejectReasonFor({marker}), "bad-txns-witness-version-not-active");
-
-    // The v7 HOLDING is caught earlier, by the always-on per-asset conservation
-    // rule in Consensus::CheckTxInputs (out > in = 0, since no v7 input can
-    // exist). Pinned deliberately: the two rules overlap here and the earlier
-    // one wins. If this string ever changes to the reservation string, the
-    // conservation chokepoint has moved and that is worth knowing.
-    BOOST_CHECK_EQUAL(RejectReasonFor({holding}), "bad-txns-usdsoq-not-conserved");
-}
-
-BOOST_AUTO_TEST_CASE(btcsoq_shapes_rejected_while_deployment_withdrawn)
-{
-    ScopedRegtestWithdrawal off(Consensus::DEPLOYMENT_BTCSOQ, 0);
-    CMutableTransaction holding = SpendTo(coinbaseTxns[11], Spk(OP_8));
-    CMutableTransaction marker  = SpendTo(coinbaseTxns[12], Spk(OP_9));
-    // Same overlap as the USDSOQ pair above: conservation pre-empts for the
-    // holding, reservation is what catches the marker.
-    BOOST_CHECK_EQUAL(RejectReasonFor({holding}), "bad-txns-btcsoq-not-conserved");
-    BOOST_CHECK_EQUAL(RejectReasonFor({marker}),  "bad-txns-witness-version-not-active");
+    // Sanity: LatticeFold and SoquObscura really are dormant on regtest, so the
+    // v3/v4 rows above tested dormancy and not an active deployment.
+    const int h = chainActive.Height() + 1;
+    const Consensus::Params& cons = Params().GetConsensus(h);
+    BOOST_CHECK(!Consensus::DeploymentActiveAtHeight(h, cons, Consensus::DEPLOYMENT_LATTICEFOLD));
+    BOOST_CHECK(!Consensus::DeploymentActiveAtHeight(h, cons, Consensus::DEPLOYMENT_SOQUOBSCURA));
 }
 
 // The base forms must stay unconditionally constructable — this rule must never
@@ -188,6 +239,255 @@ BOOST_AUTO_TEST_CASE(v1_base_form_always_constructable)
     CMutableTransaction tx = SpendTo(coinbaseTxns[13], Spk(OP_1));
     BOOST_CHECK_MESSAGE(RejectReasonFor({tx}).empty(),
         "v1 Dilithium outputs must never be gated");
+}
+
+// ---------------------------------------------------------------------------
+// 2-4. The steal, the relay refusal, and activation as a tightening.
+// ---------------------------------------------------------------------------
+
+// For each dormant version: fund it for real, then sweep it with a witness
+// that proves nothing.
+//   (2) the sweep CONNECTS while dormant — expected, and the reason the next
+//       two assertions are the only defences;
+//   (3) the funding tx is NON-STANDARD with the live (empty) activation mask,
+//       and standard with the version's bit set where Solver names the form;
+//   (4) with the deployment active, the identical sweep is REJECTED. Nothing
+//       that the active rules accept was rejected while dormant, and this
+//       sweep is something they reject that was accepted: activation only
+//       tightens. (Rejection is asserted as "block invalid" rather than by
+//       reject string because it comes from script verification, which
+//       ConnectBlock reports with an empty reason; any other active-state
+//       rejection would also satisfy the tightening property.)
+BOOST_AUTO_TEST_CASE(dormant_output_is_anyone_can_spend_nonstandard_and_activation_tightens)
+{
+    struct Row { opcodetype op; int version; const char* name; int deployment; bool solverNames; };
+    const Row rows[] = {
+        { OP_4,  4,  "v4 confidential SOQ",        Consensus::DEPLOYMENT_SOQUOBSCURA,      false },
+        { OP_5,  5,  "v5 USDSOQ authority marker", Consensus::DEPLOYMENT_USDSOQ,           true  },
+        { OP_6,  6,  "v6 P2WSH-Dilithium",         Consensus::DEPLOYMENT_P2WSH_DILITHIUM,  true  },
+        { OP_9,  9,  "v9 BTCSOQ authority marker", Consensus::DEPLOYMENT_BTCSOQ,           true  },
+        { OP_11, 11, "v11 unallocated",            -1,                                     false },
+    };
+    int cbIdx = 20;
+    for (const Row& r : rows) {
+        CMutableTransaction sweep;
+        {
+            // SoquObscura is dormant on regtest already; the others must be
+            // withdrawn for the funding and the steal.
+            std::unique_ptr<ScopedRegtestWithdrawal> off;
+            if (r.deployment >= 0 && r.deployment != Consensus::DEPLOYMENT_SOQUOBSCURA)
+                off.reset(new ScopedRegtestWithdrawal((Consensus::DeploymentPos)r.deployment, 0));
+
+            CMutableTransaction fund = SpendTo(coinbaseTxns[cbIdx++], Spk(r.op));
+
+            // (3) relay refuses the shape while dormant.
+            std::string reason;
+            BOOST_CHECK_MESSAGE(!IsStandardTx(CTransaction(fund), reason, true, 0) && reason == "scriptpubkey",
+                r.name << " funding tx must be non-standard while dormant (got '" << reason << "')");
+            if (r.solverNames) {
+                BOOST_CHECK_MESSAGE(IsStandardTx(CTransaction(fund), reason, true, WitnessVersionBit(r.version)),
+                    r.name << " funding tx must be standard once its version bit is active");
+            }
+
+            Connect(fund);
+            sweep = GarbageSweep(CTransaction(fund));
+
+            // (2) THE STEAL. Connects while dormant.
+            BOOST_CHECK_MESSAGE(BlockIsValid({sweep}),
+                r.name << ": a garbage-witness sweep must connect while the version is dormant. "
+                "If this fails, some rule verifies a dormant version's spend, which means the "
+                "version was never anyone-can-spend and its activation was never a soft fork.");
+        }
+
+        // (4) ACTIVATION TIGHTENS. Same UTXO, same sweep, deployment active.
+        if (r.deployment >= 0) {
+            std::unique_ptr<ScopedRegtestActivation> on;
+            if (r.deployment == Consensus::DEPLOYMENT_SOQUOBSCURA)
+                on.reset(new ScopedRegtestActivation(Consensus::DEPLOYMENT_SOQUOBSCURA, 0));
+            const int h = chainActive.Height() + 1;
+            BOOST_REQUIRE(Consensus::DeploymentActiveAtHeight(h, Params().GetConsensus(h),
+                                                              (Consensus::DeploymentPos)r.deployment));
+            BOOST_CHECK_MESSAGE(!BlockIsValid({sweep}),
+                r.name << ": the garbage sweep must be REJECTED once the deployment is active. "
+                "If it still connects, activating the deployment enforces nothing on this version.");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. The premise of the additive asset design: asset shapes cannot hold value
+//    before activation, on either path.
+// ---------------------------------------------------------------------------
+
+// Non-coinbase path: the per-asset conservation rule in Consensus::CheckTxInputs
+// rejects SOQ paid into a v7/v8/v10 output (asset out > asset in = 0). These
+// rules are unconditional and stay in the genesis binary; the activation
+// release satisfies them trivially by mandating nValue == 0 on asset outputs.
+BOOST_AUTO_TEST_CASE(asset_holdings_cannot_hold_value_before_activation)
+{
+    {
+        ScopedRegtestWithdrawal off(Consensus::DEPLOYMENT_USDSOQ, 0);
+        CMutableTransaction v7  = SpendTo(coinbaseTxns[30], Spk(OP_7));
+        CMutableTransaction v10 = SpendTo(coinbaseTxns[31], Spk(OP_10));
+        BOOST_CHECK_EQUAL(RejectReasonFor({v7}),  "bad-txns-usdsoq-not-conserved");
+        BOOST_CHECK_EQUAL(RejectReasonFor({v10}), "bad-txns-usdsoq-not-conserved");
+    }
+    {
+        ScopedRegtestWithdrawal off(Consensus::DEPLOYMENT_BTCSOQ, 0);
+        CMutableTransaction v8 = SpendTo(coinbaseTxns[32], Spk(OP_8));
+        BOOST_CHECK_EQUAL(RejectReasonFor({v8}), "bad-txns-btcsoq-not-conserved");
+    }
+}
+
+// Coinbase path: CheckTransaction bans asset holdings and the BTCSOQ marker in
+// a coinbase, unconditionally. A coinbase is the one transaction the
+// conservation rule does not see, so without these bans a miner could create a
+// valued asset-shaped output while the deployment is dormant. v10 is covered
+// by the same ban as v7 (IsAnyUSDSOQ), which is the part this PR added.
+BOOST_AUTO_TEST_CASE(coinbase_cannot_create_asset_shapes)
+{
+    ScopedRegtestWithdrawal offU(Consensus::DEPLOYMENT_USDSOQ, 0);
+    ScopedRegtestWithdrawal offB(Consensus::DEPLOYMENT_BTCSOQ, 0);
+    BOOST_CHECK_EQUAL(CoinbaseRejectReason(Spk(OP_7)),  "bad-cb-usdsoq-asset");
+    BOOST_CHECK_EQUAL(CoinbaseRejectReason(Spk(OP_10)), "bad-cb-usdsoq-asset");
+    BOOST_CHECK_EQUAL(CoinbaseRejectReason(Spk(OP_8)),  "bad-cb-btcsoq-asset");
+    BOOST_CHECK_EQUAL(CoinbaseRejectReason(Spk(OP_9)),  "bad-cb-btcsoq-asset");
+    // Control: the ban is about asset shapes, not about non-v1 coinbases.
+    BOOST_CHECK_EQUAL(CoinbaseRejectReason(Spk(OP_1)), "");
+}
+
+// ---------------------------------------------------------------------------
+// 5b. The activation release's authority-transaction SHAPE is valid in the
+//     genesis binary while dormant.
+// ---------------------------------------------------------------------------
+
+// Under the additive design an authority transaction spends the previous
+// marker output, carries the M-of-N signatures in THAT input's witness, and
+// creates the next marker. The genesis binary must ACCEPT that shape while the
+// deployment is dormant (marker input anyone-can-spend, ordinary verification
+// for everything else), so that the activation release's M-of-N requirement is
+// a pure tightening. Until 2026-09 CheckInputs rejected this exact shape while
+// dormant ("bad-*-authority-not-active"), which would have made the asset
+// activation a hard fork. The witness below is authority-SHAPED (6 items, tag
+// at [2], a 2420-byte item) but proves nothing; the marker input is
+// anyone-can-spend, so it connects. The same tx spending a v1 input with that
+// witness is rejected by ordinary script verification (authority_skip_gate_tests).
+BOOST_AUTO_TEST_CASE(dormant_authority_shape_spending_a_marker_input_connects)
+{
+    struct Row { opcodetype op; unsigned char tag; int deployment; const char* name; };
+    const Row rows[] = {
+        { OP_5, 0x55,           Consensus::DEPLOYMENT_USDSOQ, "USDSOQ" },
+        { OP_9, BTCSOQ_OP_MINT, Consensus::DEPLOYMENT_BTCSOQ, "BTCSOQ" },
+    };
+    int cbIdx = 40;
+    for (const Row& r : rows) {
+        ScopedRegtestWithdrawal off((Consensus::DeploymentPos)r.deployment, 0);
+
+        CMutableTransaction fund = SpendTo(coinbaseTxns[cbIdx++], Spk(r.op));
+        Connect(fund);
+        const CTransaction funded(fund);
+
+        CMutableTransaction auth;
+        auth.nVersion = 2;
+        CTxIn in;
+        in.prevout = COutPoint(funded.GetHash(), 0);
+        in.nSequence = CTxIn::SEQUENCE_FINAL;
+        // [0] payout_sig [1] payout_pk [2] tag [3] payload [4] auth_sig [5] authority_set
+        in.scriptWitness.stack.push_back(std::vector<unsigned char>(2421, 0x01));
+        in.scriptWitness.stack.push_back(std::vector<unsigned char>(1313, 0x00));
+        in.scriptWitness.stack.push_back(std::vector<unsigned char>(1, r.tag));
+        in.scriptWitness.stack.push_back(std::vector<unsigned char>(32, 0x02));
+        in.scriptWitness.stack.push_back(std::vector<unsigned char>(2420, 0x03));
+        // CheckTransaction requires the LAST witness item of every input to be
+        // 0x00-prefixed (bad-txns-requires-dilithium) unless the tx carries the
+        // OP_5 marker exemption. That rule is one the genesis binary keeps, so
+        // the activation release's authority_set item must be 0x00-prefixed —
+        // recorded as an activation-release obligation.
+        std::vector<unsigned char> authoritySet(64, 0x04);
+        authoritySet[0] = 0x00;
+        in.scriptWitness.stack.push_back(authoritySet);
+        auth.vin.push_back(in);
+        CTxOut nextMarker;
+        nextMarker.nValue = funded.vout[0].nValue - 10000;
+        nextMarker.scriptPubKey = Spk(r.op);
+        auth.vout.push_back(nextMarker);
+
+        BOOST_CHECK_MESSAGE(RejectReasonFor({auth}).empty() && BlockIsValid({auth}),
+            r.name << ": an authority-SHAPED spend of a dormant marker input must connect in the "
+            "genesis binary. A rejection here is a rule the activation release must relax, "
+            "i.e. a hard fork.");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 6. Reorg over dormant asset shapes leaves asset state untouched.
+// ---------------------------------------------------------------------------
+
+// THE ATTACK: while BTCSOQ is dormant, a block carries a raw transaction with
+// a v9 marker output and a well-formed BTCSOQ FREEZE envelope (UNFREEZE of an
+// arbitrary outpoint). ConnectBlock applies nothing (its BTCSOQ block is
+// gated). Before the undo mirrors were gated the same way, disconnecting that
+// block REVERSED the op it never applied: the registry gained a phantom
+// freeze on the target, and the tracked authority outpoint was overwritten.
+// A phantom freeze is a griefing write against a future asset holder.
+BOOST_AUTO_TEST_CASE(reorg_over_dormant_asset_shapes_does_not_touch_asset_state)
+{
+    ScopedRegtestWithdrawal off(Consensus::DEPLOYMENT_BTCSOQ, 0);
+
+    const COutPoint target(uint256S("0x00000000000000000000000000000000000000000000000000000000deadbeef"), 7);
+    const COutPoint sentinel(uint256S("0x0000000000000000000000000000000000000000000000000000000000c0ffee"), 3);
+
+    // [tag 0x63][freeze_op 0x01 = UNFREEZE][txid 32][vout 4] = 38-byte push.
+    std::vector<unsigned char> envelope;
+    envelope.push_back(BTCSOQ_OP_FREEZE);
+    envelope.push_back(FREEZE_OP_UNFREEZE);
+    envelope.insert(envelope.end(), target.hash.begin(), target.hash.end());
+    for (int i = 0; i < 4; i++) envelope.push_back((target.n >> (8 * i)) & 0xff);
+    BOOST_REQUIRE_EQUAL(envelope.size(), 38u);
+
+    const CTransaction& cb = coinbaseTxns[35];
+    const CAmount inVal = cb.vout[0].nValue;
+    CMutableTransaction tx;
+    tx.nVersion = 2;
+    CTxIn in; in.prevout = COutPoint(cb.GetHash(), 0); in.nSequence = CTxIn::SEQUENCE_FINAL;
+    tx.vin.push_back(in);
+    CTxOut marker; marker.nValue = inVal - 10000; marker.scriptPubKey = Spk(OP_9);
+    tx.vout.push_back(marker);
+    CTxOut op; op.nValue = 0; op.scriptPubKey = CScript() << OP_RETURN << envelope;
+    tx.vout.push_back(op);
+    SignInput(tx, 0, coinbaseSpk, inVal);
+
+    {
+        uint8_t tag; std::vector<uint8_t> payload;
+        BOOST_REQUIRE_MESSAGE(ParseBTCSOQAuthorityOp(CTransaction(tx), tag, payload) && tag == BTCSOQ_OP_FREEZE,
+            "the envelope must parse as a BTCSOQ freeze op, or the attack is not being exercised");
+    }
+
+    BOOST_REQUIRE(!pcoinsdbview->IsBTCSOQFrozen(target));
+    {
+        LOCK(cs_main);
+        g_btcsoq_authority_outpoint = sentinel;
+    }
+
+    Connect(tx);
+    const int tipHeight = chainActive.Height();
+
+    {
+        LOCK(cs_main);
+        CValidationState st;
+        BOOST_REQUIRE(InvalidateBlock(st, Params(), chainActive.Tip()));
+    }
+    BOOST_REQUIRE_EQUAL(chainActive.Height(), tipHeight - 1);
+
+    BOOST_CHECK_MESSAGE(!pcoinsdbview->IsBTCSOQFrozen(target),
+        "disconnecting a block that carried a dormant BTCSOQ envelope wrote a phantom freeze: "
+        "the undo path reversed an op ConnectBlock never applied");
+    BOOST_CHECK_MESSAGE(g_btcsoq_authority_outpoint == sentinel,
+        "disconnecting a block that carried a dormant v9 marker overwrote the tracked "
+        "authority outpoint: the undo path restored state ConnectBlock never advanced");
+
+    LOCK(cs_main);
+    g_btcsoq_authority_outpoint = COutPoint();   // do not leak into the next suite
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/witness_version_reservation_tests.cpp
+++ b/src/test/witness_version_reservation_tests.cpp
@@ -42,6 +42,7 @@
 #include "consensus/merkle.h"
 #include "consensus/params.h"
 #include "consensus/usdsoq.h"
+#include "consensus/privacy.h"
 #include "policy/policy.h"
 #include "test/dilithium_chain_setup.h"
 #include "test/testutil.h"   // ScopedRegtestActivation
@@ -400,9 +401,12 @@ BOOST_AUTO_TEST_CASE(dormant_authority_shape_spending_a_marker_input_connects)
         in.scriptWitness.stack.push_back(std::vector<unsigned char>(2420, 0x03));
         // CheckTransaction requires the LAST witness item of every input to be
         // 0x00-prefixed (bad-txns-requires-dilithium) unless the tx carries the
-        // OP_5 marker exemption. That rule is one the genesis binary keeps, so
-        // the activation release's authority_set item must be 0x00-prefixed —
-        // recorded as an activation-release obligation.
+        // OP_5 marker exemption. The USDSOQ row is exempt (OP_5 output plus an
+        // authority-shaped witness); the BTCSOQ row is NOT, so its last item
+        // must be 0x00-prefixed or the genesis binary rejects the shape. That
+        // rule is one the genesis binary keeps forever, so the activation
+        // release's authority_set item must be 0x00-prefixed
+        // (WITNESS_VERSION_FORK_CLASS.md §4.8).
         std::vector<unsigned char> authoritySet(64, 0x04);
         authoritySet[0] = 0x00;
         in.scriptWitness.stack.push_back(authoritySet);
@@ -488,6 +492,73 @@ BOOST_AUTO_TEST_CASE(reorg_over_dormant_asset_shapes_does_not_touch_asset_state)
 
     LOCK(cs_main);
     g_btcsoq_authority_outpoint = COutPoint();   // do not leak into the next suite
+}
+
+// The USDSOQ twin. Regtest's USDSOQ freeze-reversal path is height-gated
+// (nUSDSOQAuthorityEnforcementHeight = 7700) and the supply path needs a v7
+// output with value, which conservation forbids; the authority-outpoint
+// reversal has neither guard. Before the undo gate, disconnecting a block with
+// a v5-marker-shaped tx that spends no marker input reverted the tracked
+// outpoint to null ("bootstrap disconnected") while USDSOQ was dormant.
+BOOST_AUTO_TEST_CASE(reorg_over_dormant_usdsoq_marker_does_not_touch_authority_outpoint)
+{
+    ScopedRegtestWithdrawal off(Consensus::DEPLOYMENT_USDSOQ, 0);
+    const COutPoint sentinel(uint256S("0x0000000000000000000000000000000000000000000000000000000000c0ffee"), 5);
+
+    CMutableTransaction tx = SpendTo(coinbaseTxns[36], Spk(OP_5));
+    {
+        LOCK(cs_main);
+        g_usdsoq_authority_outpoint = sentinel;
+    }
+    Connect(tx);
+    const int tipHeight = chainActive.Height();
+    {
+        LOCK(cs_main);
+        CValidationState st;
+        BOOST_REQUIRE(InvalidateBlock(st, Params(), chainActive.Tip()));
+    }
+    BOOST_REQUIRE_EQUAL(chainActive.Height(), tipHeight - 1);
+    BOOST_CHECK_MESSAGE(g_usdsoq_authority_outpoint == sentinel,
+        "disconnecting a block that carried a dormant v5 marker overwrote the tracked USDSOQ "
+        "authority outpoint: the undo path restored state ConnectBlock never advanced");
+
+    LOCK(cs_main);
+    g_usdsoq_authority_outpoint = COutPoint();
+}
+
+// The SoquObscura twin. ConnectBlock writes key images only while the
+// deployment is active; the undo path erases the key image derived from the
+// last witness item of every spend of a confidential-shaped input. Before the
+// gate, disconnecting a block that spent a dormant v4 output with a garbage
+// witness erased whatever key image that garbage happened to hash to. Seed
+// that hash first so the erasure is observable.
+BOOST_AUTO_TEST_CASE(reorg_over_dormant_confidential_spend_does_not_touch_key_images)
+{
+    const int h = chainActive.Height() + 1;
+    BOOST_REQUIRE(!Consensus::DeploymentActiveAtHeight(h, Params().GetConsensus(h),
+                                                       Consensus::DEPLOYMENT_SOQUOBSCURA));
+
+    CMutableTransaction fund = SpendTo(coinbaseTxns[37], Spk(OP_4));
+    Connect(fund);
+    CMutableTransaction sweep = GarbageSweep(CTransaction(fund));
+    const LatticeKeyImageHash kiHash =
+        LatticeKeyImageHash::FromSerializedKeyImage(sweep.vin[0].scriptWitness.stack.back());
+    BOOST_REQUIRE(pcoinsdbview->WriteKeyImage(kiHash.hash, 1));
+    BOOST_REQUIRE(pcoinsdbview->HaveKeyImage(kiHash.hash));
+
+    Connect(sweep);
+    const int tipHeight = chainActive.Height();
+    {
+        LOCK(cs_main);
+        CValidationState st;
+        BOOST_REQUIRE(InvalidateBlock(st, Params(), chainActive.Tip()));
+    }
+    BOOST_REQUIRE_EQUAL(chainActive.Height(), tipHeight - 1);
+    BOOST_CHECK_MESSAGE(pcoinsdbview->HaveKeyImage(kiHash.hash),
+        "disconnecting a block that spent a dormant v4 output erased a key image: the undo "
+        "path reversed a write ConnectBlock never made");
+
+    pcoinsdbview->EraseKeyImage(kiHash.hash);   // do not leak into the next suite
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1218,6 +1218,16 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
                     break;
                 }
             }
+            // The marker-chain guard mirrors a ConnectBlock rule that sits inside
+            // `flags & SCRIPT_VERIFY_BTCSOQ`, so it is gated the same way. While
+            // the deployment is dormant a v9 marker is plain anyone-can-spend SOQ
+            // (additive-asset genesis door); rejecting its spend here with
+            // DoS(100) would ban the relayer of a transaction consensus accepts.
+            // The conservation mirror stays ungated, like the CheckTxInputs rule.
+            const int nBTCSOQMirrorHeight = chainActive.Height() + 1;
+            const bool fBTCSOQMirrorActive = Consensus::DeploymentActiveAtHeight(
+                nBTCSOQMirrorHeight, Params().GetConsensus(nBTCSOQMirrorHeight),
+                Consensus::DEPLOYMENT_BTCSOQ);
             if (!isBTCSOQAuthTx) {
                 CAmount nBTCSOQIn = 0, nBTCSOQOut = 0;
                 for (const auto& txin : tx.vin) {
@@ -1225,8 +1235,9 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
                     if (!c || !c->IsAvailable(txin.prevout.n)) continue;
                     // Marker-chain guard (mempool mirror of the ConnectBlock
                     // bad-btcsoq-marker-spend rule): only an authority tx may
-                    // spend a v9 marker UTXO.
-                    if (IsBTCSOQAuthorityMarker(c->vout[txin.prevout.n].scriptPubKey)) {
+                    // spend a v9 marker UTXO — once the deployment is active.
+                    if (fBTCSOQMirrorActive &&
+                        IsBTCSOQAuthorityMarker(c->vout[txin.prevout.n].scriptPubKey)) {
                         return state.DoS(100, false, REJECT_INVALID,
                             "bad-btcsoq-marker-spend", false,
                             strprintf("non-authority tx spends BTCSOQ authority marker %s:%u",
@@ -1271,7 +1282,15 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
                 if (o.scriptPubKey.size() == 34 && o.scriptPubKey[0] == OP_5 &&
                     o.scriptPubKey[1] == 32) { hasUsdsoqMarkerOut = true; break; }
             }
-            if (!hasUsdsoqMarkerOut) {
+            // Gated on the deployment exactly like its ConnectBlock twin (inside
+            // `flags & SCRIPT_VERIFY_USDSOQ`): while USDSOQ is dormant a v5 marker
+            // is plain anyone-can-spend SOQ and its spend must not earn the
+            // relayer a DoS(100) for a consensus-valid transaction.
+            const int nUSDSOQMirrorHeight = chainActive.Height() + 1;
+            const bool fUSDSOQMirrorActive = Consensus::DeploymentActiveAtHeight(
+                nUSDSOQMirrorHeight, Params().GetConsensus(nUSDSOQMirrorHeight),
+                Consensus::DEPLOYMENT_USDSOQ);
+            if (fUSDSOQMirrorActive && !hasUsdsoqMarkerOut) {
                 for (const auto& txin : tx.vin) {
                     const CCoins* c = view.AccessCoins(txin.prevout.hash);
                     if (!c || !c->IsAvailable(txin.prevout.n)) continue;
@@ -2140,10 +2159,12 @@ bool CheckTxInputs(const CChainParams& params, const CTransaction& tx, CValidati
         // was simply never extended when v10 was allocated.
         //
         // Like the v7 and v8 rules, this is STRUCTURAL and deliberately NOT
-        // deployment-gated, so the v10 witness shape is RESERVED from genesis: no
-        // v10 input can exist, therefore any tx creating a v10 output fails
-        // out > in = 0. Shipping it dormant now is what keeps a later SoquObscura
-        // activation a soft fork rather than a rule that has to be added afterwards.
+        // deployment-gated. The v10 SHAPE is creatable (additive-asset genesis
+        // door) but its VALUE is reserved from genesis: no v10 input can exist,
+        // so any tx creating a v10 output with nValue > 0 fails out > in = 0, and
+        // only zero-value v10 outputs can exist before activation. The activation
+        // release mandates nValue == 0 on asset outputs, so this rule stays
+        // satisfied trivially and never has to be relaxed.
         //
         // ⚠️ REVISIT WHEN VALUE MOVES INTO THE COMMITMENT (bead sh2u). This sums
         // nValue, which is still a plaintext CAmount on a confidential output. The
@@ -2220,8 +2241,8 @@ bool CheckTxInputs(const CChainParams& params, const CTransaction& tx, CValidati
     // so policy and consensus can never diverge (Option B pattern).
     // DEPLOYMENT POSTURE: like the USDSOQ rule above, this is structural and
     // NOT deployment-gated. On mainnet (BTCSOQ NOT_SCHEDULED) no v8 UTXOs
-    // exist, so v8 inputs are impossible and any tx CREATING v8 outputs fails
-    // this rule (out > in = 0) — i.e. the v8 witness shape is RESERVED from
+    // carrying value exist, so any tx CREATING a v8 output with nValue > 0
+    // fails this rule (out > in = 0) — i.e. the v8 VALUE is RESERVED from
     // genesis, exactly the USDSOQ v7 posture. Fleet upgrades are coordinated
     // flag-day releases, so there is no mixed-version mining window.
     if (!isBTCSOQAuthorityTx) {
@@ -3592,9 +3613,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // PAT block attestation (doc/PAT_BLOCK_ATTESTATION.md): tuples are
     // collected inside the loop below, per transaction, because the view
     // resolves each transaction's prevouts only until UpdateCoins spends them.
-    // The attested set derives from the same flags that gate v7/v8 fundability,
-    // so the set and fundability cannot disagree. Enforcement happens after the
-    // loop, once the batch is complete.
+    // The attested set is fixed (v0/v1/v7/v8 two-item spends, independent of
+    // any deployment flag) so that a later asset activation cannot change the
+    // commitment the genesis binary recomputes; see IsAttestedVersion.
+    // Enforcement happens after the loop, once the batch is complete.
     //
     // Gated on fScriptChecks, the assumevalid/checkpoint window where signature
     // verification itself is skipped. The attestation attests those same
@@ -3610,9 +3632,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // and reject valid historical blocks (bad-blk-pat-commitment-empty) during
     // fast sync.
     patattest::PatBatch patBatch;
-    patattest::AttestedSetParams patParams;
-    patParams.fUsdsoqActive = (flags & SCRIPT_VERIFY_USDSOQ) != 0;
-    patParams.fBtcsoqActive = (flags & SCRIPT_VERIFY_BTCSOQ) != 0;
+    const patattest::AttestedSetParams patParams;   // fixed set; carries no per-height facts
 
     for (unsigned int i = 0; i < block.vtx.size(); i++) {
         const CTransaction& tx = *(block.vtx[i]);
@@ -3664,7 +3684,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                         nSOQIn += prevOut.nValue;
                     } else {
                         // DIAG-FEE: Log every non-SOQ input filtered from fee
-                        LogPrintf("DIAG-FEE: FILTERED INPUT tx=%s vin[%u] prevout=%s:%u "
+                        LogPrint("diagfee", "DIAG-FEE: FILTERED INPUT tx=%s vin[%u] prevout=%s:%u "
                             "isUSDSOQ=%d isConfidential=%d value=%lld coinHeight=%d isCoinBase=%d\n",
                             tx.GetHash().ToString(), j,
                             tx.vin[j].prevout.hash.ToString(), tx.vin[j].prevout.n,
@@ -3685,7 +3705,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             // DIAG-FEE: Summary if filtered fee differs from unfiltered
             if (nSOQIn != nTotalIn) {
                 CAmount nTotalOut = tx.GetValueOut();
-                LogPrintf("DIAG-FEE: MISMATCH tx=%s inputs=%zu totalIn=%lld soqIn=%lld "
+                LogPrint("diagfee", "DIAG-FEE: MISMATCH tx=%s inputs=%zu totalIn=%lld soqIn=%lld "
                     "excluded=%lld totalOut=%lld soqOut=%lld unfilteredFee=%lld filteredFee=%lld\n",
                     tx.GetHash().ToString(), tx.vin.size(),
                     nTotalIn, nSOQIn, nTotalIn - nSOQIn,
@@ -5177,7 +5197,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // Placement: After USDSOQ enforcement, before key-image tracking.
     // Pattern: Same as LATTICEBP confidential output rejection (L2329-2342).
     //
-    // Approved: Casey Wilson, May 25 2026. BIP9 bit 11.
+    // Approved 2026-05-25. BIP9 bit 11.
     // See DL-SOQ-FEE-ARCHITECTURE-V3.md, Appendix A.
     // =========================================================================
     if (fEnforceUtxoCost) {
@@ -7158,14 +7178,9 @@ std::vector<unsigned char> GenerateCoinbaseCommitment(CBlock& block, const CBloc
         const int nHeight = pindexPrev == nullptr ? 0 : pindexPrev->nHeight + 1;
         const Consensus::Params& patConsensus = Params().GetConsensus(nHeight);
 
-        // The attested set at this height (spec §2, Decision 1): the same
-        // DeploymentActiveAtHeight facts ConnectBlock turns into
-        // SCRIPT_VERIFY_USDSOQ / SCRIPT_VERIFY_BTCSOQ.
-        patattest::AttestedSetParams patParams;
-        patParams.fUsdsoqActive = Consensus::DeploymentActiveAtHeight(
-            nHeight, patConsensus, Consensus::DEPLOYMENT_USDSOQ);
-        patParams.fBtcsoqActive = Consensus::DeploymentActiveAtHeight(
-            nHeight, patConsensus, Consensus::DEPLOYMENT_BTCSOQ);
+        // The attested set is fixed and height-independent (see
+        // IsAttestedVersion), so the miner and ConnectBlock cannot disagree.
+        const patattest::AttestedSetParams patParams;
 
         // Prevouts: outputs created earlier in this block first (in-block
         // chained spends), then the chain view. Same resolution order the

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -579,14 +579,26 @@ bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fChe
         bool hasBTCSOQAuthority = false;
 
         for (const auto& txout : tx.vout) {
-            if (txout.IsUSDSOQ()) hasUSDSOQ = true;
+            // IsAnyUSDSOQ(), not IsUSDSOQ(): the coinbase ban must cover the
+            // confidential v10 form as well as v7. Since witness-version
+            // creation is no longer consensus-reserved (see the SOQ-I009 note
+            // in ConnectBlock), a coinbase is the ONE path that could create an
+            // asset-shaped output carrying SOQ value without passing the
+            // per-asset conservation rule in CheckTxInputs. That rule and the
+            // per-asset fee filter are both satisfied trivially only while no
+            // asset-shaped output ever holds value before its deployment
+            // activates; this ban is what keeps that true.
+            if (txout.IsAnyUSDSOQ()) hasUSDSOQ = true;
             if (txout.IsBTCSOQ()) hasBTCSOQ = true;
             const CScript& spk = txout.scriptPubKey;
             if (spk.size() == 34 && spk[0] == OP_5 && spk[1] == 32) hasUSDSOQAuthority = true;
             if (IsBTCSOQAuthorityMarker(spk)) hasBTCSOQAuthority = true;
         }
 
-        // Coinbase outputs must be native SOQ — cannot mint USDSOQ via mining
+        // Coinbase outputs must be native SOQ — cannot mint USDSOQ via mining.
+        // Unconditional on purpose: a rejection the genesis binary carries is
+        // one every later release keeps, and this one is load-bearing for the
+        // additive asset design (see above).
         if (tx.IsCoinBase() && hasUSDSOQ) {
             return state.DoS(100, false, REJECT_INVALID, "bad-cb-usdsoq-asset");
         }
@@ -687,7 +699,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
         };
         // v0/v1 are the always-standard base forms and are handled by Solver.
         // v2 (PAT) is deliberately absent and must stay absent: it is
-        // permanently unfundable at consensus (ConnectBlock's versionActive),
+        // permanently unfundable at consensus (ConnectBlock's v2 creation rule),
         // because PAT's attestation is a coinbase commitment rather than an
         // output type. Setting the bit from DEPLOYMENT_CHECKPATAGG would state
         // the opposite of the consensus rule. It would also have no effect —
@@ -2366,21 +2378,27 @@ bool CheckInputs(const CTransaction& tx, CValidationState& state, const CCoinsVi
             // That is theft of arbitrary UTXOs, not merely a dormant-asset
             // mint. Proven in src/test/authority_skip_gate_tests.cpp.
             //
-            // So: default-deny. If we cannot run the stronger check, we do
-            // not grant the exemption that stands in for it. The BTCSOQ side
-            // already had this instinct in ConnectBlock
-            // (bad-btcsoq-authority-unavailable); USDSOQ had none, and both
-            // sat inside the deployment gate where mainnet never reaches
-            // them. This is the single chokepoint that is live in BOTH the
-            // connect path and mempool accept, so policy cannot drift.
+            // So: no verifier, no skip. While the deployment is dormant an
+            // authority-SHAPED transaction is simply an ordinary transaction
+            // and every input runs ordinary script verification — which is
+            // exactly what a node that knows nothing about the asset would
+            // do, so the shape gains nothing and loses nothing. This was
+            // first written as an outright rejection (bad-*-authority-not-
+            // active); that rejection was itself hard-fork shaped, because
+            // the activation release ACCEPTS the very shape it rejected
+            // (additive-asset genesis door, 2026-09). Falling through to
+            // ordinary verification is strictly more permissive than
+            // rejecting, so the activation release's M-of-N requirement is a
+            // pure tightening on top of it. With the deployment ACTIVE but no
+            // keyset configured, rejecting stays correct: that state never
+            // exists on a chain the genesis binary validates (mainnet ships
+            // NOT_SCHEDULED), and a release that schedules the height ships
+            // the keyset with it.
             // =============================================================
             if (isAuthorityTx) {
                 if (!(flags & SCRIPT_VERIFY_USDSOQ)) {
-                    return state.DoS(100, false, REJECT_INVALID,
-                        "bad-usdsoq-authority-not-active", false,
-                        "USDSOQ authority TX before USDSOQ activation");
-                }
-                if (!g_usdsoq_authority.IsInitialized()) {
+                    isAuthorityTx = false;   // dormant: verify every input like any other tx
+                } else if (!g_usdsoq_authority.IsInitialized()) {
                     return state.DoS(100, false, REJECT_INVALID,
                         "bad-usdsoq-authority-unavailable", false,
                         "USDSOQ authority TX rejected: authority key set not initialized");
@@ -2388,11 +2406,8 @@ bool CheckInputs(const CTransaction& tx, CValidationState& state, const CCoinsVi
             }
             if (isBTCSOQAuthorityTx) {
                 if (!(flags & SCRIPT_VERIFY_BTCSOQ)) {
-                    return state.DoS(100, false, REJECT_INVALID,
-                        "bad-btcsoq-authority-not-active", false,
-                        "BTCSOQ authority TX before BTCSOQ activation");
-                }
-                if (!g_btcsoq_authority.IsInitialized()) {
+                    isBTCSOQAuthorityTx = false;   // dormant: verify every input like any other tx
+                } else if (!g_btcsoq_authority.IsInitialized()) {
                     return state.DoS(100, false, REJECT_INVALID,
                         "bad-btcsoq-authority-unavailable", false,
                         "BTCSOQ authority TX rejected: authority key set not initialized");
@@ -2613,6 +2628,21 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
     // its scratch view.
     const bool fRealDisconnect = (pfClean == nullptr);
 
+    // Asset-state undo below mirrors ConnectBlock, whose asset blocks run only
+    // when the deployment is active at this height (flags derived from
+    // DeploymentActiveAtHeight). Mirror that gate here: while a deployment is
+    // dormant, a block can still CONTAIN asset-shaped outputs (they are plain
+    // anyone-can-spend SOQ since the additive-asset genesis door), and a reorg
+    // over such a block must not reverse supply, restore an authority outpoint
+    // or write a freeze-registry entry that ConnectBlock never applied.
+    const Consensus::Params& disconnectParams = Params().GetConsensus(pindex->nHeight);
+    const bool fUSDSOQActiveAtHeight = Consensus::DeploymentActiveAtHeight(
+        pindex->nHeight, disconnectParams, Consensus::DEPLOYMENT_USDSOQ);
+    const bool fBTCSOQActiveAtHeight = Consensus::DeploymentActiveAtHeight(
+        pindex->nHeight, disconnectParams, Consensus::DEPLOYMENT_BTCSOQ);
+    const bool fSoquObscuraActiveAtHeight = Consensus::DeploymentActiveAtHeight(
+        pindex->nHeight, disconnectParams, Consensus::DEPLOYMENT_SOQUOBSCURA);
+
 
     CBlockUndo blockUndo;
     CDiskBlockPos pos = pindex->GetUndoPos();
@@ -2684,7 +2714,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
     // Reversed mint = USDSOQ output being removed → UndoMint(amount)
     // Reversed burn = USDSOQ input being restored → UndoBurn(amount)
     // =========================================================================
-    if (fRealDisconnect) {
+    if (fRealDisconnect && fUSDSOQActiveAtHeight) {
         CAmount nUSDSOQReversedMint = 0;
         CAmount nUSDSOQReversedBurn = 0;
 
@@ -2780,7 +2810,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
     // the input that spent the prior authority outpoint. That input's prevout
     // is the outpoint we need to restore.
     // =========================================================================
-    if (fRealDisconnect) {
+    if (fRealDisconnect && fUSDSOQActiveAtHeight) {
         for (const auto& ptx : block.vtx) {
             const CTransaction& tx = *ptx;
             if (tx.IsCoinBase()) continue;
@@ -2866,7 +2896,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
     // We re-extract key-images from the block's witness data using the same
     // logic as ConnectBlock (last witness stack element for confidential inputs).
     // =========================================================================
-    if (fRealDisconnect && pcoinsdbview) {
+    if (fRealDisconnect && pcoinsdbview && fSoquObscuraActiveAtHeight) {
         unsigned int nErasedKeyImages = 0;
         for (const auto& ptx : block.vtx) {
             const CTransaction& tx = *ptx;
@@ -2918,7 +2948,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
     // Key-image reverse doesn't need this because key-images aren't
     // plaintext-forgeable; freeze ops are.
     // =========================================================================
-    if (fRealDisconnect && pcoinsdbview) {
+    if (fRealDisconnect && pcoinsdbview && fUSDSOQActiveAtHeight) {
         const Consensus::Params& disconnectConsensus = Params().GetConsensus(pindex->nHeight);
         unsigned int nReversedFreezeOps = 0;
         for (const auto& ptx : block.vtx) {
@@ -2977,7 +3007,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
     //      never reconnect on the new chain after a reorg (its deposit would
     //      still be marked minted), forking any node that replayed it.
     // =========================================================================
-    if (fRealDisconnect) {
+    if (fRealDisconnect && fBTCSOQActiveAtHeight) {
         CAmount nBTCSOQReversedMint = 0;
         CAmount nBTCSOQReversedBurn = 0;
 
@@ -3049,7 +3079,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
     // spent the pre-block tracked outpoint (ConnectBlock enforces this), so
     // reverting to that input's prevout restores the pre-block chain state.
     // ApplyTxInUndo above has already restored the spent coins to the view.
-    if (fRealDisconnect) {
+    if (fRealDisconnect && fBTCSOQActiveAtHeight) {
         for (const auto& ptx : block.vtx) {
             const CTransaction& tx = *ptx;
             if (tx.IsCoinBase()) continue;
@@ -3108,7 +3138,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
     // v9-authority txs only, at/after the enforcement height (pre-enforcement
     // blocks never had ops applied — a forged envelope in a non-authority tx
     // must not be able to erase a legitimate freeze or minted-deposit entry).
-    if (fRealDisconnect && pcoinsdbview) {
+    if (fRealDisconnect && pcoinsdbview && fBTCSOQActiveAtHeight) {
         const Consensus::Params& btcsoqDisconnectConsensus =
             Params().GetConsensus(pindex->nHeight);
         unsigned int nBTCSOQReversedOps = 0;
@@ -3782,126 +3812,63 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             REJECT_INVALID, "bad-cb-amount");
 
     // =========================================================================
-    // SOQ-ARCH-001: Confidential Output Rejection (Pre-Activation)
-    // When DEPLOYMENT_SOQUOBSCURA is NOT active, reject any output with
-    // nVisibility != VISIBILITY_TRANSPARENT. This prevents creation of
-    // privacy-mode UTXOs before the network has consensus support for
-    // validating range proofs and ring signatures.
+    // Witness-version creation posture (additive-asset genesis door, 2026-09).
     //
-    // Defense-in-depth: VerifyScript already makes witness v4 anyone-can-spend
-    // when SCRIPT_VERIFY_SOQUOBSCURA is unset, but this catches the edge case
-    // where nVisibility is set on a non-v4 output type (e.g., standard P2WPKH
-    // with a manually crafted nVisibility byte).
+    // A block may create an output of ANY witness version except v2. This is
+    // BIP141's posture — a dormant version is anyone-can-spend at the script
+    // layer (VerifyScript returns success while the deployment flag is clear)
+    // and NON-STANDARD at the relay layer (policy.cpp gates v2-v16 on the live
+    // activation mask computed in AcceptToMemoryPoolWorker) — and it is the
+    // posture that makes every later activation a SOFT fork: activation only
+    // ADDS a rule (the spend must now verify), and every block the new rule
+    // accepts, the genesis binary also accepts.
+    //
+    // History. SOQ-I009 (2026-08-24) reserved every dormant version at
+    // consensus (bad-txns-witness-version-not-active) and SOQ-ARCH-001
+    // rejected confidential v4/v10 outputs while SoquObscura was dormant.
+    // Both were correct for the hazards they closed at the time — fund-and-
+    // sweep of a dormant shape, and asset markers buying consensus exemptions
+    // with the verifier dormant — but both turned every activation into a
+    // HARD fork: a block the genesis binary rejects would become valid. The
+    // exemptions those markers bought are now gated on the deployment being
+    // active AND its authority initialised (CheckTxInputs, CheckInputs), so
+    // the shape alone buys nothing while dormant, and fund-and-sweep is
+    // bounded to raw-constructed outputs that no wallet path can produce and
+    // no stock miner will include. Ruled 2026-09-07; design record in
+    // doc/specifications/WITNESS_VERSION_FORK_CLASS.md.
+    //
+    // ⛔ Invariants the additive design depends on, all enforced elsewhere and
+    // pinned by witness_version_reservation_tests:
+    //   * no asset-shaped output (v7/v8/v10) can hold SOQ value before its
+    //     deployment activates — the per-asset conservation rule in
+    //     CheckTxInputs rejects it from a non-coinbase tx, and CheckTransaction
+    //     rejects it from a coinbase. That is what keeps the per-asset fee
+    //     filter and conservation rules satisfied trivially, so the activation
+    //     release can mandate nValue == 0 on asset outputs without relaxing any
+    //     genesis rule;
+    //   * nothing in ConnectBlock or DisconnectBlock touches asset state
+    //     unless the deployment is active at this height.
+    //
+    // ⛔ v2 (PAT) is the one version that stays PERMANENTLY unfundable. PAT's
+    // attestation is block metadata — a commitment in the coinbase, validated
+    // in ConnectBlock — not a UTXO, and the v2 spend path in interpreter.cpp
+    // binds NEITHER the witness program NOR the sighash: it delegates to
+    // OP_CHECKPATAGG, which by design verifies no signature, only the internal
+    // consistency of attacker-supplied 32-byte tuples. Any v2 output that ever
+    // confirmed would be spendable by anybody, and DEPLOYMENT_CHECKPATAGG is
+    // ALWAYS_ACTIVE, so unfundability is the control and it must not depend on
+    // a deployment. Ruled 2026-08-31; bead pat-v2-anyone-can-spend-ae6u.
     // =========================================================================
-    if (!(flags & SCRIPT_VERIFY_SOQUOBSCURA)) {
-        for (unsigned int i = 0; i < block.vtx.size(); i++) {
-            const CTransaction& tx = *(block.vtx[i]);
-            for (const auto& txout : tx.vout) {
-                // Phase 2: confidentiality ⟺ witness-v4 (IsConfidential). Reject creating a
-                // confidential (v4) output before the LATTICEBP privacy layer is active. This
-                // subsumes the old "nVisibility on a non-v4 output" defense-in-depth, since
-                // IsConfidential() is true only for genuine v4 outputs.
-                if (txout.IsConfidential()) {
-                    return state.DoS(100,
-                        error("ConnectBlock(): confidential output in block %d before LATTICEBP activation",
-                              pindex->nHeight),
-                        REJECT_INVALID, "bad-txns-confidential-not-active");
-                }
-            }
-        }
-    }
-
-    // =========================================================================
-    // SOQ-I009: witness-version reservation (pre-activation).
-    //
-    // Direct generalisation of the SOQ-ARCH-001 rule above, and it should have
-    // shipped with it. Soqucoin inherited BIP141's "future witness versions are
-    // anyone-can-spend until activated" posture. That posture is right for a
-    // chain that has already launched and cannot retroactively forbid shapes.
-    // It is the wrong default for a chain that has NOT launched, because it
-    // leaves two live hazards on mainnet:
-    //
-    //   1. FUND-AND-SWEEP. A dormant version short-circuits to success in
-    //      VerifyScript, so an output of that shape confirms and is then
-    //      spendable by anybody. The failure direction is loss of funds, not a
-    //      safe no-op (bead premature-witness-standardness-m9mr).
-    //   2. EXEMPTION WITHOUT VERIFIER. v5/v9 markers buy an exemption from
-    //      value conservation and from per-input script verification, while
-    //      everything that verifies the exemption sits behind the deployment
-    //      flag. Reserving the shape removes the whole class rather than
-    //      patching each exemption (SOQ-I009 proper).
-    //
-    // So: an output may only use a witness version whose deployment is active
-    // in THIS block. v0/v1 are the always-available base Dilithium forms; v2 is
-    // permanently unfundable (see the case below); v11-v16 are unallocated and
-    // can never be created until one is assigned a deployment. Policy already
-    // refuses to relay all of these (activeWitnessVersions, above), so this
-    // closes the miner-included path that policy cannot reach.
-    //
-    // Blast radius: v5/v7/v8/v9 are dormant on mainnet ONLY, so those cannot
-    // affect an existing chain. v3 (LatticeFold, retired) and v11-v16 are
-    // dormant on every network — neither has ever been relay-standard anywhere,
-    // so no honest wallet can have produced one, but this is the part of the
-    // rule that wants a stagenet resync before fleet deploy.
-    // ⛔ v2 is the one version whose posture TIGHTENS here rather than merely
-    // being pinned: it was fundable on every network until 2026-08-31, because
-    // DEPLOYMENT_CHECKPATAGG is ALWAYS_ACTIVE. Nothing could relay one (Solver
-    // never named the form, so the v2 policy bit was dead), so only a directly
-    // mined output could exist — but stagenet must be checked for one before
-    // the fleet takes this rule, or a node running it will reject the chain.
-    // v4/v10 are pre-empted by SOQ-ARCH-001 above and never reach this loop.
-    // =========================================================================
-    {
-        auto versionActive = [&flags](int version) -> bool {
-            switch (version) {
-            case 0: case 1: return true;                                  // base Dilithium forms
-            // v2 (PAT) is PERMANENTLY unfundable, and not gated on
-            // SCRIPT_VERIFY_PAT like the rest. PAT's attestation is block
-            // metadata — a commitment in the coinbase, validated here in
-            // ConnectBlock — not a UTXO, so there is no v2 output type to
-            // create and nothing that needs to be payable.
-            //
-            // This is a hard "no" rather than a dormancy gate because the v2
-            // spend path in interpreter.cpp binds NEITHER the witness program
-            // NOR the sighash: it delegates to OP_CHECKPATAGG, which by design
-            // verifies no signature, only the internal consistency of
-            // attacker-supplied 32-byte tuples. Anyone can mint a self-
-            // consistent proof, so any v2 output that ever confirmed would be
-            // spendable by anybody. Unfundability is therefore the control, and
-            // it must not be re-openable by flipping a deployment.
-            // Ruled 2026-08-31; bead pat-v2-anyone-can-spend-ae6u.
-            case 2:  return false;                                        // PAT attestation is not an output type
-            case 3:  return (flags & SCRIPT_VERIFY_LATTICEFOLD) != 0;     // LatticeFold+ (retired)
-            case 4:  return (flags & SCRIPT_VERIFY_SOQUOBSCURA) != 0;     // confidential SOQ
-            case 5: case 7: return (flags & SCRIPT_VERIFY_USDSOQ) != 0;   // USDSOQ marker / holding
-            case 6:  return (flags & SCRIPT_VERIFY_P2WSH_DILITHIUM) != 0; // P2WSH-Dilithium
-            case 8: case 9: return (flags & SCRIPT_VERIFY_BTCSOQ) != 0;   // BTCSOQ holding / marker
-            case 10: return (flags & SCRIPT_VERIFY_USDSOQ) != 0 &&
-                            (flags & SCRIPT_VERIFY_SOQUOBSCURA) != 0;     // confidential USDSOQ
-            default: return false;                                        // v11-v16 unallocated
-            }
-        };
-
-        for (unsigned int i = 0; i < block.vtx.size(); i++) {
-            const CTransaction& tx = *(block.vtx[i]);
-            for (const auto& txout : tx.vout) {
-                const CScript& spk = txout.scriptPubKey;
-                // The one shape every Soqucoin witness version uses: OP_N <32>.
-                if (spk.size() != 34 || spk[1] != 32) continue;
-                int version;
-                if (spk[0] == OP_0) {
-                    version = 0;
-                } else if (spk[0] >= OP_1 && spk[0] <= OP_16) {
-                    version = spk[0] - (OP_1 - 1);
-                } else {
-                    continue;  // not a witness program
-                }
-                if (!versionActive(version)) {
-                    return state.DoS(100,
-                        error("ConnectBlock(): witness v%d output in block %d before that "
-                              "version's deployment is active", version, pindex->nHeight),
-                        REJECT_INVALID, "bad-txns-witness-version-not-active");
-                }
+    for (unsigned int i = 0; i < block.vtx.size(); i++) {
+        const CTransaction& tx = *(block.vtx[i]);
+        for (const auto& txout : tx.vout) {
+            const CScript& spk = txout.scriptPubKey;
+            // The one shape every Soqucoin witness version uses: OP_N <32>.
+            if (spk.size() == 34 && spk[0] == OP_2 && spk[1] == 32) {
+                return state.DoS(100,
+                    error("ConnectBlock(): witness v2 output in block %d — PAT is not an output type",
+                          pindex->nHeight),
+                    REJECT_INVALID, "bad-txns-witness-version-not-active");
             }
         }
     }
@@ -4521,25 +4488,19 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                         //   2. range proofs are valid (checked in the section below)
                         //   3. commitment balance is preserved (sum_in == sum_out)
                         //
-                        // ⚠️ SHADOWED, DELIBERATELY RETAINED (n1vf). This reject can never
-                        // be the one that fires. SOQ-ARCH-001 runs EARLIER in this same
-                        // ConnectBlock, on the SAME `flags`, and already rejects every
-                        // IsConfidential() output in the block with
-                        // "bad-txns-confidential-not-active" whenever
-                        // SCRIPT_VERIFY_SOQUOBSCURA is unset. Its condition is a strict
-                        // superset of this one, so the observable reject string for a
-                        // pre-activation v10 output is ALWAYS the SOQ-ARCH-001 one — pinned
-                        // by usdsoq_v10_reject_path_tests::preactivation_v10_output_is_
-                        // rejected_by_soq_arch_001_not_the_usdsoq_rule.
-                        //
-                        // It is kept, not deleted, because the two rules are independent
-                        // fail-closed backstops on the same property and SOQ-ARCH-001's
-                        // scope is the thing most likely to be narrowed later (it is the
-                        // generic all-assets rule; this one is asset-specific). If that
-                        // ever happens the Tier A path must still fail closed. The pinning
-                        // test is what turns "silently dead" into "known dead": narrowing
-                        // SOQ-ARCH-001 flips that test's expected string, so the shadowing
-                        // relationship cannot change without someone noticing.
+                        // This is the rule that fires for a pre-activation v10 output
+                        // on a chain where USDSOQ is active (the test nets). Until
+                        // 2026-09 it was SHADOWED by SOQ-ARCH-001, a generic all-assets
+                        // rejection of confidential outputs that ran earlier in this
+                        // ConnectBlock on the same flags; that rule was retired with
+                        // the additive-asset genesis door (a dormant v4/v10 shape is
+                        // plain anyone-can-spend SOQ, and rejecting its CREATION made
+                        // SoquObscura activation a hard fork). This asset-specific
+                        // backstop stays: it is gated on USDSOQ being active, so it is
+                        // a tightening the activation release keeps, and it keeps the
+                        // Tier A path fail-closed until the privacy layer is live.
+                        // Pinned by usdsoq_v10_reject_path_tests::
+                        // preactivation_v10_output_is_rejected_by_the_usdsoq_rule.
                         if (!(flags & SCRIPT_VERIFY_SOQUOBSCURA)) {
                             return state.DoS(100,
                                 error("ConnectBlock(): USDSOQ confidential output %s:%u before "
@@ -5440,11 +5401,11 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 // enforces it. Outputs beyond vin.size() get an empty witness
                 // and are silently skipped.
                 //
-                // This loop is NOT dead code. IsConfidential() is a shape
-                // predicate over scriptPubKey, so a crafted v4/v10-shaped
-                // output reaches it even though the deployment is
-                // NOT_SCHEDULED -- the "dormant feature with a live shape"
-                // pattern. Do not assume dormancy makes this unreachable.
+                // This loop sits inside `if (flags & SCRIPT_VERIFY_SOQUOBSCURA)`
+                // (opened above the key-image extraction), so it runs only when
+                // the deployment is active at this height. A v4/v10-shaped
+                // output in a block while SoquObscura is dormant never reaches
+                // it: such an output is plain anyone-can-spend SOQ.
                 const CScriptWitness& wit = (j < tx.vin.size()) ?
                     tx.vin[j].scriptWitness : CScriptWitness();
 


### PR DESCRIPTION
## Summary

Pre-genesis consensus change: the genesis binary stops carrying consensus behaviour keyed on a
dormant feature's shape, so that every later feature activation is a soft fork. Ruled 2026-09-07;
design record in `doc/specifications/WITNESS_VERSION_FORK_CLASS.md`.

A soft fork may only add rejections. Every rule below either rejected a shape that a later
activation must accept, or reversed state that ConnectBlock never applied.

| change | before | after |
|---|---|---|
| Witness-version creation (`ConnectBlock`) | SOQ-I009 rejected creation of any dormant version; SOQ-ARCH-001 rejected confidential v4/v10 outputs | only v2 is reserved (its spend path binds nothing); every other version is creatable, anyone-can-spend at consensus, non-standard until active |
| Authority-shaped tx while dormant (`CheckInputs`) | rejected (`bad-*-authority-not-active`) | falls through to ordinary per-input script verification; the active-but-uninitialised rejection stays |
| Asset/attestation opcodes inside a v6 script (`VerifyScript`) | `BAD_OPCODE` while the asset flag is clear, executed once set | invalid in every state (opcodes are dispatched by witness version, never by script) |
| Asset undo mirrors (`DisconnectBlock`) | gated only on a real disconnect | gated on the deployment being active at that height, as ConnectBlock is |
| Coinbase USDSOQ ban (`CheckTransaction`) | v7 only | v7 and v10 (`IsAnyUSDSOQ`) |

Kept unconditional, on purpose: the coinbase asset bans, the dual-marker ban, the per-asset
`nValue` conservation rules and the per-asset fee filter. They are rejections every later release
keeps, and under the additive asset design (asset outputs carry `nValue == 0`) they are satisfied
trivially forever. The activation release must delete the mint exemption and the authority script
skip; both are dormant in this binary and recorded as obligations on the activation bead.

## Why this must land before genesis

After genesis, removing any of these rejections is itself the hard fork this change prevents.

## Threat and state pass

- **Actors.** Honest wallet: cannot construct a non-v1 address (`utiladdress.cpp DecodeDestination`).
  Raw-transaction author: can construct dormant-version outputs. Stock miner: builds from its
  mempool, where every dormant-version output is non-standard (`policy.cpp` gated on the activation
  mask from `AcceptToMemoryPoolWorker`). Modified miner: can include one. Un-upgraded node at a
  future activation: accepts everything the upgraded node accepts, which is the point.
- **States.** Mainnet pre-activation (every asset deployment `NOT_SCHEDULED`, no keyset in
  `CMainParams`); activation release sets a height; post-height. Test nets run the deployments
  active from height 0, so the creation-gate removals change no verdict there.
- **Transitions.** Pre-activation create: consensus-valid, non-standard. Pre-activation spend:
  anyone-can-spend at consensus; funds at risk are the constructor's own. At activation: create
  becomes standard, spend becomes verified. Old node at activation accepts everything the new node
  accepts.
- **Reorg across activation.** A pre-activation garbage sweep mined before the height becomes
  invalid if re-mined after it; standard BIP141 property. Reorg over a block carrying dormant asset
  shapes: undo mirrors now do nothing, matching the apply side.
- **Clocks, late or duplicate callbacks, concurrency.** None; every rule is a pure function of
  (flags at height, transaction bytes).
- **What input makes each check fail.** Creation: a v2 output (`bad-txns-witness-version-not-active`).
  v6 script: any of the seven banned opcodes anywhere in the script (`BAD_OPCODE`), in every flag
  state. Coinbase: a v7/v10/v8/v9 output. Undo: none while dormant, by design.
- **Value premise, both paths.** A non-coinbase tx cannot pay SOQ into a v7/v8/v10 output
  (per-asset conservation, unconditional). A coinbase cannot (bans, unconditional, v10 added).
  Therefore no asset-shaped output holds SOQ value before activation, and the fee filter cannot
  misprice one.

## Fork class per rule (provenance)

- SOQ-I009 creation reservation: `pre-existing` (2026-08-24), fork class recorded 2026-09-07.
- SOQ-ARCH-001 confidential creation rejection: `pre-existing`.
- `bad-*-authority-not-active` rejections: `pre-existing` (SOQ-I009), fork class found while
  writing this PR's tests.
- Asset opcodes in v6 → loosening at asset activation: `pre-existing`, found in the per-rule trace.
- Ungated undo mirrors: `pre-existing` state-corruption bug, exposed by the door, fixed here.
- Coinbase ban not covering v10: `pre-existing` gap, closed here because the ban became load-bearing.

## Tests (the first test is the attack)

`witness_version_reservation_tests` (rewritten):
- every version but v2 is creatable while dormant; v2 stays unfundable with CHECKPATAGG active;
- **the steal**: fund v4/v5/v6/v9/v11 for real, sweep with a garbage witness, the sweep connects;
- the funding tx is non-standard with the live mask, standard once the version bit is active;
- **activation tightens**: the identical sweep is rejected with the deployment active;
- value premise: v7/v8/v10 from SOQ rejected by conservation; coinbase to v7/v10/v8/v9 rejected;
- **the activation release's authority shape** (marker input carrying an authority-shaped
  witness, next marker out) connects while dormant, for USDSOQ and BTCSOQ;
- **reorg attack**: raw v9 marker plus a well-formed UNFREEZE envelope while BTCSOQ is dormant;
  disconnecting the block must not write a phantom freeze or overwrite the tracked outpoint
  (it did before the undo gates).

`v6_asset_opcode_ban_tests` (new): each banned opcode, alone and after a prefix, `BAD_OPCODE` in
eight flag states; verdict identical across states; banned byte values inside push data are data.

`authority_skip_gate_tests`: the two dormant-posture cases now assert the forged steal is stopped
by ordinary script verification (block does not connect) instead of by a named rejection.

`usdsoq_v10_reject_path_tests`: the formerly shadowed `bad-txns-usdsoq-confidential-not-active`
is now the rule that fires for a v10 output with USDSOQ active and SoquObscura dormant.

Consensus digest: **unchanged** (`a0b1e577…`). The digest exercises script verdicts with a two-item
witness and `versionActive` is not in it; the v6 opcode scan runs after the program-hash check,
which that witness fails first.

## Blast radius and deploy gate

Mainnet: no live behaviour changes (unlaunched, deployments unscheduled, no keyset).
Stagenet/testnet/regtest: the creation-gate removals and the CheckInputs fall-through are
loosenings, so history stays valid. Two tightenings need a pre-deploy scan of stagenet history,
same precedent as the 2026-08-31 v2 scan: (1) a v6 script containing one of the seven banned
opcodes anywhere in the script, including inside an unexecuted `OP_IF` branch; (2) a coinbase
paying to a v10 output (impossible under the previous gate, listed for completeness). Tracked as
bead `stagenet-scan-before-genesis-door-deploy-nydh`; the scan has not been run yet and is a
deploy gate, not a merge gate.

## Review round 1 (clean-room, one non-nesting agent, diff + repo only)

No critical findings. Everything below survived verification and is fixed in the second commit.

- **HIGH, `pre-existing-exposed-by-this-pr`: the PAT attested set was activation-dependent.**
  `IsAttestedVersion` admitted v7/v8 two-item spends only when the asset flag was set, so from an
  activation height onward a genesis node and an upgraded node recompute different block
  attestations and reject each other's coinbase commitments in both directions. That is a hard
  fork by construction, independent of everything else in this PR. Fixed: the set is fixed at
  v0/v1/v7/v8 for every height. Stagenet history is unaffected (its deployments are active from
  height 0, so v7/v8 were already attested). `pat_attestation_tests` updated; the PAT spec,
  `DEPLOYMENT_PRECONDITIONS.md` and the fork-class spec record the amendment.
- **MEDIUM, `pre-existing-exposed-by-this-pr`: mempool marker-spend mirrors were ungated** while
  their ConnectBlock twins sit inside the deployment flag, so a consensus-valid spend of a dormant
  v5/v9 marker would earn its relayer DoS(100). Fixed: both mirrors gated on the deployment.
- **MEDIUM, `pre-existing-exposed-by-this-pr`: `HasDilithiumSignatures` is an unlisted genesis
  rule** (last witness item of every input must be `0x00`-prefixed, with an unconditional `OP_5`
  exemption). Recorded in the fork-class spec (§2 table, §4.8) as a constraint on every future
  witness layout; the test comment corrected (the USDSOQ row is exempt via the marker, the BTCSOQ
  row is not).
- **MEDIUM, `introduced-by-this-pr`: only the BTCSOQ undo gates were exercised.** Added reorg
  tests for the USDSOQ authority-outpoint gate and the SoquObscura key-image gate; both fail with
  their gate reverted (mutation-checked).
- **LOW**: spec wording corrected (an exemption applied by the genesis binary may be dropped
  later; asset holding shapes are creatable only at `nValue == 0`; pool outputs keep plaintext
  `nValue`); stale comments and docs referencing the removed lambda or SOQ-ARCH-001 as live;
  the two `DIAG-FEE` per-input logs moved behind a log category (reachable with zero-value asset
  outputs); one pre-existing personnel name in a comment removed under the publishing rule.

Mutation results across both commits: reverting the undo gates, the CheckInputs fall-through,
the v6 opcode scan, the USDSOQ outpoint gate and the key-image gate each fail exactly the
intended tests.

## Docs

`CONSENSUS_COST_SPEC.md` and `FOR_AI_REVIEWERS.md` stated that the creation gate "enables
activation without a hard fork"; corrected. New `doc/specifications/WITNESS_VERSION_FORK_CLASS.md`
carries the per-version table and the additive asset-rule design the activation releases follow.
