### PR TITLE
test: reject-path coverage for 22 introduced consensus reject strings, with a mutation sweep (bead 244e)

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -188,6 +188,7 @@ BITCOIN_TESTS =\
   test/usdsoq_freeze_rules_tests.cpp \
   test/usdsoq_v7_conservation_harness_tests.cpp \
   test/usdsoq_v10_reject_path_tests.cpp \
+  test/usdsoq_supply_and_bootstrap_reject_path_tests.cpp \
   test/soquobscura_keyimage_deadcode_tests.cpp \
   test/witness_version_allocation_tests.cpp \
   test/consensus_digest_tests.cpp \

--- a/src/test/btcsoq_lifecycle_harness_tests.cpp
+++ b/src/test/btcsoq_lifecycle_harness_tests.cpp
@@ -383,8 +383,13 @@ struct BTCSOQChainSetup : public TestingSetup {
     //! tracked marker, vin[1] the SOQ fee, and vin[2] the minted v8 when
     //! `spendV8`. `burnSats` goes into the signed payload verbatim, so a caller
     //! can drive both the payload parse and the intent-mismatch rule.
+    //! `v8Override` burns a v8 coin other than the mint's own output, which is
+    //! how a caller reaches the supply-underflow guard: see the reachability
+    //! note above that case.
     CMutableTransaction BuildBurn(const CTransaction& fundCoinbase, const uint256& mintHash,
-                                  CAmount burnSats, bool spendV8)
+                                  CAmount burnSats, bool spendV8,
+                                  const COutPoint* v8Override = nullptr,
+                                  CAmount v8Value = MINT_SATS)
     {
         CMutableTransaction tx; tx.nVersion = 2;
         const CAmount fund = fundCoinbase.vout[0].nValue;
@@ -394,7 +399,9 @@ struct BTCSOQChainSetup : public TestingSetup {
         CTxIn fee; fee.prevout = COutPoint(fundCoinbase.GetHash(), 0);
         fee.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(fee);
         if (spendV8) {
-            CTxIn v8; v8.prevout = COutPoint(mintHash, 1); v8.nSequence = CTxIn::SEQUENCE_FINAL;
+            CTxIn v8;
+            v8.prevout = v8Override ? *v8Override : COutPoint(mintHash, 1);
+            v8.nSequence = CTxIn::SEQUENCE_FINAL;
             tx.vin.push_back(v8);
         }
 
@@ -405,7 +412,7 @@ struct BTCSOQChainSetup : public TestingSetup {
 
         SignV1(tx, 1, coinbaseSpk, fund, coinbaseKey, coinbasePk);
         if (spendV8)
-            SignV1(tx, 2, MakeV8Spk(coinbasePk), MINT_SATS, coinbaseKey, coinbasePk);
+            SignV1(tx, 2, MakeV8Spk(coinbasePk), v8Value, coinbaseKey, coinbasePk);
         SignAuthority(tx, 0, BTCSOQ_OP_BURN);
         return tx;
     }
@@ -1259,6 +1266,229 @@ BOOST_AUTO_TEST_CASE(the_unmutated_chained_btcsoq_mint_is_accepted)
         BuildMint(coinbaseTxns[1], OPBIND_DEPOSIT_B, 1, coinbasePk, &marker);
 
     BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "");
+}
+
+// ===========================================================================
+// SUPPLY AND BOOTSTRAP INVARIANT GUARDS (bead 244e, order item 3).
+//
+// REACHABILITY FIRST, as that bead requires, and the answer changes what these
+// tests should be. Three of the four rules below cannot be reached by any
+// sequence of valid blocks. They guard a damaged local state; they are not
+// consensus surface an attacker can drive.
+//
+//   bad-btcsoq-supply-overflow — CBTCSOQSupply::Mint fails only when
+//     total_minted + amount leaves MoneyRange (the MoneyRange guards in
+//     CBTCSOQSupply::Mint).
+//     ParseBTCSOQMintPayload caps every single mint at BTCSOQ_MAX_SATS = 2.1e15
+//     and MAX_MONEY is 2e18, so an overflow needs more than 950 maximum-value
+//     mints inside ONE block. Each authority mint carries two 2420-byte
+//     signatures, so that block cannot be built. Reached below by preloading the
+//     counter.
+//
+//   bad-btcsoq-supply-underflow — Burn fails only when total_burned + amount
+//     exceeds total_minted (the cannot-burn-more-than-minted guard in
+//     CBTCSOQSupply::Burn). On a real chain every v8
+//     UTXO was counted into total_minted when it was created, so the v8 inputs
+//     of any block sum to at most the outstanding supply. Reached below by
+//     injecting a v8 coin that no mint produced.
+//
+//   bad-btcsoq-bootstrap-reentry — needs LevelDB to hold an authority outpoint
+//     while the in-memory global is null. No block sequence produces that; a
+//     partial reindex or a corrupted datadir does, which is what the rule says.
+//     Reached below by nulling the global and leaving the database alone.
+//
+// The fourth, bad-btcsoq-authority-outpoint, IS attacker-reachable: it is the
+// rule that stops a second authority transaction from ignoring the chain of
+// custody, and its case needs no injected state.
+//
+// Recording the split is the point. "Untested" was the right flag on all four,
+// but only one of them has an attack. For the other three the correct shape is
+// to inject the damaged state and prove the guard still fires, and a later
+// reader should not mistake them for live consensus surface.
+// ===========================================================================
+
+// The one with an attack: a valid authority witness on a transaction that does
+// not continue the chain of custody.
+BOOST_AUTO_TEST_CASE(a_second_authority_tx_that_ignores_the_tracked_outpoint_is_rejected)
+{
+    SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+
+    // Bootstrap-SHAPED: no marker input at all, submitted while the tracked
+    // outpoint is set. The authority signature is genuine; the only thing wrong
+    // with the transaction is that it ignores the tracked UTXO.
+    CMutableTransaction m2 = BuildMint(coinbaseTxns[1], OPBIND_DEPOSIT_B, 1, coinbasePk);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-btcsoq-authority-outpoint");
+}
+
+BOOST_AUTO_TEST_CASE(btcsoq_supply_overflow_guard_fires_with_the_counter_at_the_ceiling)
+{
+    const uint256 m1 = SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+    COutPoint marker(m1, 0);
+
+    {
+        LOCK(cs_main);
+        const CAmount headroom = MAX_MONEY - g_btcsoq_supply.TotalMinted() - 1;
+        BOOST_REQUIRE(g_btcsoq_supply.Mint(headroom));
+        BOOST_REQUIRE_EQUAL(g_btcsoq_supply.TotalMinted(), MAX_MONEY - 1);
+    }
+
+    CMutableTransaction m2 =
+        BuildMint(coinbaseTxns[1], OPBIND_DEPOSIT_B, 1, coinbasePk, &marker);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-btcsoq-supply-overflow");
+}
+
+BOOST_AUTO_TEST_CASE(btcsoq_supply_underflow_guard_fires_on_a_v8_coin_no_mint_produced)
+{
+    const uint256 m1 = SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+
+    // Injected straight into the UTXO set, so nothing ever counted it into
+    // total_minted. Burning it takes total_burned past total_minted.
+    const CAmount phantom = MINT_SATS * 2;
+    COutPoint ghost = SeedCoin(MakeV8Spk(coinbasePk), phantom, 0xb8);
+
+    CMutableTransaction bn = BuildBurn(coinbaseTxns[1], m1, phantom, /*spendV8=*/true,
+                                       &ghost, phantom);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({bn}), "bad-btcsoq-supply-underflow");
+}
+
+BOOST_AUTO_TEST_CASE(btcsoq_bootstrap_reentry_is_rejected_while_the_database_holds_an_outpoint)
+{
+    SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+
+    {
+        LOCK(cs_main);
+        // Also the presence control for this case: it proves the accepted mint
+        // really did persist an outpoint, so the reject below cannot come from
+        // an empty database.
+        COutPoint persisted;
+        BOOST_REQUIRE(pcoinsdbview->ReadBTCSOQAuthorityOutpoint(persisted));
+        BOOST_REQUIRE(!persisted.IsNull());
+        g_btcsoq_authority_outpoint.SetNull();
+    }
+
+    CMutableTransaction m2 = BuildMint(coinbaseTxns[1], OPBIND_DEPOSIT_B, 1, coinbasePk);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-btcsoq-bootstrap-reentry");
+}
+
+// ---- The frozen registry (bead 244e, order item 4) ----------------------
+//
+// bad-txns-spend-frozen-btcsoq has two arms and the source comment on the
+// frozen-registry guard makes a strong claim about both: the guard "applies
+// to ALL txs (a freeze blocks even an authority burn of that outpoint)" and the
+// committed set is overlaid with the block's own freeze/unfreeze ops "so both
+// passes see the same state". Each arm gets a case, because a test of the
+// committed arm alone would leave the overlay unmeasured.
+
+BOOST_AUTO_TEST_CASE(spending_a_frozen_btcsoq_utxo_is_rejected)
+{
+    const uint256 m1 = SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+    COutPoint marker(m1, 0), v8(m1, 1);
+
+    CMutableTransaction fz = BuildFreeze(coinbaseTxns[1], FREEZE_OP_FREEZE, v8, &marker);
+    CBlock bf = CreateAndProcessBlock({fz}, coinbaseSpk);
+    BOOST_REQUIRE(chainActive.Tip()->GetBlockHash() == bf.GetHash());
+    {
+        LOCK(cs_main);
+        // Presence control: without this the reject below could come from an
+        // empty registry and a different rule.
+        BOOST_REQUIRE(pcoinsdbview->IsBTCSOQFrozen(v8));
+    }
+
+    // An ORDINARY transfer of the frozen coin — no authority, no marker, so the
+    // frozen registry is the only thing that can reject it.
+    const CAmount fund = coinbaseTxns[2].vout[0].nValue;
+    CMutableTransaction xfer; xfer.nVersion = 2;
+    CTxIn in; in.prevout = v8; in.nSequence = CTxIn::SEQUENCE_FINAL;
+    xfer.vin.push_back(in);
+    CTxIn fee; fee.prevout = COutPoint(coinbaseTxns[2].GetHash(), 0);
+    fee.nSequence = CTxIn::SEQUENCE_FINAL; xfer.vin.push_back(fee);
+    xfer.vout.push_back(CTxOut(MINT_SATS, MakeV8Spk(coinbasePk)));   // v8 in == v8 out
+    xfer.vout.push_back(CTxOut(fund - 10000, coinbaseSpk));
+    SignV1(xfer, 0, MakeV8Spk(coinbasePk), MINT_SATS, coinbaseKey, coinbasePk);
+    SignV1(xfer, 1, coinbaseSpk, fund, coinbaseKey, coinbasePk);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({xfer}), "bad-txns-spend-frozen-btcsoq");
+}
+
+// THE IN-BLOCK OVERLAY, AND IT DOES NOT WORK THE WAY THE COMMENT READS.
+// The frozen-registry guard's own comment says it "applies to ALL txs (a freeze
+// blocks even an authority burn of that outpoint)" and that the committed set is
+// overlaid with the block's own freeze/unfreeze ops. Measured, the two halves of
+// that overlay are ASYMMETRIC, and the freeze half cannot decide anything:
+//
+//   FREEZE + spend in ONE block  -> rejected as bad-btcsoq-freeze-dead-target,
+//     not as a frozen spend, and the transaction ORDER inside the block does not
+//     matter. ConnectBlock spends every input in a first pass (the reason the
+//     authority block has to read the marker prevout out of blockundo.vtxundo at
+//     all), and the FREEZE target liveness check reads `view` in the later pass,
+//     by which time the burn's spend has already been applied, so the target
+//     always looks dead.
+//     blockFrozenAdd therefore never gets to reject a same-block spend.
+//
+//   UNFREEZE + spend in ONE block -> ACCEPTED, and this is the half that is load
+//     bearing. The UNFREEZE branch has no liveness check at all -- it requires
+//     only that the outpoint IS frozen -- so blockFrozenRemove is consulted by the
+//     spend guard and lifts the freeze within the same block.
+//
+// Both are asserted below. The first locks in the ordering result so that a
+// later change to the pass structure fails a test instead of silently changing
+// which rule is load-bearing; the second is the positive control proving the
+// overlay is not inert, which a test of the committed arm alone cannot show.
+BOOST_AUTO_TEST_CASE(a_same_block_freeze_and_spend_dies_on_the_dead_target_instead)
+{
+    const uint256 m1 = SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+    COutPoint marker(m1, 0), v8(m1, 1);
+
+    CMutableTransaction fz = BuildFreeze(coinbaseTxns[1], FREEZE_OP_FREEZE, v8, &marker);
+    COutPoint marker2(CTransaction(fz).GetHash(), 0);
+
+    // The burn continues the chain of custody from the FREEZE's marker, so the
+    // frozen registry would be the only rule left — if it were reached.
+    CMutableTransaction bn = BuildBurn(coinbaseTxns[2], m1, MINT_SATS, /*spendV8=*/true);
+    bn.vin[0].prevout = marker2;
+    SignV1(bn, 1, coinbaseSpk, coinbaseTxns[2].vout[0].nValue, coinbaseKey, coinbasePk);
+    SignV1(bn, 2, MakeV8Spk(coinbasePk), MINT_SATS, coinbaseKey, coinbasePk);
+    SignAuthority(bn, 0, BTCSOQ_OP_BURN);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({fz, bn}), "bad-btcsoq-freeze-dead-target");
+}
+
+BOOST_AUTO_TEST_CASE(an_unfreeze_earlier_in_the_block_permits_the_spend)
+{
+    const uint256 m1 = SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+    COutPoint marker(m1, 0), v8(m1, 1);
+
+    // Commit the freeze in its own block.
+    CMutableTransaction fz = BuildFreeze(coinbaseTxns[1], FREEZE_OP_FREEZE, v8, &marker);
+    const uint256 fzHash = CTransaction(fz).GetHash();
+    CBlock bf = CreateAndProcessBlock({fz}, coinbaseSpk);
+    BOOST_REQUIRE(chainActive.Tip()->GetBlockHash() == bf.GetHash());
+    {
+        LOCK(cs_main);
+        BOOST_REQUIRE(pcoinsdbview->IsBTCSOQFrozen(v8));
+    }
+
+    // Now UNFREEZE and spend in the SAME block.
+    COutPoint marker3(fzHash, 0);
+    CMutableTransaction uf =
+        BuildFreeze(coinbaseTxns[2], FREEZE_OP_UNFREEZE, v8, &marker3);
+
+    const CAmount fund = coinbaseTxns[3].vout[0].nValue;
+    CMutableTransaction xfer; xfer.nVersion = 2;
+    CTxIn in; in.prevout = v8; in.nSequence = CTxIn::SEQUENCE_FINAL;
+    xfer.vin.push_back(in);
+    CTxIn fee; fee.prevout = COutPoint(coinbaseTxns[3].GetHash(), 0);
+    fee.nSequence = CTxIn::SEQUENCE_FINAL; xfer.vin.push_back(fee);
+    xfer.vout.push_back(CTxOut(MINT_SATS, MakeV8Spk(coinbasePk)));
+    xfer.vout.push_back(CTxOut(fund - 10000, coinbaseSpk));
+    SignV1(xfer, 0, MakeV8Spk(coinbasePk), MINT_SATS, coinbaseKey, coinbasePk);
+    SignV1(xfer, 1, coinbaseSpk, fund, coinbaseKey, coinbasePk);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({uf, xfer}), "");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/btcsoq_lifecycle_harness_tests.cpp
+++ b/src/test/btcsoq_lifecycle_harness_tests.cpp
@@ -953,6 +953,17 @@ BOOST_AUTO_TEST_CASE(chained_btcsoq_mint_with_a_scriptsig_in_place_of_the_author
 // below-threshold case, which keeps one real signature and reaches M-of-N
 // verification -- both assert the same string, and only the error() text tells
 // them apart.
+//
+// ⚠️ THIS CASE CANNOT DETECT THE REMOVAL OF THE RULE IT COVERS, and that is a
+// fact about the rule rather than about the case. Neutered in a mutation sweep,
+// the empty-signature guard produced no test failure: execution falls through to
+// CBTCSOQAuthority::VerifyAuthoritySignatures, which opens with its own
+// sigs.empty() rejection and would in any case fail valid_count >= threshold, so
+// the same input is rejected with the same string one site later. The guard is
+// therefore redundant for every input that reaches it. Keeping the case is still
+// worth it two ways: it pins that the input SHAPE is rejected, and the survival
+// of the mutant is the evidence that the verifier is not vacuous on an empty set,
+// which is the failure the guard exists to backstop.
 BOOST_AUTO_TEST_CASE(chained_btcsoq_mint_with_no_extractable_signatures_is_rejected)
 {
     CMutableTransaction m1 = BuildMint(coinbaseTxns[0], AUTHSIG_DEPOSIT_A, 0, coinbasePk);
@@ -1427,7 +1438,11 @@ BOOST_AUTO_TEST_CASE(spending_a_frozen_btcsoq_utxo_is_rejected)
 //     all), and the FREEZE target liveness check reads `view` in the later pass,
 //     by which time the burn's spend has already been applied, so the target
 //     always looks dead.
-//     blockFrozenAdd therefore never gets to reject a same-block spend.
+//     blockFrozenAdd therefore never gets to reject a same-block spend. It is
+//     shadowed rather than broken: neutering the liveness check in a mutation
+//     sweep makes this same case reject with bad-txns-spend-frozen-btcsoq, so
+//     the overlay's freeze half does work and is simply unreachable behind a
+//     rule that always fires first.
 //
 //   UNFREEZE + spend in ONE block -> ACCEPTED, and this is the half that is load
 //     bearing. The UNFREEZE branch has no liveness check at all -- it requires

--- a/src/test/btcsoq_lifecycle_harness_tests.cpp
+++ b/src/test/btcsoq_lifecycle_harness_tests.cpp
@@ -1016,8 +1016,7 @@ BOOST_AUTO_TEST_CASE(an_authority_tx_carrying_both_asset_markers_is_rejected)
     CScript v5spk = CScript() << OP_5 << std::vector<unsigned char>(kh.begin(), kh.end());
     m2.vout.back().nValue -= 10000;
     m2.vout.push_back(CTxOut(10000, v5spk));
-    SignV1(m2, 1, coinbaseSpk, coinbaseTxns[1].vout[0].nValue, coinbaseKey, coinbasePk);
-    SignAuthority(m2, 0, BTCSOQ_OP_MINT);
+    ReSignChainedAuthority(m2, coinbaseTxns[1], BTCSOQ_OP_MINT);
 
     BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-txns-dual-authority-marker");
 }
@@ -1079,8 +1078,7 @@ BOOST_AUTO_TEST_CASE(btcsoq_v8_output_under_a_non_mint_op_is_rejected)
     BOOST_REQUIRE_EQUAL(fz.vout.size(), 3u);
     fz.vout.back().nValue -= MINT_SATS;
     fz.vout.push_back(CTxOut(MINT_SATS, MakeV8Spk(coinbasePk)));
-    SignV1(fz, 1, coinbaseSpk, coinbaseTxns[1].vout[0].nValue, coinbaseKey, coinbasePk);
-    SignAuthority(fz, 0, BTCSOQ_OP_FREEZE);
+    ReSignChainedAuthority(fz, coinbaseTxns[1], BTCSOQ_OP_FREEZE);
 
     BOOST_CHECK_EQUAL(RejectReasonFor({fz}), "bad-btcsoq-unbound-mint");
 }

--- a/src/test/btcsoq_lifecycle_harness_tests.cpp
+++ b/src/test/btcsoq_lifecycle_harness_tests.cpp
@@ -109,6 +109,13 @@ static CScript MakeOpEnvelope(uint8_t tag, const std::vector<uint8_t>& payload)
     return s;
 }
 
+static const uint256 OPBIND_DEPOSIT_A = uint256S(
+    "bccc00000000000000000000000000000000000000000000000000000000b001");
+static const uint256 OPBIND_DEPOSIT_B = uint256S(
+    "bccc00000000000000000000000000000000000000000000000000000000b002");
+static const uint256 OPBIND_RELEASE = uint256S(
+    "b0de00000000000000000000000000000000000000000000000000000000b0de");
+
 } // namespace
 
 // ---------------------------------------------------------------------------
@@ -345,6 +352,61 @@ struct BTCSOQChainSetup : public TestingSetup {
         if (prevMarker)
             SignV1(tx, 1, coinbaseSpk, fund, coinbaseKey, coinbasePk);
         SignAuthority(tx, 0, BTCSOQ_OP_FREEZE);
+        return tx;
+    }
+
+    //! Establish the authority chain with one accepted BOOTSTRAP mint of
+    //! `deposit` at vout 0, and return the mint txid: the marker is at (txid, 0)
+    //! and the minted v8 at (txid, 1). Every case below then starts from a
+    //! CHAINED transaction, which is the shape an attacker has access to,
+    //! because the tracked marker outpoint is public on-chain.
+    uint256 SeedAuthorityChain(const CTransaction& fund, const uint256& deposit)
+    {
+        CMutableTransaction m = BuildMint(fund, deposit, 0, coinbasePk);
+        const uint256 h = CTransaction(m).GetHash();
+        CBlock b = CreateAndProcessBlock({m}, coinbaseSpk);
+        BOOST_REQUIRE(chainActive.Tip()->GetBlockHash() == b.GetHash());
+        return h;
+    }
+
+    //! Re-sign a chained authority tx after editing its outputs. Editing ANY
+    //! output invalidates the SIGHASH_ALL authority signature, so without this
+    //! an authority-sig rejection shadows the rule the edit was aiming at.
+    void ReSignChainedAuthority(CMutableTransaction& tx, const CTransaction& fund,
+                                uint8_t tag)
+    {
+        SignV1(tx, 1, coinbaseSpk, fund.vout[0].nValue, coinbaseKey, coinbasePk);
+        SignAuthority(tx, 0, tag);
+    }
+
+    //! A BURN authority tx chained off the mint at `mintHash`: vin[0] is the
+    //! tracked marker, vin[1] the SOQ fee, and vin[2] the minted v8 when
+    //! `spendV8`. `burnSats` goes into the signed payload verbatim, so a caller
+    //! can drive both the payload parse and the intent-mismatch rule.
+    CMutableTransaction BuildBurn(const CTransaction& fundCoinbase, const uint256& mintHash,
+                                  CAmount burnSats, bool spendV8)
+    {
+        CMutableTransaction tx; tx.nVersion = 2;
+        const CAmount fund = fundCoinbase.vout[0].nValue;
+
+        CTxIn mk; mk.prevout = COutPoint(mintHash, 0); mk.nSequence = CTxIn::SEQUENCE_FINAL;
+        tx.vin.push_back(mk);
+        CTxIn fee; fee.prevout = COutPoint(fundCoinbase.GetHash(), 0);
+        fee.nSequence = CTxIn::SEQUENCE_FINAL; tx.vin.push_back(fee);
+        if (spendV8) {
+            CTxIn v8; v8.prevout = COutPoint(mintHash, 1); v8.nSequence = CTxIn::SEQUENCE_FINAL;
+            tx.vin.push_back(v8);
+        }
+
+        std::vector<uint8_t> payload = BuildBTCSOQBurnPayload(OPBIND_RELEASE, burnSats);
+        tx.vout.push_back(CTxOut(0, markerSpk));
+        tx.vout.push_back(CTxOut(0, MakeOpEnvelope(BTCSOQ_OP_BURN, payload)));
+        tx.vout.push_back(CTxOut(fund - 10000, coinbaseSpk));
+
+        SignV1(tx, 1, coinbaseSpk, fund, coinbaseKey, coinbasePk);
+        if (spendV8)
+            SignV1(tx, 2, MakeV8Spk(coinbasePk), MINT_SATS, coinbaseKey, coinbasePk);
+        SignAuthority(tx, 0, BTCSOQ_OP_BURN);
         return tx;
     }
 };
@@ -1003,6 +1065,200 @@ BOOST_AUTO_TEST_CASE(btcsoq_v8_output_under_a_non_mint_op_is_rejected)
     SignAuthority(fz, 0, BTCSOQ_OP_FREEZE);
 
     BOOST_CHECK_EQUAL(RejectReasonFor({fz}), "bad-btcsoq-unbound-mint");
+}
+
+// ===========================================================================
+// MINT/BURN OP-BINDING REJECT PATHS (bead reject-string-coverage-gap-244e,
+// order item 2). These are the rules that bind a mint to a Bitcoin deposit and
+// a burn to a release intent — the ten reject strings below appeared nowhere
+// under src/test or qa/rpc-tests before this block.
+//
+// ⚠️ REACHABILITY RESULT, measured while writing these, and worth more than the
+// coverage count. bad-btcsoq-mint-payload and bad-btcsoq-burn-payload have a far
+// NARROWER reachable window than they read. ParseBTCSOQAuthorityOp already
+// requires the OP_RETURN push to be exactly 1 + BTCSOQOpPayloadLen(tag) bytes,
+// so every LENGTH malformation is reported as bad-btcsoq-missing-op and never
+// reaches the op-specific parse. The only inputs that reach these two rejects
+// are a correctly-sized payload whose sats field is non-positive or above
+// BTCSOQ_MAX_SATS -- the trailing pair of guards in ParseBTCSOQMintPayload and
+// ParseBTCSOQBurnPayload, which are the same two lines in each. Both cases
+// below drive that field, because a test that truncated the payload would
+// assert the wrong rule and still be green.
+// ===========================================================================
+
+
+// ---- MINT binding ---------------------------------------------------------
+
+// The envelope length check passes and the amount field does not: sats == 0.
+BOOST_AUTO_TEST_CASE(btcsoq_mint_payload_with_a_non_positive_amount_is_rejected)
+{
+    const uint256 m1 = SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+    COutPoint marker(m1, 0);
+
+    CMutableTransaction m2 =
+        BuildMint(coinbaseTxns[1], OPBIND_DEPOSIT_B, 1, coinbasePk, &marker);
+
+    std::vector<uint8_t> zeroSats = BuildBTCSOQMintPayload(
+        OPBIND_DEPOSIT_B, 1, 0, ComputeBTCSOQRecipientCommitment(MakeV8Spk(coinbasePk)));
+    BOOST_REQUIRE_EQUAL(zeroSats.size(), BTCSOQ_MINT_PAYLOAD_LEN);
+    m2.vout[2] = CTxOut(0, MakeOpEnvelope(BTCSOQ_OP_MINT, zeroSats));
+    ReSignChainedAuthority(m2, coinbaseTxns[1], BTCSOQ_OP_MINT);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-btcsoq-mint-payload");
+}
+
+// One deposit backs exactly one v8 output. A second v8 output would let one
+// attested deposit mint twice its sats in a single transaction.
+BOOST_AUTO_TEST_CASE(btcsoq_mint_with_two_v8_outputs_is_rejected)
+{
+    const uint256 m1 = SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+    COutPoint marker(m1, 0);
+
+    CMutableTransaction m2 =
+        BuildMint(coinbaseTxns[1], OPBIND_DEPOSIT_B, 1, coinbasePk, &marker);
+    m2.vout.back().nValue -= MINT_SATS;   // fund the extra output out of the SOQ change
+    m2.vout.push_back(CTxOut(MINT_SATS, MakeV8Spk(coinbasePk)));
+    ReSignChainedAuthority(m2, coinbaseTxns[1], BTCSOQ_OP_MINT);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-btcsoq-mint-outputs");
+}
+
+// The minted amount must equal the attested deposit, to the base unit.
+BOOST_AUTO_TEST_CASE(btcsoq_mint_output_value_must_equal_the_attested_deposit)
+{
+    const uint256 m1 = SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+    COutPoint marker(m1, 0);
+
+    CMutableTransaction m2 =
+        BuildMint(coinbaseTxns[1], OPBIND_DEPOSIT_B, 1, coinbasePk, &marker);
+    m2.vout[1].nValue = MINT_SATS + 1;   // the payload still commits MINT_SATS
+    ReSignChainedAuthority(m2, coinbaseTxns[1], BTCSOQ_OP_MINT);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-btcsoq-mint-amount");
+}
+
+// The recipient commitment is what stops an authority signature from being
+// replayed to a different recipient, so redirecting the v8 output must fail.
+BOOST_AUTO_TEST_CASE(btcsoq_mint_recipient_must_match_the_signed_commitment)
+{
+    const uint256 m1 = SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+    COutPoint marker(m1, 0);
+
+    CMutableTransaction m2 =
+        BuildMint(coinbaseTxns[1], OPBIND_DEPOSIT_B, 1, coinbasePk, &marker);
+
+    CKey thief; thief.MakeNewKey(true);
+    std::vector<unsigned char> thiefPk(thief.GetPubKey().begin(), thief.GetPubKey().end());
+    m2.vout[1].scriptPubKey = MakeV8Spk(thiefPk);   // value unchanged, so only the commitment can reject
+    ReSignChainedAuthority(m2, coinbaseTxns[1], BTCSOQ_OP_MINT);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-btcsoq-mint-recipient");
+}
+
+// Anti-replay, PERSISTED arm: the deposit is already in the minted set on disk.
+// The existing double_mint_rejected case asserts only that the tip did not move,
+// which passes for the wrong reject as happily as for the right one.
+BOOST_AUTO_TEST_CASE(btcsoq_double_mint_is_rejected_by_name)
+{
+    const uint256 m1 = SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+    COutPoint marker(m1, 0);
+
+    CMutableTransaction m2 =
+        BuildMint(coinbaseTxns[1], OPBIND_DEPOSIT_A, 0, coinbasePk, &marker);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-btcsoq-double-mint");
+}
+
+// Anti-replay, IN-BLOCK arm: neither mint is on disk yet, so only the
+// per-block blockMintedDeposits set can catch the second one. A test that
+// exercised the persisted arm alone would leave this one unmeasured.
+BOOST_AUTO_TEST_CASE(two_mints_of_one_deposit_in_the_same_block_are_rejected)
+{
+    CMutableTransaction m1 = BuildMint(coinbaseTxns[0], OPBIND_DEPOSIT_A, 0, coinbasePk);
+    COutPoint marker(CTransaction(m1).GetHash(), 0);
+    CMutableTransaction m2 =
+        BuildMint(coinbaseTxns[1], OPBIND_DEPOSIT_A, 0, coinbasePk, &marker);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m1, m2}), "bad-btcsoq-double-mint");
+}
+
+// ---- BURN binding ---------------------------------------------------------
+
+// Same narrow window as the mint payload: correctly sized, sats == 0.
+BOOST_AUTO_TEST_CASE(btcsoq_burn_payload_with_a_non_positive_amount_is_rejected)
+{
+    const uint256 m1 = SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+    CMutableTransaction bn = BuildBurn(coinbaseTxns[1], m1, /*burnSats=*/0,
+                                       /*spendV8=*/true);
+    BOOST_CHECK_EQUAL(RejectReasonFor({bn}), "bad-btcsoq-burn-payload");
+}
+
+// A BURN that destroys nothing. Without this rule the authority could record a
+// release intent on Bitcoin against no burned supply at all.
+BOOST_AUTO_TEST_CASE(btcsoq_burn_with_no_v8_inputs_is_rejected)
+{
+    const uint256 m1 = SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+    CMutableTransaction bn = BuildBurn(coinbaseTxns[1], m1, MINT_SATS,
+                                       /*spendV8=*/false);
+    BOOST_CHECK_EQUAL(RejectReasonFor({bn}), "bad-btcsoq-burn-empty");
+}
+
+// The signed release intent must equal the consensus burn, so the gateway can
+// never be told to release more than was destroyed.
+BOOST_AUTO_TEST_CASE(btcsoq_burn_intent_must_equal_the_v8_input_sum)
+{
+    const uint256 m1 = SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+    CMutableTransaction bn = BuildBurn(coinbaseTxns[1], m1, MINT_SATS - 1,
+                                       /*spendV8=*/true);
+    BOOST_CHECK_EQUAL(RejectReasonFor({bn}), "bad-btcsoq-burn-amount");
+}
+
+// Asset flows must match the signed op in the other direction too: v8 inputs
+// may only be spent under BURN. Here a FREEZE-tagged authority tx spends one.
+BOOST_AUTO_TEST_CASE(btcsoq_v8_inputs_under_a_non_burn_op_are_rejected)
+{
+    const uint256 m1 = SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+    COutPoint marker(m1, 0), v8(m1, 1);
+
+    CMutableTransaction fz = BuildFreeze(coinbaseTxns[1], FREEZE_OP_FREEZE, v8, &marker);
+    CTxIn in; in.prevout = v8; in.nSequence = CTxIn::SEQUENCE_FINAL;
+    fz.vin.push_back(in);   // vin[2] = the minted v8, spent under FREEZE
+    SignV1(fz, 2, MakeV8Spk(coinbasePk), MINT_SATS, coinbaseKey, coinbasePk);
+    ReSignChainedAuthority(fz, coinbaseTxns[1], BTCSOQ_OP_FREEZE);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({fz}), "bad-btcsoq-unbound-burn");
+}
+
+// ---- FREEZE binding -------------------------------------------------------
+
+// The freeze op byte inside the envelope is not the envelope tag, and only
+// FREEZE/UNFREEZE are defined. An unknown byte must not fall through to a
+// default action on a live outpoint.
+BOOST_AUTO_TEST_CASE(btcsoq_freeze_with_an_unknown_op_byte_is_rejected)
+{
+    const uint256 m1 = SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+    COutPoint marker(m1, 0), v8(m1, 1);
+
+    CMutableTransaction fz = BuildFreeze(coinbaseTxns[1], 0x7f, v8, &marker);
+    BOOST_CHECK_EQUAL(RejectReasonFor({fz}), "bad-btcsoq-freeze-payload");
+}
+
+// ---- The presence control for every case above --------------------------
+
+// PRESENCE CONTROL. Each of the eleven cases above mutates one field of a
+// chained authority tx and asserts one exact reject string. If the unmutated
+// chained shape were itself invalid, those cases could pass for the wrong
+// reason. This one asserts the empty reject reason, so it fails if the baseline
+// ever stops connecting — and eleven silent false passes become one loud one.
+BOOST_AUTO_TEST_CASE(the_unmutated_chained_btcsoq_mint_is_accepted)
+{
+    const uint256 m1 = SeedAuthorityChain(coinbaseTxns[0], OPBIND_DEPOSIT_A);
+    COutPoint marker(m1, 0);
+
+    CMutableTransaction m2 =
+        BuildMint(coinbaseTxns[1], OPBIND_DEPOSIT_B, 1, coinbasePk, &marker);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/btcsoq_lifecycle_harness_tests.cpp
+++ b/src/test/btcsoq_lifecycle_harness_tests.cpp
@@ -695,4 +695,314 @@ BOOST_AUTO_TEST_CASE(btcsoq_freeze_unfreeze_freeze_round_trip_is_accepted)
         "accepted — the rule is about redundancy, not about freezing once");
 }
 
+// ===========================================================================
+// AUTHORITY-SIGNATURE REJECT PATHS (bead reject-string-coverage-gap-244e).
+//
+// bad-btcsoq-authority-sig appeared nowhere in the tree until now, along with
+// bad-btcsoq-tag-mismatch, bad-btcsoq-missing-op, bad-btcsoq-unbound-mint and
+// bad-btcsoq-unbound-burn. Every existing case in this file signs with the real
+// authority; none measured what happens when the signature is wrong.
+//
+// ONE STRING, SEVEN EMIT SITES, so a test that asserts the string pins nothing
+// about WHICH rule ran. In ConnectBlock the sites are, in the order a
+// transaction meets them: the marker prevout being unavailable in both the view
+// and the block undo; a null witness on the authority input; an empty signature
+// set after extraction; and M-of-N verification failing. Three more sit in the
+// mempool mirror in AcceptToMemoryPoolWorker. Sites are named by their error()
+// text rather than by line number, because a line number in a test comment
+// drifts silently on the next edit to validation.cpp; the exact lines against
+// this branch's base commit are in the PR body. The four cases below cover all
+// four ConnectBlock sites except the prevout-unavailable one, and each was
+// attributed by reading the emitted error() text, not by trusting the string.
+//
+// The chained shape is used throughout because it is the one an attacker has
+// access to: the tracked marker outpoint is public on-chain.
+// ===========================================================================
+
+//! An authority-SHAPED witness stack whose signature slots hold filler.
+//! Its consumer is the CheckInputs authority skip, NOT
+//! CTransaction::HasDilithiumSignatures: the skip tests shape alone -- a v9
+//! marker output, six or more items, a one-byte op tag at index 2 inside
+//! [BTCSOQ_OP_MINT, BTCSOQ_OP_FREEZE], and at least one item of exactly 2420
+//! bytes. HasDilithiumSignatures' whole-transaction exemption keys on 0x55 at
+//! index 2 and an OP_5 output, so it never applies to a v9 transaction and this
+//! stack does not try to satisfy it.
+//!
+//! Carried on the FEE input by any case that empties the authority input's
+//! witness. Without it that case relies on script checks being queued rather
+//! than run inline, which makes the test pass for a reason unrelated to the
+//! rule under test.
+static std::vector<std::vector<unsigned char>> DecoyStack(uint8_t tag)
+{
+    std::vector<std::vector<unsigned char>> s;
+    s.push_back(std::vector<unsigned char>{0x00});
+    s.push_back(std::vector<unsigned char>{0x00});
+    s.push_back(std::vector<unsigned char>{tag});
+    s.push_back(std::vector<unsigned char>{0x00});
+    s.push_back(std::vector<unsigned char>(2420, 0xcc));
+    s.push_back(std::vector<unsigned char>(2420, 0xdd));
+    s.push_back(std::vector<unsigned char>{0x00});
+    return s;
+}
+
+static const uint256 AUTHSIG_DEPOSIT_A = uint256S(
+    "bccc00000000000000000000000000000000000000000000000000000000a001");
+static const uint256 AUTHSIG_DEPOSIT_B = uint256S(
+    "bccc00000000000000000000000000000000000000000000000000000000a002");
+
+BOOST_AUTO_TEST_CASE(chained_btcsoq_mint_signed_by_outsiders_is_rejected)
+{
+    CMutableTransaction m1 = BuildMint(coinbaseTxns[0], AUTHSIG_DEPOSIT_A, 0, coinbasePk);
+    const uint256 m1Hash = CTransaction(m1).GetHash();
+    CBlock b1 = CreateAndProcessBlock({m1}, coinbaseSpk);
+    BOOST_REQUIRE(chainActive.Tip()->GetBlockHash() == b1.GetHash());
+    COutPoint marker(m1Hash, 0);
+
+    CMutableTransaction m2 =
+        BuildMint(coinbaseTxns[1], AUTHSIG_DEPOSIT_B, 1, coinbasePk, &marker);
+
+    // Re-sign the authority input with two keypairs outside the set. The layout
+    // and the sighash are correct, so only set membership can reject it.
+    AuthKey out0, out1;
+    {
+        CTransaction ctx(m2);
+        uint256 h = SignatureHash(markerSpk, ctx, 0, SIGHASH_ALL, CAmount(0),
+                                  SIGVERSION_WITNESS_V0, nullptr);
+        BuildAuthorityWitnessStack(m2.vin[0].scriptWitness.stack, BTCSOQ_OP_MINT,
+                                   AuthSign(h, out0.sk), AuthSign(h, out1.sk));
+    }
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-btcsoq-authority-sig");
+}
+
+BOOST_AUTO_TEST_CASE(chained_btcsoq_mint_below_threshold_is_rejected)
+{
+    CMutableTransaction m1 = BuildMint(coinbaseTxns[0], AUTHSIG_DEPOSIT_A, 0, coinbasePk);
+    const uint256 m1Hash = CTransaction(m1).GetHash();
+    CBlock b1 = CreateAndProcessBlock({m1}, coinbaseSpk);
+    BOOST_REQUIRE(chainActive.Tip()->GetBlockHash() == b1.GetHash());
+    COutPoint marker(m1Hash, 0);
+
+    CMutableTransaction m2 =
+        BuildMint(coinbaseTxns[1], AUTHSIG_DEPOSIT_B, 1, coinbasePk, &marker);
+
+    // Replace the second signature with a one-byte item. The extractor selects
+    // by exact DILITHIUM_SIG_SIZE, so the verifier sees one signature against a
+    // threshold of two.
+    m2.vin[0].scriptWitness.stack[5] = std::vector<unsigned char>{0x00};
+    BOOST_REQUIRE_EQUAL(
+        ExtractBTCSOQWitnessSignatures(m2.vin[0].scriptWitness.stack).size(), 1u);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-btcsoq-authority-sig");
+}
+
+// THE NULL-WITNESS ARM, AND THE ONE BYTE THAT DECIDES WHETHER IT RUNS.
+// ConnectBlock rejects a BTCSOQ authority transaction whose authority input
+// carries no witness ("has no witness on authority input"). Whether that arm
+// ever executes depends entirely on what CheckTransaction does with the same
+// transaction first, and the answer measured on this tree is: it depends on the
+// scriptSig, which is one attacker-chosen push.
+//
+// CTransaction::HasDilithiumSignatures runs before ConnectBlock (from
+// CheckTransaction) and requires every input to present a blob whose first byte
+// is 0x00. For an input with a witness it reads the witness stack's last item.
+// For an input with NO witness it falls back to the scriptSig's LAST PUSH and
+// applies the same one-byte test to that. Nothing requires the scriptSig to be
+// empty, and per-input script verification -- which would demand an empty
+// scriptSig for a native witness program -- is skipped for BTCSOQ authority
+// transactions.
+//
+// So the two cases below are the same attack shape one push apart:
+//
+//   empty scriptSig       -> no blob at all -> bad-txns-requires-dilithium,
+//                            and the authority block never runs
+//   scriptSig <0x00...>   -> the fallback is satisfied -> the authority block
+//                            runs and the null-witness arm rejects
+//
+// Both are kept, and both assert the string they actually produce. The first
+// one alone would read as proof that the arm is unreachable, which is what a
+// reading of it claimed before the second case was written.
+BOOST_AUTO_TEST_CASE(chained_btcsoq_mint_with_no_witness_on_the_authority_input_dies_earlier)
+{
+    CMutableTransaction m1 = BuildMint(coinbaseTxns[0], AUTHSIG_DEPOSIT_A, 0, coinbasePk);
+    const uint256 m1Hash = CTransaction(m1).GetHash();
+    CBlock b1 = CreateAndProcessBlock({m1}, coinbaseSpk);
+    BOOST_REQUIRE(chainActive.Tip()->GetBlockHash() == b1.GetHash());
+    COutPoint marker(m1Hash, 0);
+
+    CMutableTransaction m2 =
+        BuildMint(coinbaseTxns[1], AUTHSIG_DEPOSIT_B, 1, coinbasePk, &marker);
+    m2.vin[0].scriptWitness.stack.clear();
+
+    // No decoy on the fee input here: this transaction is rejected before
+    // CheckInputs is reached, so a stack that only the CheckInputs skip reads
+    // would be inert, and carrying it would suggest it was load-bearing.
+    BOOST_REQUIRE_MESSAGE(m2.vin[0].scriptWitness.IsNull(),
+        "the authority input must carry no witness");
+    BOOST_REQUIRE_MESSAGE(m2.vin[0].scriptSig.empty(),
+        "and no scriptSig, which is what makes the fallback find nothing");
+    BOOST_CHECK_MESSAGE(!CTransaction(m2).HasDilithiumSignatures(),
+        "with neither a witness nor a scriptSig push there is no blob to test");
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-txns-requires-dilithium");
+}
+
+// The same transaction plus one scriptSig push, which is all it takes to clear
+// CheckTransaction and put the null-witness arm on the path. Measured emit
+// site: "has no witness on authority input".
+BOOST_AUTO_TEST_CASE(chained_btcsoq_mint_with_a_scriptsig_in_place_of_the_authority_witness_is_rejected)
+{
+    CMutableTransaction m1 = BuildMint(coinbaseTxns[0], AUTHSIG_DEPOSIT_A, 0, coinbasePk);
+    const uint256 m1Hash = CTransaction(m1).GetHash();
+    CBlock b1 = CreateAndProcessBlock({m1}, coinbaseSpk);
+    BOOST_REQUIRE(chainActive.Tip()->GetBlockHash() == b1.GetHash());
+    COutPoint marker(m1Hash, 0);
+
+    CMutableTransaction m2 =
+        BuildMint(coinbaseTxns[1], AUTHSIG_DEPOSIT_B, 1, coinbasePk, &marker);
+    m2.vin[0].scriptWitness.stack.clear();
+    // Not a public key and not 1313 bytes. The per-input fallback tests the
+    // first byte and the first byte only.
+    m2.vin[0].scriptSig = CScript() << std::vector<unsigned char>{0x00, 0xab, 0xcd};
+    // Load-bearing: without the skip, the empty witness plus a non-empty
+    // scriptSig on a native witness program also fails script verification, and
+    // the case would no longer isolate the authority rule.
+    m2.vin[1].scriptWitness.stack = DecoyStack(BTCSOQ_OP_MINT);
+
+    BOOST_CHECK_MESSAGE(CTransaction(m2).HasDilithiumSignatures(),
+        "the scriptSig fallback must be satisfied, or this case degenerates "
+        "into the bad-txns-requires-dilithium case above");
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-btcsoq-authority-sig");
+}
+
+// The third emit site: a witness that survives extraction with zero signatures.
+// ExtractBTCSOQWitnessSignatures selects items of exactly DILITHIUM_SIG_SIZE
+// from indices [4, size-1), so a six-item stack carrying the correct op tag and
+// no 2420-byte item passes the tag check and arrives at the verifier empty.
+// Measured emit site: "has no signatures in witness". Distinct from the
+// below-threshold case, which keeps one real signature and reaches M-of-N
+// verification -- both assert the same string, and only the error() text tells
+// them apart.
+BOOST_AUTO_TEST_CASE(chained_btcsoq_mint_with_no_extractable_signatures_is_rejected)
+{
+    CMutableTransaction m1 = BuildMint(coinbaseTxns[0], AUTHSIG_DEPOSIT_A, 0, coinbasePk);
+    const uint256 m1Hash = CTransaction(m1).GetHash();
+    CBlock b1 = CreateAndProcessBlock({m1}, coinbaseSpk);
+    BOOST_REQUIRE(chainActive.Tip()->GetBlockHash() == b1.GetHash());
+    COutPoint marker(m1Hash, 0);
+
+    CMutableTransaction m2 =
+        BuildMint(coinbaseTxns[1], AUTHSIG_DEPOSIT_B, 1, coinbasePk, &marker);
+
+    std::vector<std::vector<unsigned char>> stack;
+    stack.push_back(std::vector<unsigned char>{0x00});             // [0] payout_sig
+    stack.push_back(std::vector<unsigned char>{0x00});             // [1] payout_pk
+    stack.push_back(std::vector<unsigned char>{BTCSOQ_OP_MINT});   // [2] op tag
+    stack.push_back(std::vector<unsigned char>{0x00});             // [3] payload
+    stack.push_back(std::vector<unsigned char>{0x00});             // [4] not a sig
+    stack.push_back(std::vector<unsigned char>{0x00});             // [5] authority_set
+    m2.vin[0].scriptWitness.stack = stack;
+    m2.vin[1].scriptWitness.stack = DecoyStack(BTCSOQ_OP_MINT);
+
+    // The tag check must pass, or this case asserts bad-btcsoq-tag-mismatch and
+    // never reaches the extractor.
+    BOOST_REQUIRE_EQUAL(GetBTCSOQWitnessTag(m2.vin[0].scriptWitness.stack),
+                        BTCSOQ_OP_MINT);
+    BOOST_REQUIRE_EQUAL(
+        ExtractBTCSOQWitnessSignatures(m2.vin[0].scriptWitness.stack).size(), 0u);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-btcsoq-authority-sig");
+}
+
+// bad-txns-dual-authority-marker. Each marker grants its own asset's ex-nihilo
+// exemption, so a transaction carrying both would need stacked exemptions
+// reasoned about; it is invalid instead. Untested until now, and it is what
+// stops the v9 path from reaching the OP_5 exemption above.
+BOOST_AUTO_TEST_CASE(an_authority_tx_carrying_both_asset_markers_is_rejected)
+{
+    CMutableTransaction m1 = BuildMint(coinbaseTxns[0], AUTHSIG_DEPOSIT_A, 0, coinbasePk);
+    const uint256 m1Hash = CTransaction(m1).GetHash();
+    CBlock b1 = CreateAndProcessBlock({m1}, coinbaseSpk);
+    BOOST_REQUIRE(chainActive.Tip()->GetBlockHash() == b1.GetHash());
+    COutPoint marker(m1Hash, 0);
+
+    CMutableTransaction m2 =
+        BuildMint(coinbaseTxns[1], AUTHSIG_DEPOSIT_B, 1, coinbasePk, &marker);
+
+    // Splice a USDSOQ v5 marker in beside the BTCSOQ v9 one, funded from change.
+    uint256 kh;
+    CSHA256().Write(coinbasePk.data(), coinbasePk.size()).Finalize(kh.begin());
+    CScript v5spk = CScript() << OP_5 << std::vector<unsigned char>(kh.begin(), kh.end());
+    m2.vout.back().nValue -= 10000;
+    m2.vout.push_back(CTxOut(10000, v5spk));
+    SignV1(m2, 1, coinbaseSpk, coinbaseTxns[1].vout[0].nValue, coinbaseKey, coinbasePk);
+    SignAuthority(m2, 0, BTCSOQ_OP_MINT);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-txns-dual-authority-marker");
+}
+
+BOOST_AUTO_TEST_CASE(btcsoq_witness_tag_must_match_the_signed_op_tag)
+{
+    CMutableTransaction m1 = BuildMint(coinbaseTxns[0], AUTHSIG_DEPOSIT_A, 0, coinbasePk);
+    const uint256 m1Hash = CTransaction(m1).GetHash();
+    CBlock b1 = CreateAndProcessBlock({m1}, coinbaseSpk);
+    BOOST_REQUIRE(chainActive.Tip()->GetBlockHash() == b1.GetHash());
+    COutPoint marker(m1Hash, 0);
+
+    CMutableTransaction m2 =
+        BuildMint(coinbaseTxns[1], AUTHSIG_DEPOSIT_B, 1, coinbasePk, &marker);
+
+    // The signed OP_RETURN still says MINT. Only the unsigned witness tag moves,
+    // which is the whole reason the equality check exists: the witness is not
+    // sighash-covered and is malleable in flight.
+    m2.vin[0].scriptWitness.stack[2] = std::vector<unsigned char>{BTCSOQ_OP_FREEZE};
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-btcsoq-tag-mismatch");
+}
+
+BOOST_AUTO_TEST_CASE(btcsoq_authority_tx_without_an_op_envelope_is_rejected)
+{
+    CMutableTransaction m1 = BuildMint(coinbaseTxns[0], AUTHSIG_DEPOSIT_A, 0, coinbasePk);
+    const uint256 m1Hash = CTransaction(m1).GetHash();
+    CBlock b1 = CreateAndProcessBlock({m1}, coinbaseSpk);
+    BOOST_REQUIRE(chainActive.Tip()->GetBlockHash() == b1.GetHash());
+    COutPoint marker(m1Hash, 0);
+
+    CMutableTransaction m2 =
+        BuildMint(coinbaseTxns[1], AUTHSIG_DEPOSIT_B, 1, coinbasePk, &marker);
+
+    // BuildMint lays out [0] marker, [1] v8 mint, [2] op envelope, [3] change.
+    BOOST_REQUIRE_EQUAL(m2.vout.size(), 4u);
+    m2.vout.erase(m2.vout.begin() + 2);
+    // Re-sign: removing an output changes the SIGHASH_ALL sighash, and an
+    // authority-sig rejection would then shadow the missing-op rule.
+    SignAuthority(m2, 0, BTCSOQ_OP_MINT);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({m2}), "bad-btcsoq-missing-op");
+}
+
+// Asset flows must match the signed op: v8 outputs may only be created under
+// MINT. Here a FREEZE-tagged authority tx carries a v8 output.
+BOOST_AUTO_TEST_CASE(btcsoq_v8_output_under_a_non_mint_op_is_rejected)
+{
+    CMutableTransaction m1 = BuildMint(coinbaseTxns[0], AUTHSIG_DEPOSIT_A, 0, coinbasePk);
+    const uint256 m1Hash = CTransaction(m1).GetHash();
+    CBlock b1 = CreateAndProcessBlock({m1}, coinbaseSpk);
+    BOOST_REQUIRE(chainActive.Tip()->GetBlockHash() == b1.GetHash());
+    COutPoint marker(m1Hash, 0);
+    COutPoint v8op(m1Hash, 1);
+
+    CMutableTransaction fz = BuildFreeze(coinbaseTxns[1], FREEZE_OP_FREEZE, v8op, &marker);
+    // Splice a v8 output into an otherwise valid FREEZE, funded out of the
+    // change, then re-sign so the rejection is the op binding and not the sig.
+    BOOST_REQUIRE_EQUAL(fz.vout.size(), 3u);
+    fz.vout.back().nValue -= MINT_SATS;
+    fz.vout.push_back(CTxOut(MINT_SATS, MakeV8Spk(coinbasePk)));
+    SignV1(fz, 1, coinbaseSpk, coinbaseTxns[1].vout[0].nValue, coinbaseKey, coinbasePk);
+    SignAuthority(fz, 0, BTCSOQ_OP_FREEZE);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({fz}), "bad-btcsoq-unbound-mint");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/usdsoq_supply_and_bootstrap_reject_path_tests.cpp
+++ b/src/test/usdsoq_supply_and_bootstrap_reject_path_tests.cpp
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Soqucoin Labs Inc.
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+//
+// usdsoq_supply_and_bootstrap_reject_path_tests.cpp — the two remaining USDSOQ
+// reject strings from bead reject-string-coverage-gap-244e that do not wait on
+// another bead:
+//
+//   bad-usdsoq-supply-overflow      the supply guard in ConnectBlock's mint path
+//   bad-usdsoq-bootstrap-reentry     the H2 re-entry guard in ConnectBlock's
+//                                    USDSOQ bootstrap branch
+//
+// Rules are named by symbol, not by file and line: a line number in a test
+// comment is checked by nothing and drifts on the next edit to validation.cpp.
+// The exact lines against this branch's base commit are in the PR body.
+//
+// Both are the USDSOQ twins of rules covered on the BTCSOQ side in
+// btcsoq_lifecycle_harness_tests.cpp, and the reachability answer is the same:
+// neither is attacker-reachable.
+//
+//   supply-overflow — CUSDSOQSupply::Mint fails only when total_minted leaves
+//     MoneyRange. Reaching that needs mints summing to a large fraction of
+//     MAX_MONEY, every one of them signed by the authority, so the guard is
+//     against an authority or accounting error and not against an outsider.
+//     Reached here by preloading the counter.
+//
+//   bootstrap-reentry — needs LevelDB to hold an authority outpoint while the
+//     in-memory global is null. No block produces that state; a partial reindex
+//     or a corrupted datadir does, which is exactly what the rule says ("Run
+//     -reindex to repair"). Reached here by nulling the global and leaving the
+//     database alone.
+//
+// So these are invariant guards against a damaged local state, not consensus
+// surface an attacker can drive, and the correct shape is to inject the state
+// and prove the guard still fires. Recorded so a later reader does not re-file
+// them as missing attack tests. Each case carries a presence control, because a
+// reject asserted against an empty database or an untouched counter would prove
+// nothing.
+
+#include "chainparams.h"
+#include "consensus/usdsoq.h"
+#include "consensus/validation.h"
+#include "test/dilithium_chain_setup.h"
+#include "txdb.h"
+#include "validation.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+//! Above the UTXO-cost floor, same value the BTCSOQ harness uses.
+static const CAmount V7_MINT = 1000000;
+
+} // namespace
+
+struct UsdsoqSupplyBootstrapSetup : public DilithiumChainSetup {
+    UsdsoqTestAuthority auth;
+
+    //! A BOOTSTRAP authority transaction: input 0 is a mature coinbase that
+    //! carries the authority witness, and the transaction creates the v5 marker
+    //! that starts the chain of custody. With `mintV7` it also mints a v7
+    //! output ex nihilo, which is what puts a delta into the supply counter —
+    //! the marker-only form leaves the counter untouched and cannot reach the
+    //! overflow rule at all.
+    CMutableTransaction BuildBootstrap(const CTransaction& feeCoinbase, CAmount mintV7)
+    {
+        const CAmount feeVal = feeCoinbase.vout[0].nValue;
+        CMutableTransaction tx;
+        tx.nVersion = 2;
+
+        CTxIn in;
+        in.prevout = COutPoint(feeCoinbase.GetHash(), 0);
+        in.nSequence = CTxIn::SEQUENCE_FINAL;
+        tx.vin.push_back(in);
+
+        CTxOut mark; mark.nValue = 100000; mark.scriptPubKey = auth.MarkerSpk();
+        tx.vout.push_back(mark);
+        if (mintV7 > 0) {
+            CTxOut v7; v7.nValue = mintV7; v7.scriptPubKey = Spk(OP_7);
+            tx.vout.push_back(v7);
+        }
+        CTxOut chg; chg.nValue = feeVal - 110000; chg.scriptPubKey = Spk(OP_1);
+        tx.vout.push_back(chg);
+
+        // No per-input signature: input 0 is the authority input, and
+        // auth.Sign rebuilds its whole witness stack, so a v1 signature written
+        // here would be discarded. The input is not script-verified either --
+        // the v5 marker output plus the authority stack shape takes the
+        // CheckInputs authority skip.
+        auth.Sign(tx, 0, auth.MarkerSpk());
+        return tx;
+    }
+};
+
+BOOST_FIXTURE_TEST_SUITE(usdsoq_supply_and_bootstrap_reject_path_tests,
+                         UsdsoqSupplyBootstrapSetup)
+
+// PRESENCE CONTROL for both cases below. An authority bootstrap that mints v7
+// must connect on an untouched counter, otherwise the two rejects could be
+// coming from something wrong with the transaction rather than from the guard
+// under test.
+BOOST_AUTO_TEST_CASE(an_authority_bootstrap_that_mints_v7_is_accepted)
+{
+    CMutableTransaction boot = BuildBootstrap(coinbaseTxns[0], V7_MINT);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({boot}), "");
+}
+
+BOOST_AUTO_TEST_CASE(usdsoq_supply_overflow_guard_fires_with_the_counter_at_the_ceiling)
+{
+    {
+        LOCK(cs_main);
+        BOOST_REQUIRE_EQUAL(g_usdsoq_supply.TotalMinted(), 0);
+        BOOST_REQUIRE(g_usdsoq_supply.Mint(MAX_MONEY - 1));
+        BOOST_REQUIRE_EQUAL(g_usdsoq_supply.TotalMinted(), MAX_MONEY - 1);
+    }
+
+    CMutableTransaction boot = BuildBootstrap(coinbaseTxns[0], V7_MINT);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({boot}), "bad-usdsoq-supply-overflow");
+}
+
+BOOST_AUTO_TEST_CASE(usdsoq_bootstrap_reentry_is_rejected_while_the_database_holds_an_outpoint)
+{
+    CMutableTransaction boot = BuildBootstrap(coinbaseTxns[0], 0);
+    CBlock b = CreateAndProcessBlock({boot}, coinbaseSpk);
+    BOOST_REQUIRE(chainActive.Tip()->GetBlockHash() == b.GetHash());
+
+    {
+        LOCK(cs_main);
+        // Presence control: this proves the accepted bootstrap really did
+        // persist an outpoint, so the reject below cannot come from an empty
+        // database taking the same branch for a different reason.
+        COutPoint persisted;
+        BOOST_REQUIRE(pcoinsdbview->ReadUSDSOQAuthorityOutpoint(persisted));
+        BOOST_REQUIRE(!persisted.IsNull());
+
+        // The damaged state the H2 guard exists for.
+        g_usdsoq_authority_outpoint.SetNull();
+    }
+
+    CMutableTransaction boot2 = BuildBootstrap(coinbaseTxns[1], 0);
+
+    BOOST_CHECK_EQUAL(RejectReasonFor({boot2}), "bad-usdsoq-bootstrap-reentry");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/usdsoq_supply_and_bootstrap_reject_path_tests.cpp
+++ b/src/test/usdsoq_supply_and_bootstrap_reject_path_tests.cpp
@@ -7,8 +7,8 @@
 // another bead:
 //
 //   bad-usdsoq-supply-overflow      the supply guard in ConnectBlock's mint path
-//   bad-usdsoq-bootstrap-reentry     the H2 re-entry guard in ConnectBlock's
-//                                    USDSOQ bootstrap branch
+//   bad-usdsoq-bootstrap-reentry    the H2 re-entry guard in ConnectBlock's
+//                                   USDSOQ bootstrap branch
 //
 // Rules are named by symbol, not by file and line: a line number in a test
 // comment is checked by nothing and drifts on the next edit to validation.cpp.


### PR DESCRIPTION
Closed without merging. Replaced by #94, which carries the same test additions with the comments and commit messages rewritten.