### PR TITLE
consensus: ban the v5 coinbase marker, reject APO unconditionally on the single-key path, and remove the scan's forgettable wiring

### DIFF
--- a/contrib/stagenet-scan-genesis-door.py
+++ b/contrib/stagenet-scan-genesis-door.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Pre-deploy gate for the additive-asset genesis door (soqucoin PR #83).
 
-Scans a live stagenet chain for the two rules that the door TIGHTENS on an
+Scans a live stagenet chain for the rules that the v2.4.0 tag TIGHTENS on an
 existing chain, so that a fleet node carrying the new binary is proven to
-accept every block already in stagenet history before it is deployed:
+accept every block already in stagenet history before it is deployed. Four
+detectors, T1, T2, T2b and T3:
 
   T1  a witness-v6 (OP_6 <32>) spend whose witnessScript contains one of
       OP_USDSOQ_MINT/BURN/FREEZE/ROTATE (0xf4-0xf7), OP_SOQUOBSCURA_RANGEPROOF
@@ -13,6 +14,26 @@ accept every block already in stagenet history before it is deployed:
       SCRIPT_ERR_BAD_OPCODE in every asset-flag state.
   T2  a COINBASE output paying to OP_10 <32> (confidential USDSOQ), now
       rejected by CheckTransaction (IsAnyUSDSOQ) as bad-cb-usdsoq-asset.
+  T2b a COINBASE output paying to OP_5 <32> (USDSOQ authority marker), now
+      rejected by the same CheckTransaction branch as bad-cb-usdsoq-asset.
+      ⚠️ T2 AND T2b CANNOT FIRE ON THIS NETWORK AND THEIR ZEROS CARRY NO
+      INFORMATION. ContextualCheckBlock (src/validation.cpp, the
+      bad-cb-output-type rule added in 38c4f700e, 2025-11-21) already rejects
+      ANY coinbase output that is not OP_1 <32> or OP_RETURN, on every network
+      except regtest, at every height above 0. That predates every block of the
+      current stagenet chain, so no coinbase asset output has ever been valid
+      here. Both detectors are kept as belt-and-braces against a future change
+      to that rule; do not cite their zeros as evidence for the CheckTransaction
+      bans. The bans themselves are defence in depth, and on regtest they are
+      the only such rule.
+  T3  a SIGHASH_ANYPREVOUT (0x41) or ANYPREVOUTANYSCRIPT (0x42) signature on the
+      single-key Dilithium path — any two-item witness. Bead mpu9 made that
+      rejection UNCONDITIONAL, and stagenet runs DEPLOYMENT_APO active from
+      height 0, so unlike mainnet this network COULD have accepted such a spend.
+      Any hit is a block the new binary rejects. Scoped to the single-key
+      path by t3_classify: a witness-v6 spend also has a two-item stack,
+      [witnessScript, pubkey], and reading the last byte of a witnessScript
+      as a hashtype is a false positive.
 
 Everything else the door changes is a loosening or is flag-neutral on stagenet
 (USDSOQ and BTCSOQ are active from height 0 there, SoquObscura is dormant), so
@@ -99,6 +120,101 @@ def scan_script(script):
     return "ok", None
 
 
+DILITHIUM_SIG_BYTES = 2420          # src/key.h:23 SIGNATURE_SIZE
+DILITHIUM_PUBKEY_BYTES = (1312, 1313)   # raw (CPubKey::GetLen accepts only
+                                        # 1312) and the 0x00-prefixed form
+                                        # VerifyScript accepts
+
+
+def t3_classify(stack_hex, tracked_ver):
+    """Is this input a single-key-path spend, and if so its base sighash type?
+
+    Approximates the REACHABILITY condition in VerifyScript, rather than
+    matching any two witness items. Consensus reaches the IsAPOSigHashType
+    rejection (src/script/interpreter.cpp, the single-key Dilithium path in
+    VerifyScript) only for v0/v1 and the v7/v8 holding shapes, and only after
+    SHA256(pubkey) matches the 32-byte program.
+
+    This function does NOT recompute that hash: progs holds no v0/v1 entries,
+    so the program is not available here. It substitutes the prevout version
+    and the ML-DSA-44 size check below. Any spend already in a block matched
+    the hash by construction, so for the historical question this scan asks,
+    the substitution loses nothing.
+
+    A witness-v6 spend ALSO presents a two-item stack, [witnessScript,
+    pubkey] (see classify_v6), so treating the last byte of a witnessScript
+    as a hashtype is a false positive. Once T3 gates the verdict that would
+    be a false FAIL, i.e. a blocked deploy on no evidence.
+
+    tracked_ver is the prevout's witness version when the scan has seen the
+    output that created it, else None. progs holds v2+ only, so on a scan
+    from height 0 an untracked prevout is v0/v1 -- the shape stagenet uses.
+    On an incremental scan (--from > 0) prevouts created below the range are
+    also untracked; the shape test below carries the discrimination there,
+    and the residual error direction is a false FAIL, never a false PASS.
+
+    Returns (status, base_sighash_type|None); status is one of "checked",
+    "not_single_key", "not_dilithium_shape", "undecodable".
+    """
+    if len(stack_hex) != 2 or not stack_hex[0]:
+        return "not_single_key", None
+    if tracked_ver is not None and tracked_ver not in (7, 8):
+        return "not_single_key", None
+    try:
+        sig = bytes.fromhex(stack_hex[0])
+        pubkey = bytes.fromhex(stack_hex[1])
+    except ValueError:
+        return "undecodable", None
+    if not sig:
+        return "undecodable", None
+    # A spend that reached a block under the OLD binary passed CheckSig, so
+    # its signature and pubkey are real ML-DSA-44 objects of known size.
+    # Any other two-item shape cannot be a block this binary newly rejects.
+    if len(sig) != DILITHIUM_SIG_BYTES + 1 or len(pubkey) not in DILITHIUM_PUBKEY_BYTES:
+        return "not_dilithium_shape", None
+    return "checked", sig[-1] & 0x7F
+
+
+# Every tightening this scan detects. main() builds its hit lists FROM this
+# tuple and compute_verdict REQUIRES exactly these keys, so there is no
+# per-detector wiring between the two that can be forgotten.
+#
+# ⛔ Bead mpu9's T3 was collected, printed and serialised, and then left out of
+# the verdict condition, so a real hit reported PASS. The first fix tested
+# compute_verdict in isolation, which did not help: the function was generic
+# over its keys, so the assertions passed for any key set and the mutation that
+# mattered was at the CALL SITE. A pure-function test proves nothing about the
+# wiring. The wiring is therefore removed rather than tested: adding a detector
+# means adding its name here, and the JSON block below reads every name in this
+# tuple, so deleting one raises KeyError on the next run instead of silently
+# dropping a gate.
+SCAN_TESTS = ("T1", "T2", "T2b", "T3")
+
+
+def compute_verdict(hits, controls):
+    """(verdict, exit code) from the hit lists and the positive controls.
+
+    hits maps a test name to its hit list and MUST carry exactly SCAN_TESTS.
+    Every entry blocks the deploy: a tightening this binary adds, found in
+    history, means a node carrying it would reject a block the chain already
+    has.
+    """
+    missing = sorted(set(SCAN_TESTS) - set(hits))
+    unexpected = sorted(set(hits) - set(SCAN_TESTS))
+    if missing or unexpected:
+        raise ValueError(
+            f"verdict wiring broken: missing {missing}, unexpected {unexpected}. "
+            f"compute_verdict must receive exactly SCAN_TESTS ({list(SCAN_TESTS)}); "
+            f"a detector that is not passed here cannot block a deploy.")
+    fired = sorted(name for name, hs in hits.items() if hs)
+    if fired:
+        return (f"FAIL - tightening hit in history ({', '.join(fired)}); "
+                f"do not deploy, re-decide"), 2
+    if not all(v for v in controls.values() if isinstance(v, bool)):
+        return "FAIL - instrument not proven; zero hits mean nothing", 3
+    return "PASS", 0
+
+
 def selftest():
     fails = []
     count = [0]
@@ -135,6 +251,65 @@ def selftest():
     check("v6 stack witnessScript position", classify_v6(stack, prog), ("banned", "OP_USDSOQ_FREEZE"))
     check("v6 hash mismatch detected", classify_v6(stack, b"\x00" * 32), ("hash_mismatch", None))
     check("v6 short stack detected", classify_v6([ws.hex()], prog), ("short_stack", None))
+    # T3: the detector that gates the APO tightening must prove itself too.
+    good_sig = "aa" * DILITHIUM_SIG_BYTES
+    good_pk = "00" + "bb" * 1312
+    check("t3 sighash_all", t3_classify([good_sig + "01", good_pk], None), ("checked", 0x01))
+    check("t3 anyprevout", t3_classify([good_sig + "41", good_pk], None), ("checked", 0x41))
+    check("t3 anyprevoutanyscript", t3_classify([good_sig + "42", good_pk], None), ("checked", 0x42))
+    check("t3 anyonecanpay|apo masks to 0x41",
+          t3_classify([good_sig + "c1", good_pk], None), ("checked", 0x41))
+    check("t3 raw 1312-byte pubkey accepted",
+          t3_classify([good_sig + "01", "bb" * 1312], None), ("checked", 0x01))
+    # The false-positive vector this scoping exists to kill: a two-item v6
+    # witness whose witnessScript happens to end in 0x41.
+    check("t3 v6 prevout excluded", t3_classify([good_sig + "41", good_pk], 6),
+          ("not_single_key", None))
+    check("t3 v7 prevout is single-key", t3_classify([good_sig + "41", good_pk], 7),
+          ("checked", 0x41))
+    check("t3 v8 prevout is single-key", t3_classify([good_sig + "42", good_pk], 8),
+          ("checked", 0x42))
+    check("t3 short witnessScript is not a signature",
+          t3_classify(["5141", good_pk], None), ("not_dilithium_shape", None))
+    check("t3 wrong pubkey size rejected",
+          t3_classify([good_sig + "41", "bb" * 33], None), ("not_dilithium_shape", None))
+    check("t3 three-item stack is not single-key",
+          t3_classify([good_sig + "41", good_pk, "00"], None), ("not_single_key", None))
+    check("t3 empty sig", t3_classify(["", good_pk], None), ("not_single_key", None))
+    check("t3 odd-length hex", t3_classify(["abc", good_pk], None), ("undecodable", None))
+    # The verdict is the gate. Assert that EVERY tightening blocks the deploy
+    # on its own -- the C1 defect was a hit list that was collected, printed
+    # and then left out of this condition.
+    ok_controls = {"a": True, "b": True}
+    none = {name: [] for name in SCAN_TESTS}
+    check("verdict passes when clean and proven",
+          compute_verdict(none, ok_controls), ("PASS", 0))
+    for name in SCAN_TESTS:
+        hits = dict(none, **{name: [{"height": 1}]})
+        got = compute_verdict(hits, ok_controls)
+        check(f"verdict FAILs on a {name} hit alone", (got[1], name in got[0]), (2, True))
+    check("verdict FAILs on an unproven instrument",
+          compute_verdict(none, {"a": True, "b": False})[1], 3)
+    check("a hit outranks an unproven instrument",
+          compute_verdict(dict(none, T3=[{"height": 1}]), {"a": False})[1], 2)
+    # The defect was at the CALL SITE, so assert the guard that makes a
+    # forgotten detector loud instead of silent.
+    for dropped in SCAN_TESTS:
+        short = {k: v for k, v in none.items() if k != dropped}
+        try:
+            compute_verdict(short, ok_controls)
+            check(f"verdict REFUSES a hits dict missing {dropped}", "accepted", "ValueError")
+        except ValueError as e:
+            check(f"verdict REFUSES a hits dict missing {dropped}", dropped in str(e), True)
+    try:
+        compute_verdict(dict(none, T9=[]), ok_controls)
+        check("verdict REFUSES an unknown detector name", "accepted", "ValueError")
+    except ValueError as e:
+        check("verdict REFUSES an unknown detector name", "T9" in str(e), True)
+    # F10: v5 is the version T2b exists for and was not in the version table.
+    check("v5 program", witness_version("5520" + h32)[0], 5)
+    check("v7 program", witness_version("5720" + h32)[0], 7)
+    check("v8 program", witness_version("5820" + h32)[0], 8)
     if fails:
         print("SELFTEST FAIL\n  " + "\n  ".join(fails))
         return 1
@@ -211,6 +386,9 @@ def main():
     ap.add_argument("--conf", default="/root/.soqucoin/soqucoin.conf")
     ap.add_argument("--datadir", default="/root/.soqucoin")
     ap.add_argument("--from", dest="h_from", type=int, default=0)
+    ap.add_argument("--partial", action="store_true",
+                    help="allow a PASS over a partial range. The deploy gate must "
+                         "NOT use this: a partial scan cannot clear the chain.")
     ap.add_argument("--to", dest="h_to", type=int, default=None, help="inclusive; default = tip at start")
     ap.add_argument("--batch", type=int, default=100)
     ap.add_argument("--out", default=None)
@@ -236,7 +414,11 @@ def main():
     spent = {}            # version -> count of spends seen (v2..v16 only, from progs)
     cb_outputs = {}       # version -> coinbase output count ("nonprogram" for the rest)
     v6 = {"spends": 0, "ok": 0, "banned": 0, "parse_fail": 0, "hash_mismatch": 0, "short_stack": 0}
-    hits_t1, hits_t2, anomalies, txs_total = [], [], [], 0
+    # T3: two-item (single-key path) witnesses, by base sighash type of stack[0].
+    t3 = {"checked": 0, "not_single_key": 0, "not_dilithium_shape": 0,
+          "undecodable": 0, "apo": 0, "apoanyscript": 0, "base_types": {}}
+    hits = {name: [] for name in SCAN_TESTS}
+    anomalies, txs_total = [], 0
     t0 = time.time()
 
     for start in range(args.h_from, h_to + 1, args.batch):
@@ -257,7 +439,9 @@ def main():
                         key = ver if ver is not None else "nonprogram"
                         cb_outputs[key] = cb_outputs.get(key, 0) + 1
                         if ver == 10:
-                            hits_t2.append({"height": h, "txid": tx["txid"], "n": vout["n"]})
+                            hits["T2"].append({"height": h, "txid": tx["txid"], "n": vout["n"]})
+                        elif ver == 5:
+                            hits["T2b"].append({"height": h, "txid": tx["txid"], "n": vout["n"]})
                     if ver is not None:
                         created[ver] = created.get(ver, 0) + 1
                         if ver >= 2:
@@ -266,6 +450,23 @@ def main():
                     continue
                 for vin in tx["vin"]:
                     key = (vin["txid"], vin["vout"])
+                    # T3 is evaluated BEFORE the progs.pop below so it can see
+                    # the prevout's witness version and exclude v2+ shapes that
+                    # are not the single-key path. v0/v1 are never in progs.
+                    tracked = progs.get(key)
+                    status, base = t3_classify(vin.get("txinwitness", []),
+                                               tracked[0] if tracked else None)
+                    t3[status] += 1
+                    if status == "undecodable":
+                        anomalies.append({"height": h, "txid": tx["txid"],
+                                          "status": "t3_sig_undecodable"})
+                    elif status == "checked":
+                        t3["base_types"][hex(base)] = t3["base_types"].get(hex(base), 0) + 1
+                        if base in (0x41, 0x42):
+                            t3["apo" if base == 0x41 else "apoanyscript"] += 1
+                            hits["T3"].append({"height": h, "txid": tx["txid"],
+                                            "prevout": f'{vin["txid"]}:{vin["vout"]}',
+                                            "sighash": hex(base)})
                     entry = progs.pop(key, None)
                     if entry is None:
                         continue
@@ -279,14 +480,15 @@ def main():
                     rec = {"height": h, "txid": tx["txid"], "prevout": f"{key[0]}:{key[1]}",
                            "status": status, "detail": detail}
                     if status in ("banned", "parse_fail"):
-                        hits_t1.append(rec)          # the tightening: accepted then, rejected now
+                        hits["T1"].append(rec)       # the tightening: accepted then, rejected now
                     elif status != "ok":
                         anomalies.append(rec)        # rejected before #83 too: scanner or RPC defect
         done = heights[-1] - args.h_from + 1
         if (heights[-1] + 1) % 5000 == 0 or heights[-1] == h_to:
             rate = done / max(time.time() - t0, 1e-9)
             sys.stderr.write(f"height {heights[-1]}/{h_to}  txs={txs_total}  v6spends={v6['spends']}  "
-                             f"t1={len(hits_t1)} t2={len(hits_t2)}  {rate:.0f} blk/s\n")
+                             + " ".join(f"{n.lower()}={len(hits[n])}" for n in SCAN_TESTS)
+                             + f"  {rate:.0f} blk/s\n")
 
     result = {
         "scan": "additive-asset genesis door pre-deploy gate (bead nydh)",
@@ -300,8 +502,11 @@ def main():
         "coinbase_outputs_by_version": {str(k): v for k, v in sorted(cb_outputs.items(), key=lambda kv: str(kv[0]))},
         "unspent_v2plus_programs_at_end": len(progs),
         "T1_v6_witnessScript": v6,
-        "T1_hits": hits_t1,
-        "T2_coinbase_v10_hits": hits_t2,
+        "T1_hits": hits["T1"],
+        "T2_coinbase_v10_hits": hits["T2"],
+        "T2b_coinbase_v5_hits": hits["T2b"],
+        "T3_single_key_path_sighash": t3,
+        "T3_apo_on_single_key_path_hits": hits["T3"],
         "instrument_anomalies": anomalies,
     }
     # The instrument must prove it saw the chain before its zero counts mean
@@ -311,20 +516,25 @@ def main():
     # tightening (both were rejected before #83), so it is a scanner or RPC
     # defect and also blocks the verdict.
     controls = {
+        # F9: a partial range can satisfy every other control and still miss
+        # the block that matters. A PASS asserts something about the WHOLE
+        # chain, so a partial scan is not allowed to produce one unless the
+        # operator says so explicitly with --partial.
+        "full_range_scanned": args.partial or (args.h_from == 0 and h_to == tip_h),
         "v6_spends_seen_nonzero": v6["spends"] > 0,
         "v6_outputs_created": created.get(6, 0),
         "v7_outputs_created_nonzero": created.get(7, 0) > 0,
+        # T3's zero is only a result if the detector actually decoded
+        # signatures on the single-key path in this range. Seeing SIGHASH_ALL
+        # is the stronger form: it proves the byte being read really is a
+        # hashtype, not merely that the loop ran.
+        "t3_single_key_spends_checked_nonzero": t3["checked"] > 0,
+        "t3_saw_sighash_all": t3["base_types"].get("0x1", 0) > 0,
         "coinbase_v0_or_v1_seen": (cb_outputs.get(0, 0) + cb_outputs.get(1, 0)) > 0,
         "no_instrument_anomalies": not anomalies,
     }
     result["positive_controls"] = controls
-    instrument_ok = all(v for v in controls.values() if isinstance(v, bool))
-    if hits_t1 or hits_t2:
-        verdict, code = "FAIL - tightening hit in history; do not deploy, re-decide", 2
-    elif not instrument_ok:
-        verdict, code = "FAIL - instrument not proven; zero hits mean nothing", 3
-    else:
-        verdict, code = "PASS", 0
+    verdict, code = compute_verdict(hits, controls)
     result["verdict"] = verdict
     result["elapsed_s"] = round(time.time() - t0, 1)
     text = json.dumps(result, indent=2)

--- a/doc/DEPLOYMENT_PRECONDITIONS.md
+++ b/doc/DEPLOYMENT_PRECONDITIONS.md
@@ -38,6 +38,37 @@ feature that satisfies its own row and violates one of these is **not** ready.
    batch-activate. `NOT_SCHEDULED` stays until the relevant Halborn Phase 2 scope
    signs off on that specific feature.
 
+   ⛔ **ONE EXCEPTION, AND IT IS MANDATORY, NOT PERMISSIVE: the witness-v6
+   covenant stack.** `DEPLOYMENT_P2WSH_DILITHIUM`, `DEPLOYMENT_DILITHIUM_KEYHASH`,
+   `DEPLOYMENT_CSFS`, `DEPLOYMENT_V6_CONTROLFLOW` and `DEPLOYMENT_APO` MUST
+   activate at the SAME height, in one flag-day, and so does `DEPLOYMENT_CTV`.
+   Splitting them is not a conservative choice here, it is a hard fork. Two
+   distinct mechanisms produce it, and the deployments are not interchangeable:
+
+   - **Stack arity**, for `DEPLOYMENT_CSFS`, `DEPLOYMENT_DILITHIUM_KEYHASH` and
+     `DEPLOYMENT_V6_CONTROLFLOW`. Each of those opcodes changes the stack depth
+     between its clear and set states, so a v6 script that fails the clean-stack
+     check while one of them is dormant PASSES once it activates.
+   - **Sighash acceptance**, for `DEPLOYMENT_APO`. APO is a sighash type, not an
+     opcode, and changes no stack depth. Its loosening is a `SIG_HASHTYPE`
+     rejection inside `OP_CHECKDILITHIUMKEYHASH` turning into an acceptance.
+
+   `DEPLOYMENT_P2WSH_DILITHIUM` is neither: it is the version gate itself, and
+   it is the baseline the other four are measured against. `DEPLOYMENT_CTV` is
+   arity-neutral and could in principle follow later; it is held to the same
+   flag-day so that the rule has no exception to remember, and the test below
+   enforces that. Either mechanism gives a loosening measured against the
+   intermediate release, and it splits every
+   node running it. Measured against the genesis binary the combined activation
+   is a soft fork, because a dormant v6 output is anyone-can-spend.
+   `DEPLOYMENT_CTV` is the one member of the stack that is
+   genuinely arity-neutral and could follow later; it is included in the
+   flag-day anyway so that the rule has no edge case to remember. Audit scope
+   must therefore clear for the WHOLE stack before any of it is scheduled.
+   Rationale and the per-opcode arity trace:
+   `doc/specifications/WITNESS_VERSION_FORK_CLASS.md` §3a and the v6 row of §2.
+   Pinned by `witness_version_allocation_tests::v6_covenant_stack_activates_together`.
+
 4. **Relay policy must move in lockstep with consensus, never ahead of it.** A
    gated witness version is anyone-can-spend until its deployment activates. If
    relay policy also calls it standard, the pair is not a safe failure, it is a
@@ -239,8 +270,14 @@ BIP 119 `OP_CHECKTEMPLATEVERIFY`, BIP 118 `SIGHASH_ANYPREVOUT`, BIP 348
 2. ☐ APO specifically: the hashtype gate must be pinned
    (`apo_hashtype_gate_tests.cpp`), since ANYPREVOUT changes what a signature
    commits to.
-3. ☐ These three are commonly activated together for eLTOO. That is still three
-   separate decisions under rule 3 above.
+3. ☐ These three are commonly activated together for eLTOO. Under the v6
+   covenant-stack exception to rule 3 they are not three separate scheduling
+   decisions. All three activate in the same flag-day as
+   `DEPLOYMENT_P2WSH_DILITHIUM`, `DEPLOYMENT_DILITHIUM_KEYHASH` and
+   `DEPLOYMENT_V6_CONTROLFLOW`: a later activation of CSFS or APO is a
+   loosening, and CTV is included so the rule has no exception. They remain
+   three separate AUDIT decisions, and the flag-day cannot be scheduled until
+   all of them clear.
 
 ### `DEPLOYMENT_P2WSH_DILITHIUM` (bit 10)
 Witness v6: P2WSH with Dilithium. Covenant script execution and L2SOQ Lightning.

--- a/doc/specifications/WITNESS_VERSION_FORK_CLASS.md
+++ b/doc/specifications/WITNESS_VERSION_FORK_CLASS.md
@@ -28,7 +28,7 @@ switches from reject to accept at activation is a hard fork however it is gated.
 | `bad-*-authority-not-active`: authority-shaped tx rejected while the asset deployment is dormant | `CheckInputs` | same (the activation release accepts the shape) | replaced by fall-through to ordinary per-input script verification |
 | Undo mirrors for asset supply, authority outpoint, freeze registry and key images | `DisconnectBlock` | state corruption, not fork class: reversed ops ConnectBlock never applied | gated on the deployment exactly as ConnectBlock is |
 | Asset/attestation opcodes inside a v6 script: `BAD_OPCODE` while the asset flag is clear, executed once set | `interpreter.cpp` v6 path | rejection relaxed at asset activation → hard fork for every asset activation after P2WSH-Dilithium | made unconditionally invalid inside v6 (opcodes are dispatched by witness version, never by script) |
-| Coinbase asset bans (`bad-cb-usdsoq-asset`, `bad-cb-btcsoq-asset`) and dual-marker ban | `CheckTransaction` | rejections every release keeps | **kept**, coinbase USDSOQ ban extended to v10 |
+| Coinbase asset bans (`bad-cb-usdsoq-asset`, `bad-cb-btcsoq-asset`) and dual-marker ban | `CheckTransaction` | rejections every release keeps | **kept**, coinbase USDSOQ ban extended to v10 and to the v5 authority marker (2026-09-08), matching the v9 ban; §4.4 authority transactions are ordinary transactions that spend a marker, never coinbases, so this is a rejection every activation release keeps |
 | `HasDilithiumSignatures` (`bad-txns-requires-dilithium`): the LAST witness item of every non-coinbase input must begin `0x00`, with a whole-tx exemption when an `OP_5` output plus an authority-shaped witness is present | `CheckTransaction` via `primitives/transaction.cpp` | the check is a rejection every release keeps; the exemption is applied by the genesis binary (dropping it later only tightens) | **kept**; constrains every future witness layout (§4.8) |
 | PAT attested set: v7/v8 two-item spends joined the set only when their deployment was active | `consensus/pat_attestation.cpp`, `ConnectBlock` commitment check | commitment became a function of activation state → genesis and upgraded nodes reject each other's commitments = **hard fork** | set fixed at v0/v1/v7/v8 for every height |
 | Mempool marker-spend mirrors (`bad-*-marker-spend`) | `AcceptToMemoryPoolWorker` | policy, not fork class, but DoS(100) on a consensus-valid spend of a dormant marker | gated on the deployment like their ConnectBlock twins |
@@ -51,14 +51,42 @@ program nor the sighash.
 | v3 | LatticeFold (retired) | soft, if ever revived with a sound verifier | creatable, anyone-can-spend |
 | v4 | SoquObscura pool (confidential SOQ) | **soft**, provided the activation release follows §4 (shielded-pool value model) | |
 | v5 / v7 | USDSOQ authority / holding | **soft**, provided the activation release follows §4 | |
-| v6 | P2WSH-Dilithium | **soft** | spend binds `SHA256(witnessScript)` to the program and the sighash inside the script; the covenant opcodes (CTV, CSFS, CDKH, V6_CONTROLFLOW) are NOP-when-clear inside v6 scripts and can activate with it or after it |
+| v6 | P2WSH-Dilithium | **soft**, provided the activation release follows §3a | spend binds `SHA256(witnessScript)` to the program and the sighash inside the script. ⛔ The covenant opcodes are NOT interchangeable here: only CTV is arity-neutral with its flag clear (`interpreter.cpp` `OP_CHECKTEMPLATEVERIFY`: validates and leaves its hash on the stack when set, NOP when clear). CSFS (pops 3 pushes 1 when set, NOP when clear), CDKH (pops 3 when set, NOP7 when clear) and V6_CONTROLFLOW (its opcodes are silently ignored when clear, there is no terminal `BAD_OPCODE`) each change the stack depth between states, so a script that fails the clean-stack check while they are dormant passes once they activate. A later activation of any of the three is a LOOSENING. **CTV activates in the same flag-day regardless**, so that the rule has no exception to remember, and `witness_version_allocation_tests::v6_covenant_stack_activates_together` enforces that. APO is in the flag-day too, by a different mechanism: it is a sighash type, not an opcode, and its loosening is a rejection inside CDKH turning into an acceptance. See §3a |
 | v8 / v9 | BTCSOQ holding / authority | **soft**, provided the activation release follows §4 | |
 | v10 | confidential USDSOQ | **soft**, provided the activation release follows §4 | the USDSOQ-gated backstop `bad-txns-usdsoq-confidential-not-active` stays: it is a tightening |
 | v11–v16 | unallocated | soft for any future version whose rules are additive | allocation-time review applies §1 |
 
-Out of scope here and tracked separately: `DEPLOYMENT_APO` gates SIGHASH_ANYPREVOUT at consensus
-on the v1/v7/v8 path, so its activation is a rejection relaxed = hard fork; the additive fix is
-to reject those hashtypes on v1/v7/v8 permanently and reach APO only inside v6 scripts.
+### 3a. APO / eLTOO, and the activation-sequencing rule (bead mpu9, ruled 2026-09-08)
+
+D1 found that `DEPLOYMENT_APO` gated SIGHASH_ANYPREVOUT at consensus on the v1/v7/v8 single-key
+path, so activating it would relax a rejection = hard fork. Option (a) was ruled and is
+implemented:
+
+* **The single-key path (v0/v1, and the v7/v8 holding shapes) rejects APO hashtypes
+  UNCONDITIONALLY** (`interpreter.cpp`, `IsAPOSigHashType` at the VerifyScript call site). v1 is
+  active from genesis, so the genesis binary rejects those spends and every later release must
+  keep rejecting them. `DEPLOYMENT_APO` can no longer open this path, so the trap cannot be
+  sprung by scheduling a height.
+* **APO reaches the chain only inside witness v6**, through `OP_CHECKDILITHIUMKEYHASH`, whose
+  handler keeps the `SCRIPT_VERIFY_APO` gate. That is safe because OP_CDKH is NOP-when-clear:
+  while its flag is clear the opcode succeeds without inspecting any signature, so the genesis
+  binary rejects nothing there and activation only ADDS a requirement.
+* eLTOO is unaffected. Its channel outputs are already v6 (`src/stagenet-eltoo.cpp` `MakeV6Spk`,
+  `OP_6 <SHA256(witnessScript)>`) and its ANYPREVOUT signatures are verified inside the v6
+  witnessScript.
+
+⛔ **SEQUENCING IS PART OF THE FORK CLASS — this is a rule on the activation coordination, not
+on the code.** `DEPLOYMENT_APO` MUST activate in the SAME flag-day as
+`DEPLOYMENT_P2WSH_DILITHIUM` and `DEPLOYMENT_DILITHIUM_KEYHASH`. Measured against the genesis
+binary a combined activation is a soft fork, because a dormant v6 output is anyone-can-spend and
+the genesis binary accepts any v6 script. Activating APO LATER is a loosening measured against
+the intermediate release: between the two heights a v6 script spending with an APO signature is
+rejected, and after the second height it is accepted, which splits every node running the
+v6-without-APO release. The whole covenant / eLTOO / atomic-swap stack (v6, CTV, CSFS, CDKH,
+V6_CONTROLFLOW, APO) therefore activates as ONE flag-day, which is what D1 §4 assumed.
+
+Pinned by `apo_hashtype_gate_tests`: the single-key path rejects APO *with the deployment
+active*, with an ordinary-hashtype spend as the positive control.
 
 ## 4. The additive asset-rule design the activation releases must follow
 
@@ -114,6 +142,20 @@ non-v1 address (`utiladdress.cpp`), and a stock miner builds blocks from its mem
 the anyone-can-spend window takes raw construction plus a miner running modified policy, and
 the only funds at risk are the constructor's own.
 
+Residual, tracked separately: the USDSOQ bootstrap in `ConnectBlock` selects its authority
+input by SHAPE — any `OP_5 <32>` prevout, while the tracked outpoint is null — and does not
+require the program to equal `ComputeAuthorityKeyHash`. BTCSOQ does not have this shape: its
+bootstrap pins the authority input to index 0 and signs against the tx's own new v9 marker
+output. Neither is exploitable without the authority keyset, since a bootstrap still verifies
+M-of-N ML-DSA-44 against the configured keys. The coinbase bans are defence in depth rather
+than the closure of a live hole: `ContextualCheckBlock` already rejects any coinbase output that
+is not `OP_1 <32>` or `OP_RETURN` with `bad-cb-output-type`, on every network except regtest,
+above height 0, and has done since 2025-11-21. On regtest the `CheckTransaction` bans are the
+only such rule. An ordinary transaction can still create a marker by paying its own SOQ into it,
+which is the route that matters. Pinning the USDSOQ fallback is a tightening, so it is safe to add in the release that
+schedules USDSOQ, alongside the keyset.
+
 Tests: `witness_version_reservation_tests` (creation posture, the steal, relay refusal,
-activation-tightens, the value premise on both paths, reorg over dormant shapes),
-`v6_asset_opcode_ban_tests`, `authority_skip_gate_tests`, `usdsoq_v10_reject_path_tests`.
+activation-tightens, the value premise on both paths, reorg over dormant shapes, the coinbase
+marker bans for v5 and v9), `v6_asset_opcode_ban_tests`, `authority_skip_gate_tests`,
+`usdsoq_v10_reject_path_tests`.

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -119,13 +119,35 @@ static inline void popstack(vector<valtype>& stack)
 //
 // Enforced at the call sites that actually hold `flags`, which avoids the
 // three-class interface change that was the stated reason for not gating it.
+static bool IsAPOSigHashType(const std::vector<unsigned char>& vchSig)
+{
+    if (vchSig.empty()) return false;  // let the normal path raise its own error
+    const int baseHashType = vchSig.back() & 0x7f;
+    return baseHashType == SIGHASH_ANYPREVOUT ||
+           baseHashType == SIGHASH_ANYPREVOUTANYSCRIPT;
+}
+
+//! v6 / OP_CHECKDILITHIUMKEYHASH path: gated on DEPLOYMENT_APO.
+//!
+//! Safe to gate, because the only caller sits INSIDE the
+//! `flags & SCRIPT_VERIFY_DILITHIUM_KEYHASH` branch and OP_CDKH is
+//! NOP-when-clear. While that flag is clear the opcode succeeds without
+//! looking at any signature, so the genesis binary REJECTS NOTHING here.
+//! Activating v6 + CDKH + APO together therefore only ADDS a requirement:
+//! a soft fork measured against the genesis binary, which is the test in
+//! doc/specifications/WITNESS_VERSION_FORK_CLASS.md §1.
+//!
+//! ⛔ SEQUENCING IS PART OF THE FORK CLASS. DEPLOYMENT_APO must activate in
+//! the SAME flag-day as DEPLOYMENT_P2WSH_DILITHIUM and
+//! DEPLOYMENT_DILITHIUM_KEYHASH. Activating APO LATER is a loosening measured
+//! against the intermediate release — a v6 script spending with an APO
+//! signature is rejected between the two heights and accepted after — which
+//! splits every node running the v6-without-APO release. Ruled 2026-09-08;
+//! spec §3.
 static bool APOSigHashTypeAllowed(const std::vector<unsigned char>& vchSig, unsigned int flags)
 {
     if (flags & SCRIPT_VERIFY_APO) return true;
-    if (vchSig.empty()) return true;  // let the normal path raise its own error
-    const int baseHashType = vchSig.back() & 0x7f;
-    return baseHashType != SIGHASH_ANYPREVOUT &&
-           baseHashType != SIGHASH_ANYPREVOUTANYSCRIPT;
+    return !IsAPOSigHashType(vchSig);
 }
 
 bool CheckSignatureEncoding(const vector<unsigned char>& vchSig, unsigned int flags, ScriptError* serror)
@@ -1821,15 +1843,39 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
         // Asset and attestation opcodes are dispatched by WITNESS VERSION (v2,
         // v3, v4, v5 above), never from inside a script, and a v6 script may
         // not contain one. This is UNCONDITIONAL — not gated on the asset
-        // deployments — because EvalScript answers BAD_OPCODE for these while
-        // their flag is clear and executes them once it is set. Reachable from
-        // a v6 script, that is a rule that FAILS before an asset activation and
-        // SUCCEEDS after it, i.e. a loosening, which would make every asset
-        // activation that follows P2WSH-Dilithium a hard fork. Rejecting the
-        // opcode's presence in every state is a rule the activation release
-        // keeps, so it stays a soft fork. Scanned with GetOp so bytes inside
-        // pushes are not mistaken for opcodes; a script that fails to parse is
-        // rejected here rather than half-executed.
+        // deployments — for two reasons, which do not apply to the same
+        // opcodes:
+        //
+        //   * OP_CHECKFOLDPROOF and the four USDSOQ opcodes are flag-gated
+        //     inside EvalScript and EXECUTE once their flag is set.
+        //     OP_CHECKFOLDPROOF answers BAD_OPCODE while
+        //     SCRIPT_VERIFY_LATTICEFOLD is clear (:364); the USDSOQ four answer
+        //     the DISTINCT error SCRIPT_ERR_USDSOQ_NOT_ACTIVE while
+        //     SCRIPT_VERIFY_USDSOQ is clear (:514). Different error codes, one
+        //     shape: reachable from a v6 script, that is a rule that FAILS
+        //     before an asset activation and SUCCEEDS after it, a loosening,
+        //     which would make every asset activation that follows
+        //     P2WSH-Dilithium a hard fork. Rejecting the opcode's presence in
+        //     every state is a rule the activation release keeps, so it stays
+        //     a soft fork.
+        //   * OP_SOQUOBSCURA_RANGEPROOF answers BAD_OPCODE while
+        //     SCRIPT_VERIFY_SOQUOBSCURA is clear (:476) but does NOT execute
+        //     once it is set: it fails closed with
+        //     SCRIPT_ERR_SOQUOBSCURA_RANGEPROOF_UNVERIFIED and has deliberately
+        //     no accept path (:481). It cannot loosen while that holds, so it
+        //     is banned here as a tightening in its own right. Banning it now
+        //     is what keeps the ban free on the release that ships a verifier.
+        //   * OP_CHECKPATAGG has NO flag gate in EvalScript, because
+        //     DEPLOYMENT_CHECKPATAGG is ALWAYS_ACTIVE on every network, so it
+        //     never has a dormant state to loosen out of. It is banned here as
+        //     a tightening in its own right: v2 is the version that dispatches
+        //     PAT, and PAT verifies no signature, so the opcode has no business
+        //     inside a v6 covenant either way. Do not restate this one as
+        //     flag-gated; it is not.
+        //
+        // Scanned with GetOp so bytes inside pushes are not mistaken for
+        // opcodes; a script that fails to parse is rejected here rather than
+        // half-executed.
         {
             CScript::const_iterator pc = witnessScript.begin();
             opcodetype op;
@@ -1970,8 +2016,25 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
     // The signing path passes the scriptPubKey (OP_1 <32-byte-hash>) to
     // SignatureHash. Passing scriptSig (empty for witness) produces a different
     // sighash, causing every Dilithium signature to fail verification.
-    // SOQ-I010: APO sighash types are inert until DEPLOYMENT_APO activates.
-    if (!APOSigHashTypeAllowed(sig, flags)) {
+    // ⛔ SOQ-I010 / bead mpu9: APO SIGHASH TYPES ARE PERMANENTLY INVALID ON THIS
+    // PATH, AND THIS REJECTION IS NOT GATED ON DEPLOYMENT_APO. Ruled 2026-09-08.
+    //
+    // This is the single-key Dilithium path, shared by v0/v1 (active from
+    // genesis) and the v7/v8 holding shapes. Because v1 is ACTIVE from genesis,
+    // the genesis binary already rejects an APO signature here. Gating the
+    // rejection on DEPLOYMENT_APO would mean activation turns a rejection into
+    // an acceptance — a loosening, i.e. a HARD FORK — however it is scheduled.
+    // Flag-day activation does not change fork class; only direction does.
+    //
+    // eLTOO does not need APO here. Its channel outputs are witness v6
+    // (src/stagenet-eltoo.cpp MakeV6Spk) and its ANYPREVOUT signatures are
+    // verified inside the v6 witnessScript by OP_CHECKDILITHIUMKEYHASH, which
+    // is NOP-when-clear and therefore soft-fork activatable. APO reaches the
+    // chain through v6 and nowhere else.
+    //
+    // Do not "restore symmetry" by re-gating this on the flag. The asymmetry is
+    // the point: v6 is dormant at genesis and this path is not.
+    if (IsAPOSigHashType(sig)) {
         return set_error(serror, SCRIPT_ERR_SIG_HASHTYPE);
     }
 
@@ -2040,12 +2103,19 @@ bool TransactionSignatureChecker::CheckSig(const std::vector<unsigned char>& vch
     //      no-op and the Halborn Phase 2 sighash review would have been gating
     //      an already-enforced feature.
     //   ✅ "CheckSig() does not receive `flags`."  Still true, and still not
-    //      worth an interface change across three classes. The gate now lives at
-    //      the two call sites that DO hold `flags` — VerifyScript's v0/v1
-    //      Dilithium path and EvalScript's OP_CHECKDILITHIUMKEYHASH handler —
-    //      via APOSigHashTypeAllowed(). Mempool and consensus derive
-    //      SCRIPT_VERIFY_APO from the same DeploymentActiveAtHeight call, so the
-    //      two paths agree at off/off and on/on (no accept-then-reject split).
+    //      worth an interface change across three classes. The two call sites
+    //      that DO hold `flags` carry the rule, and since 2026-09-08 they carry
+    //      DIFFERENT rules, because they have different fork classes (bead
+    //      mpu9):
+    //        - VerifyScript's v0/v1 single-key Dilithium path rejects APO
+    //          UNCONDITIONALLY (IsAPOSigHashType). v1 is active from genesis, so
+    //          a deployment-gated rejection there would loosen at activation.
+    //        - EvalScript's OP_CHECKDILITHIUMKEYHASH handler stays gated on
+    //          SCRIPT_VERIFY_APO (APOSigHashTypeAllowed), because the opcode is
+    //          NOP-when-clear, so the genesis binary rejects nothing there.
+    //      Mempool and consensus derive SCRIPT_VERIFY_APO from the same
+    //      DeploymentActiveAtHeight call, so the v6 path agrees at off/off and
+    //      on/on (no accept-then-reject split).
     //
     // Pinned by src/test/apo_hashtype_gate_tests.cpp.
     //

--- a/src/test/apo_hashtype_gate_tests.cpp
+++ b/src/test/apo_hashtype_gate_tests.cpp
@@ -75,14 +75,49 @@ struct ApoGateSetup : public DilithiumChainSetup {
 
 BOOST_FIXTURE_TEST_SUITE(apo_hashtype_gate_tests, ApoGateSetup)
 
-// Reachability control first: regtest activates APO at height 0, so an
-// APO-signed spend must connect. Without this the rejections below could be
-// caused by anything.
-BOOST_AUTO_TEST_CASE(apo_signature_connects_while_deployment_active)
+// THE TRAP THIS PINS (bead mpu9, ruled 2026-09-08). Until 2026-09-08 this case
+// asserted the OPPOSITE — that an APO-signed v1 spend CONNECTS while
+// DEPLOYMENT_APO is active. That behaviour is what made activating APO a HARD
+// FORK: v1 is active from genesis, so the genesis binary rejects this spend,
+// and a release that accepts it accepts a block the genesis binary rejects.
+// Flag-day scheduling does not change that; only direction does.
+//
+// The rejection on the single-key path is now UNCONDITIONAL. APO reaches the
+// chain only inside witness v6, through OP_CHECKDILITHIUMKEYHASH, which is
+// NOP-when-clear and therefore soft-fork activatable (covenant_tests,
+// dilithium_keyhash_committed_tests, keyhash_broadcast_tests,
+// lightning_script_tests cover that path; eLTOO channel outputs are v6, see
+// src/stagenet-eltoo.cpp MakeV6Spk).
+//
+// Regtest activates APO at height 0, so this runs with the deployment ACTIVE.
+// That is the point: the flag must not be able to open this path.
+BOOST_AUTO_TEST_CASE(apo_rejected_on_single_key_path_even_when_deployment_active)
 {
-    CMutableTransaction tx = SpendWithHashType(coinbaseTxns[0], SIGHASH_ANYPREVOUT);
+    const int h = chainActive.Height() + 1;
+    BOOST_REQUIRE_MESSAGE(Consensus::DeploymentActiveAtHeight(
+        h, Params().GetConsensus(h), Consensus::DEPLOYMENT_APO),
+        "regtest must have DEPLOYMENT_APO active, or this proves nothing");
+
+    CMutableTransaction apo = SpendWithHashType(coinbaseTxns[0], SIGHASH_ANYPREVOUT);
+    BOOST_CHECK_MESSAGE(!BlockIsValid({apo}),
+        "SIGHASH_ANYPREVOUT was honoured on the v1 single-key path with "
+        "DEPLOYMENT_APO ACTIVE — the flag can still open a path the genesis "
+        "binary rejects, which is a hard fork (bead mpu9)");
+
+    CMutableTransaction apoas = SpendWithHashType(coinbaseTxns[4], SIGHASH_ANYPREVOUTANYSCRIPT);
+    BOOST_CHECK_MESSAGE(!BlockIsValid({apoas}),
+        "SIGHASH_ANYPREVOUTANYSCRIPT was honoured on the v1 single-key path "
+        "with DEPLOYMENT_APO ACTIVE");
+}
+
+// Positive control for the case above: with APO ACTIVE, the same harness and
+// the same key produce a spend that CONNECTS when the hashtype is ordinary. So
+// the rejections above are about the hashtype, not about a broken fixture.
+BOOST_AUTO_TEST_CASE(single_key_path_still_spends_with_an_ordinary_hashtype)
+{
+    CMutableTransaction tx = SpendWithHashType(coinbaseTxns[5], SIGHASH_ALL);
     BOOST_CHECK_MESSAGE(BlockIsValid({tx}),
-        "SIGHASH_ANYPREVOUT must work while DEPLOYMENT_APO is active");
+        "ordinary SIGHASH_ALL spending broke — the APO rejection is too wide");
 }
 
 // The gate. Same transaction, deployment withdrawn (mainnet's posture).

--- a/src/test/witness_version_allocation_tests.cpp
+++ b/src/test/witness_version_allocation_tests.cpp
@@ -46,7 +46,9 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 BOOST_FIXTURE_TEST_SUITE(witness_version_allocation_tests, BasicTestingSetup)
@@ -523,6 +525,127 @@ BOOST_AUTO_TEST_CASE(retired_v3_is_still_soft_fork_safe_not_burned)
     BOOST_CHECK_MESSAGE(!StandardWith(Program(3), WitnessVersionBit(3)),
         "witness v3 must never be relay-standard, even with its mask bit forced on. That is "
         "the only thing standing between anyone-can-spend and a funded v3 output");
+}
+
+// ⛔ THE ATTACK THIS PINS: someone schedules the v6 covenant stack the way
+// DEPLOYMENT_PRECONDITIONS.md rule 3 reads at a glance — one feature at a time
+// — and ships DEPLOYMENT_P2WSH_DILITHIUM + DEPLOYMENT_DILITHIUM_KEYHASH at
+// height H1 and DEPLOYMENT_APO at H2 > H1. Between H1 and H2 every node
+// rejects a v6 spend carrying an ANYPREVOUT signature; at H2 the upgraded
+// nodes accept it and every node still on the H1 release forks off. That is a
+// HARD FORK produced by a one-line chainparams edit, and until this test
+// existed nothing in the tree observed it.
+//
+// TWO mechanisms produce it, and the deployments are not interchangeable.
+// (Line numbers are deliberately omitted: they drifted within a single editing
+// session. Find each handler by its opcode in EvalScript.)
+//
+// 1. STACK ARITY, inside a v6 script:
+//
+//   OP_CSFS            set: pops 3, pushes 1.   clear: NOP.
+//   OP_CDKH            set: pops 3.             clear: NOP7.
+//   V6_CONTROLFLOW     set: OP_DROP/OP_EQUAL/OP_SHA256/OP_CLTV/OP_CSV execute.
+//                      clear: silently ignored. The v6 dispatch chain has NO
+//                      terminal else->BAD_OPCODE, so an unmatched opcode is a
+//                      no-op rather than a failure.
+//   OP_CTV             set: validates and leaves its hash on the stack.
+//                      clear: NOP. ARITY-NEUTRAL, the only one of the four.
+//
+//   For the eLTOO shape <khB> OP_CDKH <khA> OP_CDKH OP_1 satisfied by
+//   [sigA, pkA, sigB, pkB]: with CDKH clear nothing is popped, seven items
+//   remain, and the clean-stack check in VerifyScript's P2WSH-Dilithium branch
+//   REJECTS. With CDKH set the stack reduces to [1] and it ACCEPTS.
+//
+// 2. SIGHASH ACCEPTANCE, for DEPLOYMENT_APO. APO is a sighash type, not an
+//    opcode, and changes no stack depth. Its loosening is the SIG_HASHTYPE
+//    rejection inside OP_CHECKDILITHIUMKEYHASH turning into an acceptance.
+//
+// DEPLOYMENT_P2WSH_DILITHIUM is neither: it is the version gate, the baseline
+// the other four are measured against. Rejected-then-accepted is a loosening
+// however it is scheduled; flag-day activation does not change fork class,
+// only direction does.
+//
+// Measured against the GENESIS binary the combined activation is still a soft
+// fork, because a dormant v6 output is anyone-can-spend. So the whole stack in
+// one flag-day is safe and any split of it is not.
+//
+// See doc/specifications/WITNESS_VERSION_FORK_CLASS.md §3a and the v6 row of
+// §2, doc/DEPLOYMENT_PRECONDITIONS.md rule 3's exception, and bead mpu9.
+BOOST_AUTO_TEST_CASE(v6_covenant_stack_activates_together)
+{
+    const std::pair<Consensus::DeploymentPos, const char*> kStack[] = {
+        {Consensus::DEPLOYMENT_P2WSH_DILITHIUM, "DEPLOYMENT_P2WSH_DILITHIUM"},
+        {Consensus::DEPLOYMENT_DILITHIUM_KEYHASH, "DEPLOYMENT_DILITHIUM_KEYHASH"},
+        {Consensus::DEPLOYMENT_CSFS, "DEPLOYMENT_CSFS"},
+        {Consensus::DEPLOYMENT_V6_CONTROLFLOW, "DEPLOYMENT_V6_CONTROLFLOW"},
+        {Consensus::DEPLOYMENT_APO, "DEPLOYMENT_APO"},
+        // CTV is arity-neutral and could in principle follow later. It is held
+        // to the same height anyway so the rule has no edge case to remember.
+        {Consensus::DEPLOYMENT_CTV, "DEPLOYMENT_CTV"},
+    };
+
+    // ⛔ EVERY TIER, NOT JUST THE ONE COVERING HEIGHT 0. Each network builds a
+    // height-indexed tier tree and GetConsensus(h) returns whichever tier
+    // covers h; stagenet's maturityMirrorConsensus tier (height >= 100,000) is
+    // the tier stagenet is about to enter. An edit applied to one tier is
+    // invisible to the others, which is the hazard CRegTestParams::
+    // UpdateActivationHeight in chainparams.cpp warns about in the same words.
+    // Reading only GetConsensus(0) let a per-tier split pass this test.
+    const int kProbeHeights[] = {0, 1, 9, 10, 19, 20, 144999, 145000,
+                                 371336, 371337, 99999, 100000, 100001, 1000000};
+
+    for (const std::string& net : {CBaseChainParams::MAIN, CBaseChainParams::TESTNET,
+                                   CBaseChainParams::REGTEST, CBaseChainParams::STAGENET}) {
+        SelectParams(net);
+
+        std::set<const Consensus::Params*> tiers;
+        for (int probe : kProbeHeights) tiers.insert(&Params().GetConsensus(probe));
+
+        // Positive control: the probe must actually reach more than one tier,
+        // or "checked every tier" is a claim about a single struct. Every
+        // network in this loop builds at least two.
+        BOOST_CHECK_MESSAGE(
+            tiers.size() >= 2,
+            net + ": the height probe reached only " + std::to_string(tiers.size()) +
+            " consensus tier(s). This test asserts the flag-day invariant on EVERY "
+            "tier, so if the tier layout changed, kProbeHeights must change with it. "
+            "A single-tier result means the per-tier check is not running");
+
+        for (const Consensus::Params* tier : tiers) {
+        const Consensus::Params& params = *tier;
+
+        const int32_t anchor = params.vDeployments[kStack[0].first].nActivationHeight;
+        for (const auto& d : kStack) {
+            const int32_t h = params.vDeployments[d.first].nActivationHeight;
+            BOOST_CHECK_MESSAGE(
+                h == anchor,
+                net + " (tier effective from height " +
+                std::to_string(params.nHeightEffective) + "): " + d.second +
+                " is scheduled at height " + std::to_string(h) +
+                " but " + kStack[0].second + " is at " + std::to_string(anchor) +
+                ". The witness-v6 covenant stack MUST activate in ONE flag-day. "
+                "Splitting it is a HARD FORK: these opcodes change stack arity "
+                "between their clear and set states, so a v6 script that fails the "
+                "clean-stack check while one of them is dormant PASSES once it "
+                "activates, which splits every node on the intermediate release. "
+                "APO splits it by a different mechanism, sighash acceptance rather "
+                "than arity, and is in the same flag-day for that reason. "
+                "See WITNESS_VERSION_FORK_CLASS.md 3a and bead mpu9. If you are "
+                "scheduling the flag-day, move ALL of these to the same height, "
+                "IN EVERY TIER of this network's consensus tree");
+
+            // NO_HEIGHT_ACTIVATION defers to the BIP9 state machine, whose
+            // per-deployment timing is not a single flag-day by construction.
+            BOOST_CHECK_MESSAGE(
+                params.vDeployments[d.first].nActivationHeight !=
+                    Consensus::BIP9Deployment::NO_HEIGHT_ACTIVATION,
+                net + ": " + d.second + " must not use NO_HEIGHT_ACTIVATION. The v6 "
+                "covenant stack activates by height, together; the BIP9 state machine "
+                "would let its members cross the threshold independently");
+        }
+        }
+    }
+    SelectParams(CBaseChainParams::MAIN);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/witness_version_reservation_tests.cpp
+++ b/src/test/witness_version_reservation_tests.cpp
@@ -340,21 +340,58 @@ BOOST_AUTO_TEST_CASE(asset_holdings_cannot_hold_value_before_activation)
     }
 }
 
-// Coinbase path: CheckTransaction bans asset holdings and the BTCSOQ marker in
-// a coinbase, unconditionally. A coinbase is the one transaction the
+// Coinbase path: CheckTransaction bans asset holdings and BOTH authority
+// markers in a coinbase, unconditionally. A coinbase is the one transaction the
 // conservation rule does not see, so without these bans a miner could create a
 // valued asset-shaped output while the deployment is dormant. v10 is covered
 // by the same ban as v7 (IsAnyUSDSOQ), which is the part this PR added.
+//
+// THE ATTACK THIS PINS: a miner mines a coinbase paying to a v5 (USDSOQ
+// authority) or v9 (BTCSOQ authority) marker while the deployment is dormant.
+// It costs nothing — a coinbase spends no inputs. The two markers are NOT
+// symmetric in what that buys the miner:
+//
+//   v5 (USDSOQ) is the one with a shape-matching consumer. The bootstrap
+//   fallback selects THE authority input by SHAPE, taking the first input
+//   whose prevout is OP_5 <32> while the tracked outpoint is null (see the
+//   localAuthOutpoint.IsNull() branch in ConnectBlock), with the
+//   attacker-chosen prevout supplying the authorityScriptCode.
+//
+//   v9 (BTCSOQ) is not. Its bootstrap pins nAuthorityInputIndex = 0 and never
+//   scans inputs for a v9 prevout, so a planted v9 marker UTXO is inert. Its
+//   ban is a tightening in its own right, not a fix for this attack. Do not
+//   restate it as one.
+//
+// ⚠️ AND THE COINBASE ROUTE IS ALREADY CLOSED OUTSIDE REGTEST, corrected
+// 2026-09-08 after review. ContextualCheckBlock rejects any coinbase output
+// that is not OP_1 <32> or OP_RETURN with bad-cb-output-type, on every network
+// except regtest, above height 0, and has done since 2025-11-21. So on
+// mainnet, testnet and stagenet a miner cannot mine this block at all, and
+// this case passes here only because the suite runs on regtest, where that
+// rule is exempted. What this test pins is the CheckTransaction layer:
+// defence in depth on the real networks, and the ONLY such rule on regtest.
+// It is not evidence that a live hole was closed.
+//
+// v9 was banned when BTCSOQ landed; v5 was not, and before the additive-asset
+// genesis door it did not matter, because creating a v5 output at all was
+// consensus-reserved while USDSOQ was dormant. The door removed that
+// reservation, so the ban has to carry the weight.
 BOOST_AUTO_TEST_CASE(coinbase_cannot_create_asset_shapes)
 {
     ScopedRegtestWithdrawal offU(Consensus::DEPLOYMENT_USDSOQ, 0);
     ScopedRegtestWithdrawal offB(Consensus::DEPLOYMENT_BTCSOQ, 0);
     BOOST_CHECK_EQUAL(CoinbaseRejectReason(Spk(OP_7)),  "bad-cb-usdsoq-asset");
     BOOST_CHECK_EQUAL(CoinbaseRejectReason(Spk(OP_10)), "bad-cb-usdsoq-asset");
+    BOOST_CHECK_EQUAL(CoinbaseRejectReason(Spk(OP_5)),  "bad-cb-usdsoq-asset");
     BOOST_CHECK_EQUAL(CoinbaseRejectReason(Spk(OP_8)),  "bad-cb-btcsoq-asset");
     BOOST_CHECK_EQUAL(CoinbaseRejectReason(Spk(OP_9)),  "bad-cb-btcsoq-asset");
-    // Control: the ban is about asset shapes, not about non-v1 coinbases.
+    // Control: the ban is about asset shapes and markers, not about non-v1
+    // coinbases. Scoped to the CheckTransaction layer under test: a coinbase
+    // paying to v6 is rejected bad-cb-output-type by ContextualCheckBlock on
+    // every network except regtest, so this control holds here because the
+    // suite runs on regtest. It asserts that THIS ban does not over-reach.
     BOOST_CHECK_EQUAL(CoinbaseRejectReason(Spk(OP_1)), "");
+    BOOST_CHECK_EQUAL(CoinbaseRejectReason(Spk(OP_6)), "");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -596,18 +596,49 @@ bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fChe
         }
 
         // Coinbase outputs must be native SOQ — cannot mint USDSOQ via mining.
+        // The v5 authority marker is forbidden in a coinbase for the same
+        // reason the v9 marker is (see the BTCSOQ rule below): with witness-
+        // version creation no longer consensus-reserved, a coinbase-born v5
+        // UTXO costs the miner nothing and would sit in the UTXO set as a
+        // candidate prevout for the bootstrap fallback in ConnectBlock, which
+        // accepts ANY v5 prevout as the authority input while the tracked
+        // outpoint is null. This is a partial control, not a complete one: an
+        // ordinary transaction can still create a v5 output by paying its own
+        // SOQ into it, and neither marker ban changes that. Both paths are
+        // inert without the authority keyset (a bootstrap still verifies M-of-N
+        // ML-DSA against the configured keys), and the residual is tracked
+        // separately: pin the bootstrap fallback to ComputeAuthorityKeyHash.
+        //
+        // ⚠️ SCOPE OF THIS BAN, corrected 2026-09-08 after review. On mainnet,
+        // testnet and stagenet a miner ALREADY cannot produce such a coinbase:
+        // ContextualCheckBlock rejects any coinbase output that is not
+        // OP_1 <32> or OP_RETURN with bad-cb-output-type, on every network
+        // except regtest, at every height above 0. That rule predates every
+        // block of the current stagenet chain, so no coinbase asset output has
+        // ever been valid there. This ban is therefore DEFENCE IN DEPTH on the
+        // real networks, and on REGTEST it is the only such rule. Do not
+        // describe it as closing a reachable miner path; the earlier version of
+        // this comment did, and it was wrong.
+        //
+        // It is still worth having. It rejects at CheckTransaction rather than
+        // at ContextualCheckBlock, so it holds if the output-type rule is ever
+        // relaxed, and it makes the v5 case explicit next to the v9 one.
+        //
         // Unconditional on purpose: a rejection the genesis binary carries is
-        // one every later release keeps, and this one is load-bearing for the
-        // additive asset design (see above).
-        if (tx.IsCoinBase() && hasUSDSOQ) {
+        // one every later release keeps.
+        if (tx.IsCoinBase() && (hasUSDSOQ || hasUSDSOQAuthority)) {
             return state.DoS(100, false, REJECT_INVALID, "bad-cb-usdsoq-asset");
         }
 
         // DL-BTCSOQ-CONSENSUS-NATIVE: same rule for BTCSOQ (v8), and the v9
-        // authority marker is also forbidden in a coinbase — a coinbase-born
-        // marker UTXO could otherwise serve as a bootstrap-fallback prevout.
-        // (Unlike USDSOQ, BTCSOQ has no legacy chain, so this is strict from
-        // genesis on every network.)
+        // authority marker is also forbidden in a coinbase. NOT for the reason
+        // the v5 ban above exists: BTCSOQ's bootstrap pins
+        // nAuthorityInputIndex = 0 (see the BTCSOQ block in ConnectBlock) and
+        // never scans inputs for a v9 prevout, so a coinbase-born v9 marker is
+        // inert, unlike a v5 one. This ban is a tightening in its own right,
+        // kept because a free miner-only asset-shaped UTXO has no legitimate
+        // use. (Unlike USDSOQ, BTCSOQ has no legacy chain, so this is strict
+        // from genesis on every network.)
         if (tx.IsCoinBase() && (hasBTCSOQ || hasBTCSOQAuthority)) {
             return state.DoS(100, false, REJECT_INVALID, "bad-cb-btcsoq-asset");
         }
@@ -7175,9 +7206,6 @@ std::vector<unsigned char> GenerateCoinbaseCommitment(CBlock& block, const CBloc
     // producer/validator drift.
     // =========================================================================
     if (pcoinsTip != nullptr && block.vtx.size() > 1) {
-        const int nHeight = pindexPrev == nullptr ? 0 : pindexPrev->nHeight + 1;
-        const Consensus::Params& patConsensus = Params().GetConsensus(nHeight);
-
         // The attested set is fixed and height-independent (see
         // IsAttestedVersion), so the miner and ConnectBlock cannot disagree.
         const patattest::AttestedSetParams patParams;


### PR DESCRIPTION
Replaces #88, which was never merged. Three commits ahead of the v2.4.0 tag: two consensus tightenings, the activation-sequencing rule they imply, and the pre-deploy scan that must be able to reject them.

#88 was rebuilt rather than amended because a second clean-room review found a defect in the fix itself and falsified a claim carried in its commit messages, and commit messages cannot be corrected after merge. The superseded commits are kept locally at tags `prereview/genesis-door-fixups-20260908` and `prereview/genesis-door-r1-20260908`.

## What changed

| Commit | Rule |
|---|---|
| `c27c71e01` | `CheckTransaction` rejects a coinbase output paying `OP_5 <32>` (USDSOQ authority marker) as `bad-cb-usdsoq-asset` |
| `21bb56e48` | `VerifyScript`'s single-key Dilithium path rejects SIGHASH_ANYPREVOUT and ANYPREVOUTANYSCRIPT **unconditionally**; the v6 covenant stack is pinned to one flag-day, on every consensus tier |
| `aaf40593e` | The pre-deploy scan has no per-detector wiring left that can be forgotten |

Both consensus edits are tightenings. Neither makes anything valid that was invalid.

## Threat and state pass

**Actors.** A miner (writes coinbases). A spender (chooses hashtype and witness shape). The maintainer who schedules an activation height. The operator who runs the pre-deploy gate and the fleet deploy.

**States.** Per deployment: dormant (`NOT_SCHEDULED`), scheduled-not-reached, active. Per network, the six v6-stack deployments hold that state independently *in each consensus tier*, which is the hazard. Per chain: genesis binary, intermediate release, activation release.

**Transitions, and what each makes valid.**

- *Dormant to active, `DEPLOYMENT_APO`, single-key path.* Before: the gated rejection fired only while the flag was clear, so activation turned a rejection into an acceptance. v1 is active from genesis, so the genesis binary already rejects here, making that a loosening against a deployed binary, i.e. a hard fork, however it is scheduled. After: the rejection does not consult the flag.
- *Dormant to active, `DEPLOYMENT_APO`, `OP_CHECKDILITHIUMKEYHASH`.* Kept flag-gated deliberately. `OP_CDKH` is NOP-when-clear, and with `SCRIPT_VERIFY_P2WSH_DILITHIUM` clear a v6 spend short-circuits to success before the script is parsed. The genesis binary rejects nothing there, so activation only adds a rule. The asymmetry between the two call sites is the design.
- *Split activation of the v6 stack.* The general case. **Two mechanisms, not one.** Stack arity for `OP_CSFS` (pops 3, pushes 1 when set; NOP when clear), `OP_CDKH` (pops 3 when set; NOP7 when clear) and the `V6_CONTROLFLOW` opcodes (silently ignored when clear, with no terminal `BAD_OPCODE`): `<khB> OP_CDKH <khA> OP_CDKH OP_1` satisfied by `[sigA, pkA, sigB, pkB]` leaves seven items with CDKH clear and fails the clean-stack check, and reduces to `[1]` with CDKH set. Sighash acceptance for `DEPLOYMENT_APO`, which is a sighash type rather than an opcode and changes no stack depth: its loosening is the `SIG_HASHTYPE` rejection inside `OP_CDKH` becoming an acceptance. `DEPLOYMENT_P2WSH_DILITHIUM` is neither; it is the version gate the other four are measured against. `DEPLOYMENT_CTV` is arity-neutral and could in principle follow later, and is held to the same flag-day so the rule has no exception.
- *Dormant to active, `DEPLOYMENT_USDSOQ`, with a planted v5 coinbase marker.* USDSOQ's bootstrap fallback selects the authority input by shape, taking any input whose prevout is `OP_5 <32>` while the tracked outpoint is null, with the attacker-chosen prevout supplying the `authorityScriptCode`. **The coinbase route to that marker is already closed outside regtest**; see the scope note below. The reachable route is an ordinary transaction paying its own SOQ into a v5 output, which neither ban touches.
- *The same, BTCSOQ.* Does not apply. BTCSOQ pins `nAuthorityInputIndex = 0` and never scans inputs for a v9 prevout, so a planted v9 marker is inert. Two comments claimed otherwise and are corrected.

**What input makes each new check FAIL.** The v5 ban: a coinbase with a 34-byte `OP_5`-prefixed output. The APO rejection: a two-item witness whose `stack[0]` last byte masks to `0x41` or `0x42`, asserted **with the deployment active**. The flag-day invariant: any one of the six deployments at a different height **in any tier**. All three mutation-proven, see Verification.

**Concurrency, clocks, restarts.** None of these paths are time- or order-dependent. Mempool and consensus derive the flags from the same `DeploymentActiveAtHeight` call, so there is no accept-then-reject window, and `apo_is_not_in_standard_flags` still pins the policy side.

## Scope of the v5 coinbase ban, corrected after review

An earlier version of this branch described the ban as closing a reachable miner path. That was wrong. `ContextualCheckBlock` already rejects any coinbase output that is not `OP_1 <32>` or `OP_RETURN`, with `bad-cb-output-type`, on every network except regtest, above height 0. That rule landed in `38c4f700e` (2025-11-21), an ancestor of this branch's base, and predates every block of the current stagenet chain.

So the ban is defence in depth on mainnet, testnet and stagenet, and on regtest it is the only such rule. It is still worth having: it rejects one layer earlier, so it survives any relaxation of the output-type rule, and it states the v5 case beside the v9 one. Four texts that described it otherwise are corrected, and **the T2 and T2b detectors cannot fire on a real network, so their zeros are not evidence for these bans.**

## Chain safety: replayed against stagenet history

Stagenet runs `DEPLOYMENT_APO` from height 0, unlike mainnet, so it is the one network where a block the APO rule now rejects could already exist. Full scan with the corrected instrument:

```
range     0..74,258 (74,259 blocks), 81,734 txs
T1_hits                        []
T2_coinbase_v10_hits           []
T2b_coinbase_v5_hits           []
T3_apo_on_single_key_path_hits []
T3 base sighash types          {"0x1": 75327}      all SIGHASH_ALL
T3 checked / not_single_key    75327 / 239
not_dilithium_shape            0
undecodable                    0
instrument_anomalies           []
positive_controls              8/8 true
verdict                        PASS      (109.8 s)
```

`t3_saw_sighash_all` asserts that at least one decoded byte was SIGHASH_ALL, which establishes that the byte being read is a hashtype. `full_range_scanned` asserts the scan covered genesis to tip.

## Why the gate commit exists, and why its first version was not enough

The scan is the only check that can establish whether a tightening rejects a block already in history. It could not report either tightening this branch adds: `hits_t3` was collected, printed and serialised, then left out of the fail condition, and the v5 ban had no detector at all.

**The first fix for that was itself defective.** It extracted `compute_verdict` and asserted in selftest that each of T1, T2, T2b and T3 blocks the deploy. Those assertions could not fail: the function was generic over its dict keys, so they held for any key set, and the mutation that mattered was at the call site in `main()`, which selftest never executed. Deleting `"T3": hits_t3` from that call left `SELFTEST OK (41 checks)` and exit 0. A pure-function test proves nothing about the wiring.

The wiring is therefore removed rather than tested. `SCAN_TESTS` is the single detector list; `main()` builds its hit lists from it, the JSON block reads every name in it, and `compute_verdict` raises unless it receives exactly those keys. Deleting a detector now fails three ways: selftest exits 1, and a live run exits 1 naming the detector.

T3 also over-matched. A two-item v6 witness is `[witnessScript, pubkey]`, so the last byte of a witnessScript was read as a hashtype. That produced no false hits over history, but once T3 gates the verdict it produces a FAIL on no evidence. `t3_classify` now applies the prevout version and the ML-DSA-44 signature and pubkey sizes.

A partial range could also report a bare PASS, since nothing required `range.from == 0` or `range.to == tip`. `full_range_scanned` is now a control, with `--partial` as the explicit opt-out that the deploy gate must not use.

**Operational note for the deploy runbook:** run the re-scan over the full range. It costs under two minutes, and an incremental run cannot resolve the witness version of a prevout created below its range.

**Caveat on the runbook's gate 4.** The consensus digest does not exercise either changed code path. `src/test/consensus_digest_tests.cpp` never calls `CheckTransaction`, so the v5 ban cannot move it, and its `VerifyScript` driver passes a 4-byte pubkey that fails the program-hash `memcmp` before control reaches the APO check, with `SCRIPT_VERIFY_APO` absent from its flag sets. The digest is unchanged at `e7ea83dc`, which is the expected result and is not evidence about either rule.

## Findings by provenance

`introduced-this-arc`:
- T3 hits collected but absent from the verdict condition. **Deploy blocker.**
- The v5 coinbase ban shipped without a detector. **Deploy blocker.**
- The first fix for the above tested the function and not the wiring, so it did not close the defect.
- T3 matching any two-item witness rather than the single-key path.
- The flag-day test read only the tier covering height 0, so a split confined to stagenet's mirror tier passed it. That tier is the one this deploy exists for.
- The v5 ban's reachability rationale, stated in four texts, was false.
- The rewritten v6 opcode-ban rationale, accurate for one of seven opcodes rather than the six it claimed.
- Seven line references that did not resolve, in text added by this branch. Replaced with symbol names; the numbers drifted within one editing session.

`pre-existing`:
- `WITNESS_VERSION_FORK_CLASS.md` summary table: the covenant opcodes "can activate with it or after it". False for three of four.
- `DEPLOYMENT_PRECONDITIONS.md` rule 3 "Never batch-activate" and the eLTOO trio as "three separate decisions". A maintainer following it schedules `P2WSH_DILITHIUM` at H1 and `APO` at H2, which is the hard fork §3a exists to prevent.
- `src/validation.cpp` comment claiming a coinbase-born v9 marker could serve as a bootstrap-fallback prevout.
- The sequencing invariant observed by no test.
- The v5 marker shape is open-coded eight times in `validation.cpp` while v9 has a named predicate. This diff adds no new copy; tracked with the USDSOQ bootstrap-pinning work.

`inherited`: none in this diff.

## Verification

- Build clean. The two remaining `validation.cpp` warnings (`nValueIn`, `IsSuperMajority`) are present at v2.3.0; the `patConsensus` warning is gone.
- Full suite (`--report_level=detailed`): **792 of 793 passed, 1 skipped, zero failures**, exit 0. The skip is `script_tests/script_PushData`, disabled at v2.3.0 too. Baseline before this branch was 791/792 with the same skip. The 677 `fatal internal error` lines are expected output from tests exercising error paths, and the count matches the pre-branch run. Assertion totals are not cited: they vary run to run at identical case counts.
- Mutation-proven, each failing with a message naming the defect: the v5 coinbase ban; the APO rejection with the deployment active (fails on both `0x41` and `0x42`); the flag-day invariant on mainnet; **the flag-day invariant on the stagenet mirror tier alone, with the base tier untouched, which the first version of the test did not catch**; and the scan verdict, where deleting a detector now fails selftest and a live run.
- Scanner selftest 21 to 49 checks. The live run calls it before scanning.
- Full stagenet scan PASS, above.

⚠️ A note for anyone repeating the mutation tests: after restoring a mutated source file, `make` did not always recompile it, and the stale binary reported a failure that looked real. `touch` the file before rebuilding.

## Review

#88 was reviewed clean-room by three independent reviewers, and this branch by a fourth working in an isolated worktree that ran the mutation tests itself. All findings above are theirs. The fixes and this body have not been reviewed, so a fresh pass is required before merge.

Related: bead `mpu9` (ruling and evidence), bead `nydh` (the scan instrument). Ops runbook PRs soqucoin-ops #109 and #110 merge before the tag, in that order; #110 §2 records the scope re-decision that puts this branch in the tag.
