### PR TITLE
consensus: give the stagenet maturity-mirror tier the chain's genesis fields (bead lfll)

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1484,11 +1484,9 @@ public:
         consensus.hashGenesisBlock = genesis.GetHash();
         digishieldConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
         auxpowConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
-        // The mirror tier was copied from auxpowConsensus BEFORE the genesis
-        // fields existed, so it carried a zero hash and a zero seed until
-        // 2026-09-07 (bead stagenet-mirror-tier-zeroed-genesis-lfll). Every
-        // tier must carry the chain's genesis fields; the digest absorbs both
-        // per tier, and genesis_chainparams_tests asserts it for every network.
+        // Every tier carries the genesis fields, including the mirror tier
+        // copied above; asserted for every network by genesis_chainparams_tests
+        // (bead stagenet-mirror-tier-zeroed-genesis-lfll).
         maturityMirrorConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
         assert(consensus.hashGenesisBlock == uint256S("0x97df3ae79eaf5623c0feecfa1079439f8acdfea06a0f2acb4ef63c6b9ad91bb0"));
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1484,6 +1484,12 @@ public:
         consensus.hashGenesisBlock = genesis.GetHash();
         digishieldConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
         auxpowConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
+        // The mirror tier was copied from auxpowConsensus BEFORE the genesis
+        // fields existed, so it carried a zero hash and a zero seed until
+        // 2026-09-07 (bead stagenet-mirror-tier-zeroed-genesis-lfll). Every
+        // tier must carry the chain's genesis fields; the digest absorbs both
+        // per tier, and genesis_chainparams_tests asserts it for every network.
+        maturityMirrorConsensus.hashGenesisBlock = consensus.hashGenesisBlock;
         assert(consensus.hashGenesisBlock == uint256S("0x97df3ae79eaf5623c0feecfa1079439f8acdfea06a0f2acb4ef63c6b9ad91bb0"));
 
         // SOQ-H3: Lattice-BP++ consensus seed
@@ -1493,6 +1499,7 @@ public:
             "N=256,Q=8380417,K=4,range=64");
         digishieldConsensus.latticeBPSeed = consensus.latticeBPSeed;
         auxpowConsensus.latticeBPSeed = consensus.latticeBPSeed;
+        maturityMirrorConsensus.latticeBPSeed = consensus.latticeBPSeed;
         // Phase 4 byte-less merkle root (unchanged — same coinbase, new serialization)
         assert(genesis.hashMerkleRoot == uint256S("0x994391b757742376b24ebdd37b0fa9ebc11da47366ca8f9ac0a21094da350736"));
 

--- a/src/test/consensus_digest_tests.cpp
+++ b/src/test/consensus_digest_tests.cpp
@@ -719,8 +719,27 @@ BOOST_AUTO_TEST_CASE(consensus_digest_is_pinned)
     // The fleet must run this binary before a coinbase mined at >= 100000 is
     // spent at depth 240-287, or nodes on the old binary and nodes on this one
     // will disagree and split stagenet.
+    //
+    // Moved from a0b1e577... on 2026-09-07 when the stagenet maturity-mirror
+    // tier received the chain's genesis fields (bead
+    // stagenet-mirror-tier-zeroed-genesis-lfll). NOT a rule change on the wire:
+    // the tier had been copied from auxpowConsensus before hashGenesisBlock and
+    // latticeBPSeed were assigned, so GetConsensus(h >= 100000) on stagenet
+    // carried a zero hash and a zero seed, and this pin certified that as
+    // correct. No live validation path reads either field from a height tier
+    // (CheckBlockIndex compares the genesis hash only under -checkblockindex,
+    // regtest-only by default; the seed has no live consumer), so a node with
+    // and a node without this change accept identical blocks.
+    //
+    // The absorbed inputs that move, and only these:
+    //   1. stagenet GetConsensus(1000000).hashGenesisBlock, 0 -> 97df3ae7...
+    //   2. stagenet GetConsensus(1000000).latticeBPSeed, all-zero -> the
+    //      ComputeSoquObscuraSeed value every other stagenet tier already had.
+    // Mainnet, testnet and regtest have no tier copied before their genesis
+    // assignment, and genesis_chainparams_tests now asserts every sampled tier
+    // against the base tier on every network so this cannot recur silently.
     const std::string expected =
-        "a0b1e5777acce071132d36c9bb07ce97f9c7b69b3ed5f13eb9a08f66c9baa00a";
+        "e7ea83dca405f0ca831014af9ddc1022e3f194d8024c0ec2c3ef0dbb6bd7350a";
 
     BOOST_CHECK_MESSAGE(digest.ToString() == expected,
         "consensus digest is " + digest.ToString() + ", expected " + expected +

--- a/src/test/consensus_digest_tests.cpp
+++ b/src/test/consensus_digest_tests.cpp
@@ -726,18 +726,22 @@ BOOST_AUTO_TEST_CASE(consensus_digest_is_pinned)
     // the tier had been copied from auxpowConsensus before hashGenesisBlock and
     // latticeBPSeed were assigned, so GetConsensus(h >= 100000) on stagenet
     // carried a zero hash and a zero seed, and this pin certified that as
-    // correct. No live validation path reads either field from a height tier
-    // (CheckBlockIndex compares the genesis hash only under -checkblockindex,
-    // regtest-only by default; the seed has no live consumer), so a node with
-    // and a node without this change accept identical blocks.
+    // correct. No validation, relay or mining path reads either field from a
+    // height tier: CheckBlockIndex compares the genesis hash only under
+    // -checkblockindex (regtest-only by default, and it would have fired AT
+    // height 100000, where GetConsensus first resolves to the mirror tier), and
+    // the seed's only height-tier reader is the getprivacyparams RPC
+    // (rpc/privacy.cpp), which would have reported a zero seed from that height.
+    // So a node with and a node without this change accept identical blocks.
     //
     // The absorbed inputs that move, and only these:
     //   1. stagenet GetConsensus(1000000).hashGenesisBlock, 0 -> 97df3ae7...
     //   2. stagenet GetConsensus(1000000).latticeBPSeed, all-zero -> the
     //      ComputeSoquObscuraSeed value every other stagenet tier already had.
-    // Mainnet, testnet and regtest have no tier copied before their genesis
-    // assignment, and genesis_chainparams_tests now asserts every sampled tier
-    // against the base tier on every network so this cannot recur silently.
+    // On mainnet, testnet and regtest every copied tier is listed in the
+    // assignments that follow the genesis block, and genesis_chainparams_tests
+    // now asserts every sampled tier against the base tier on every network so
+    // this cannot recur silently.
     const std::string expected =
         "e7ea83dca405f0ca831014af9ddc1022e3f194d8024c0ec2c3ef0dbb6bd7350a";
 

--- a/src/test/genesis_chainparams_tests.cpp
+++ b/src/test/genesis_chainparams_tests.cpp
@@ -263,10 +263,16 @@ BOOST_AUTO_TEST_CASE(stagenet_maturity_mirrors_mainnet_from_the_gate_height)
 // hash and a zero seed. That happened to the stagenet maturity-mirror tier
 // (bead stagenet-mirror-tier-zeroed-genesis-lfll): GetConsensus(h >= 100000)
 // reported hashGenesisBlock == 0, CheckBlockIndex would abort on it under
-// -checkblockindex, and the consensus digest certified the zeroed tier as
-// correct. This case reads the base tier at runtime and compares every sampled
-// tier against it on every network, and also refuses an all-zero base so two
-// zeroed sides cannot agree their way past it.
+// -checkblockindex, the getprivacyparams RPC would report a zero seed, and the
+// consensus digest certified the zeroed tier as correct. This case reads the
+// base tier at runtime and compares every sampled tier against it on every
+// network, and also refuses an all-zero base so two zeroed sides cannot agree
+// their way past it.
+//
+// Reach: only tiers linked into the GetConsensus tree are observable here. On
+// mainnet and testnet digishieldConsensus is assigned but not linked (the tree
+// is consensus -> auxpowConsensus), so a defect confined to it would be
+// invisible to this case and to the digest alike; nothing reads it today.
 BOOST_AUTO_TEST_CASE(every_tier_carries_the_genesis_fields_on_every_network)
 {
     const std::string nets[] = {CBaseChainParams::MAIN, CBaseChainParams::TESTNET,

--- a/src/test/genesis_chainparams_tests.cpp
+++ b/src/test/genesis_chainparams_tests.cpp
@@ -256,6 +256,43 @@ BOOST_AUTO_TEST_CASE(stagenet_maturity_mirrors_mainnet_from_the_gate_height)
     SelectParams(CBaseChainParams::MAIN);
 }
 
+// Every height-gated tier carries the chain's genesis fields. The tiers are
+// built by copying the previous tier and then overriding a few fields, and the
+// genesis hash and the Lattice-BP++ seed are assigned per tier AFTER the copies,
+// so a tier that is copied early and not listed there silently carries a zero
+// hash and a zero seed. That happened to the stagenet maturity-mirror tier
+// (bead stagenet-mirror-tier-zeroed-genesis-lfll): GetConsensus(h >= 100000)
+// reported hashGenesisBlock == 0, CheckBlockIndex would abort on it under
+// -checkblockindex, and the consensus digest certified the zeroed tier as
+// correct. This case reads the base tier at runtime and compares every sampled
+// tier against it on every network, and also refuses an all-zero base so two
+// zeroed sides cannot agree their way past it.
+BOOST_AUTO_TEST_CASE(every_tier_carries_the_genesis_fields_on_every_network)
+{
+    const std::string nets[] = {CBaseChainParams::MAIN, CBaseChainParams::TESTNET,
+                                CBaseChainParams::STAGENET, CBaseChainParams::REGTEST};
+    // Every tier boundary in chainparams.cpp plus a point far above the last one.
+    const int heights[] = {0, 1, 9, 10, 11, 19, 20, 21, 99, 100, 101, 1000,
+                           99999, 100000, 100001, 1000000};
+    for (const std::string& net : nets) {
+        SelectParams(net);
+        const Consensus::Params& base = Params().GetConsensus(0);
+        BOOST_CHECK_MESSAGE(!base.hashGenesisBlock.IsNull(), net + ": base tier genesis hash is zero");
+        bool seedAllZero = true;
+        for (unsigned char b : base.latticeBPSeed) seedAllZero = seedAllZero && (b == 0);
+        BOOST_CHECK_MESSAGE(!seedAllZero, net + ": base tier latticeBPSeed is all zero");
+        for (int h : heights) {
+            const Consensus::Params& tier = Params().GetConsensus(h);
+            BOOST_CHECK_MESSAGE(tier.hashGenesisBlock == base.hashGenesisBlock,
+                net + ": tier at height " + std::to_string(h) + " carries genesis hash " +
+                tier.hashGenesisBlock.ToString() + ", base tier has " + base.hashGenesisBlock.ToString());
+            BOOST_CHECK_MESSAGE(tier.latticeBPSeed == base.latticeBPSeed,
+                net + ": tier at height " + std::to_string(h) + " carries a different latticeBPSeed");
+        }
+    }
+    SelectParams(CBaseChainParams::MAIN);
+}
+
 // ============================================================================
 // BIP9 Deployment Sanity Tests
 //


### PR DESCRIPTION
## What
The stagenet tier arming at height 100,000 was copied from auxpowConsensus before hashGenesisBlock and latticeBPSeed were assigned, and the per-tier assignments after the genesis block listed only the three older tiers. GetConsensus(h >= 100000) on stagenet carried a zero genesis hash and an all-zero seed. Two assignments in chainparams.cpp fix it; the digest is re-pinned a0b1e577 -> e7ea83dc with the two moving inputs recorded in the pin history.

## Correction to the first commit message (permanent, so recorded here)
b809d902a says the seed "has no live consumer" and that CheckBlockIndex would abort "on the first block past the gate". Both are imprecise, found by the clean-room review: the getprivacyparams RPC (src/rpc/privacy.cpp:777-782) reads latticeBPSeed from the tip-height tier and would have reported 32 zero bytes from stagenet height 100,000; and GetConsensus(100000) already resolves to the mirror tier, so the abort under -checkblockindex would fire AT 100,000. Neither is a validation, relay or mining path, so the wire claim below stands. The comments in the tree carry the corrected wording (1533a8cb4).

## Threat and state pass
- **Actors:** fleet nodes on v2.3.0 (240, zeroed tier) vs nodes carrying this change; the pool as block producer.
- **States:** stagenet below 100,000 (tiers unchanged by this PR) and at/above 100,000 (tier now carries the real genesis hash and seed).
- **Wire effect:** none. Every hashGenesisBlock reader in validation/init uses the base tier except CheckBlockIndex (validation.cpp:8391), which returns unless fCheckBlockIndex (init.cpp:967 -> DefaultConsistencyChecks, true only on regtest). The seed's only height-tier reader is the RPC above. A node with and without this change accepts identical blocks, so bundling it into the pre-100,000 fleet deploy adds no split risk.
- **What input makes the new check fail:** any tier on any network whose genesis hash or seed differs from the base tier, or a base tier that is itself zero. Against the unfixed source it fails on stagenet tiers 100000, 100001 and 1000000 on both fields (6 assertions), and on nothing else.
- **Restarts, reorgs, clocks, concurrency:** not applicable; chainparams are constructed once at startup.
- **Reversal:** none needed; nothing on disk depends on these fields.

## Provenance
pre-existing (introduced by the 2026-08-29 mirror-tier commit, bead x48g; surfaced by the clean-room review of c6bec52af).

## Review record
Clean-room review (one non-nesting agent, diff + repo, read-only): no CRITICAL/HIGH. MEDIUM: the seed-consumer claim (fixed in comments, corrected above). LOW: per-tier hand listing is the same pattern that produced the defect; a helper assigning all tiers would be a strictly better mechanism. Declined for this pre-freeze PR: it would touch all four network classes for a defect the new cross-network test now catches on any tier; filed as follow-up on bead tofg's pattern. LOW: mainnet/testnet digishieldConsensus is not linked into the GetConsensus tree, so neither this test nor the digest can see it; recorded in the test comment, nothing reads it. Two NITs (repeated prose, one-block wording) fixed.

## Tests
- New: genesis_chainparams_tests/every_tier_carries_the_genesis_fields_on_every_network. Reads the base tier at runtime (one runtime side, no second literal), 16 sampled heights straddling every tier boundary on all four networks; refuses an all-zero base.
- Mutation: with the two assignments deleted, exactly the 6 expected assertions fail; restored, genesis + digest suites pass.
- Digest pin moved deliberately with history entry (consensus_digest_tests.cpp).
- Full unit suite on the b809d902a tree (code-identical to HEAD; 1533a8cb4 is comment-only): result posted below before this PR leaves draft.

## Deploy
Rides the v2.4.0 (FC5) fleet deploy per the ops runbook (soqucoin-ops #110 §2); the runbook's expected digest is e7ea83dc.