### PR TITLE
doc: past-tense the gateway design records; LatticeFold+ deprecated; based on Dogecoin Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ cp config.example.json config.json && nano config.json
 | **LaBRADOR Aggregator** | _(planned; no path yet)_ | ◻ Not started |
 | **PQ Wallet Library** | `src/wallet/pqwallet/` | ✅ In-tree |
 
-Note: Lattice-BP++ (SOQ-P002) and LatticeFold+ are deprecated and superseded by SoquObscura (SOQ-P010). Deprecated code will be removed in the next node release.
+Note: Lattice-BP++ (SOQ-P002) is superseded by SoquObscura (SOQ-P010). LatticeFold+ batch verification (`OP_CHECKFOLDPROOF`, witness v3) is deprecated. The opcode remains in the tree behind a deployment that does not activate on any network. It was reviewed in the April 2026 external extension audit. Its successor for confidential assets and succinct proofs is SoquObscura, a lattice-based confidential-asset system in research, whose deployment is not scheduled on any network and which is subject to the second external audit phase before any activation.
 
 > ⛔ **Status note, so this table is not read as a claim of what exists.** Rows marked
 > ◻ have **no code in this tree**. Earlier revisions of this table cited concrete paths

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@
 
 ## Reporting a Vulnerability
 
-Soqucoin Core is a post-quantum cryptocurrency with native Dilithium batching and recursive LatticeFold+ verification. Security is therefore non-negotiable.
+Soqucoin Core is a post-quantum cryptocurrency with native Dilithium (ML-DSA-44) signatures and PAT batch attestation. LatticeFold+ batch verification is deprecated and its deployment does not activate on any network. Security is therefore non-negotiable.
 
 To report a security vulnerability, please send a PGP-encrypted email to:
 

--- a/doc/DEPLOYMENT_PRECONDITIONS.md
+++ b/doc/DEPLOYMENT_PRECONDITIONS.md
@@ -160,7 +160,11 @@ carries the launch risk the others defer.**
 ## Withdrawn — not to be activated
 
 ### `DEPLOYMENT_LATTICEFOLD` (bit 28) — `nStartTime=0 / nTimeout=0`
-Terminal `THRESHOLD_FAILED`. `OP_CHECKFOLDPROOF` and witness v3.
+Terminal `THRESHOLD_FAILED`. `OP_CHECKFOLDPROOF` and witness v3. Deprecated: the
+opcode remains in the tree behind a deployment that does not activate on any
+network. Its successor for confidential assets and succinct proofs is SoquObscura
+(`DEPLOYMENT_SOQUOBSCURA`, `NOT_SCHEDULED` on every network, subject to the second
+external audit phase before any activation).
 
 Withdrawn from launch consensus because the verifier reads its statement fields
 from the untrusted proof blob and every algebraic check is homogeneous in the

--- a/doc/FOR_AI_REVIEWERS.md
+++ b/doc/FOR_AI_REVIEWERS.md
@@ -73,7 +73,7 @@ Verified against src/chainparams.cpp (mainnet parameters begin at line 133).
 |---|---|---|---|
 | CSV, SegWit | CSV, SEGWIT | ALWAYS_ACTIVE | chainparams.cpp:222-228 |
 | PAT aggregation (witness v2) | CHECKPATAGG | ALWAYS_ACTIVE | chainparams.cpp:231-233 |
-| LatticeFold (witness v3) | LATTICEFOLD | retired, can never activate | chainparams.cpp:261-263 |
+| LatticeFold (witness v3) | LATTICEFOLD | deprecated; nStartTime 0, nTimeout 0, does not activate on any network | chainparams.cpp:286-287 |
 | SoquObscura (witness v4/v10) | SOQUOBSCURA | NOT_SCHEDULED on all four networks | chainparams.cpp:352, 644, 894, 1205 |
 | USDSOQ (witness v5/v7/v10) | USDSOQ | NOT_SCHEDULED | chainparams.cpp:353 |
 | BTCSOQ (witness v8/v9) | BTCSOQ | NOT_SCHEDULED | chainparams.cpp:354 |

--- a/doc/FOR_AI_REVIEWERS.md
+++ b/doc/FOR_AI_REVIEWERS.md
@@ -142,10 +142,11 @@ words because a reviewer will otherwise state it less charitably.
 Current state by network: mainnet, testnet, and regtest ship EMPTY
 authority keysets, and validation default-denies every authority-shaped
 transaction when the keyset is uninitialized. Combined with NOT_SCHEDULED
-deployment heights on mainnet, no one, including the project, can mint,
-burn, or freeze on mainnet at genesis. Stagenet carries 2-of-3 test
-keysets (chainparams.cpp:1218-1234) and is where asset flows have actually
-been exercised.
+deployment heights on mainnet, no authority keyset exists there and no
+party can mint, burn or freeze at genesis. The authority model exists for
+licensed issuers and custodians. The project is not an issuer and holds no
+reserves. Stagenet carries 2-of-3 test keysets (chainparams.cpp:1218-1234)
+and is where asset flows have actually been exercised.
 
 History a scanner will find and should read in context: stagenet enforced
 authority signatures from height 7700 onward

--- a/doc/GOVERNANCE.md
+++ b/doc/GOVERNANCE.md
@@ -157,8 +157,10 @@ Like Dogecoin, Soqucoin uses **perpetual tail emission** (no supply cap) to:
 | Dilithium Signatures | ✅ ACTIVE | Genesis |
 | SegWit | ✅ ACTIVE | Always-active |
 | CSV (BIP68/112/113) | ✅ ACTIVE | Always-active |
-| PAT / LatticeFold+ | ✅ ACTIVE | Always-active |
-| Lattice-BP++, USDSOQ, CTV, APO, CSFS, P2WSH-Dilithium, UTXO Cost, Dilithium Keyhash, V6 Control Flow | 🟡 DORMANT on mainnet | Flag-day height, set after audit clearance (active on test networks) |
+| PAT | ✅ ACTIVE | Always-active |
+| LatticeFold+ (`OP_CHECKFOLDPROOF`, witness v3) | ⛔ DEPRECATED | Deployment does not activate on any network; successor SoquObscura |
+| SoquObscura (supersedes Lattice-BP++) | ◻ RESEARCH | `NOT_SCHEDULED` on every network; subject to the second external audit phase before any activation |
+| USDSOQ, CTV, APO, CSFS, P2WSH-Dilithium, UTXO Cost, Dilithium Keyhash, V6 Control Flow | 🟡 DORMANT on mainnet | Flag-day height, set after audit clearance (active on test networks) |
 
 ---
 

--- a/doc/PAT_BLOCK_ATTESTATION.md
+++ b/doc/PAT_BLOCK_ATTESTATION.md
@@ -250,7 +250,8 @@ validator, which accepts the first matching output and stops
 (`validation.cpp:5401`); that behaviour depends on coinbase output order and
 permits a decoy ahead of the intended commitment. The same observation applies
 to LatticeFold itself and is recorded for a separate review; LatticeFold is
-withdrawn, so it is not urgent.
+deprecated and its deployment does not activate on any network, so it is not
+urgent.
 
 A 2-byte magic is a weak tag: any 36-byte `OP_RETURN` beginning with the same
 four bytes parses as a commitment. The coinbase is miner-controlled, so a

--- a/doc/bridge/BRIDGE_ARCHITECTURE.md
+++ b/doc/bridge/BRIDGE_ARCHITECTURE.md
@@ -8,8 +8,7 @@
 > redemption, of backing, or of a timeline; the specific dates and backing tables below
 > predate the current review and will be revised.
 
-> **Status:** Shipped to Devnet/Stagenet  
-> **Target Activation:** Q3 2026 (after block 100,000 / 5B SOQ mined)  
+> **Status:** Design record. Demonstrated on devnet and stagenet in 2026; not deployed.  
 > **Last Updated:** June 15, 2026  
 > **Audit Requirement:** Halborn Phase 2 Audit in progress  
 
@@ -17,9 +16,9 @@
 
 ## Overview
 
-This document specifies the gateway architecture for converting between pSOQ (Solana SPL token) and native SOQ. We are publishing this to document the technical design and trust model of the SOQ-TEC cross-chain gateway.
+This document records the gateway design, as of June 2026, for moving between pSOQ (Solana SPL token) and native SOQ. It was published to document the technical design and trust model of the SOQ-TEC cross-chain gateway. The design was not deployed.
 
-**Bottom line up front:** The gateway uses a standard lock-and-mint / burn-and-release pattern. It is built for cryptographic longevity in a post-quantum environment, utilizing Dilithium attestations and XMSS-Lite revolving vault custody.
+**Bottom line up front:** The design used a standard lock-and-mint / burn-and-release pattern. It was built for cryptographic longevity in a post-quantum environment, utilizing Dilithium attestations and XMSS-Lite revolving vault custody.
 
 ---
 
@@ -83,7 +82,7 @@ This component resides on Solana. The trade-off is explicit: pSOQ holders use So
 - Fail to release locked SOQ (liveness failure)
 - Censor specific redemption requests
 
-We mitigate this through multi-signature threshold requirements and active monitoring.
+The design mitigated this through multi-signature threshold requirements and monitoring.
 
 ---
 
@@ -104,7 +103,7 @@ We mitigate this through multi-signature threshold requirements and active monit
 | Solana gas fee signatures | Ed25519 (vulnerable to Shor's algorithm) |
 | Relayer uptime | Dependent on relayer committee stability |
 
-**For miners considering pSOQ:** If your threat model includes quantum adversaries on the Solana network, pSOQ is not the right vehicle. It is a liquidity gateway, not a long-term store of value. Mine native SOQ post-mainnet for actual PQ protection.
+**For miners considering pSOQ:** If your threat model includes quantum adversaries on the Solana network, pSOQ is not the right vehicle. The design treated it as a liquidity path and never as a long-term store of value. Mine native SOQ post-mainnet for actual PQ protection.
 
 ---
 
@@ -112,18 +111,18 @@ We mitigate this through multi-signature threshold requirements and active monit
 
 ### Peg Maintenance
 
-The 1:1 redemption rate is what holds the two prices together:
-- If pSOQ trades below SOQ: holders can redeem pSOQ for SOQ at 1:1, reducing pSOQ supply until prices converge.
-- If pSOQ trades above SOQ: holders can lock SOQ for pSOQ at 1:1, increasing pSOQ supply until prices converge.
+The design relied on a 1:1 redemption rate to hold the two prices together:
+- If pSOQ traded below SOQ, holders could redeem pSOQ for SOQ at 1:1, reducing pSOQ supply until prices converged.
+- If pSOQ traded above SOQ, holders could lock SOQ for pSOQ at 1:1, increasing pSOQ supply until prices converged.
 
-This assumes:
-1. Gateway is operational
-2. Liquidity exists on both sides
-3. Transaction costs do not exceed the spread
+This assumed:
+1. An operating gateway
+2. Liquidity on both sides
+3. Transaction costs below the spread
 
 ### Backing Model
 
-The gateway is designed for full 1:1 backing. Foundation mining rewards fund reserve pools post-Phase-2 audit to ensure senior priority redemption for the public float.
+The design called for full 1:1 backing, with reserve pools funded from Foundation mining rewards after the Phase 2 audit and senior redemption priority for the public float. No reserve pool was funded and the design was not deployed.
 
 ---
 
@@ -135,7 +134,7 @@ The gateway is designed for full 1:1 backing. Foundation mining rewards fund res
 | Development | Q2 2026 ✅ | Custom Dilithium relayer, XMSS Vault |
 | Audit | Q2-Q3 2026 | Halborn Phase 2 audit (in progress) |
 | Testnet | Q2-Q3 2026 | Integration testing on devnet and stagenet |
-| Mainnet | Q3 2026 | Production gateway activation |
+| Mainnet | Planned for Q3 2026 at the time of writing | Not carried out; the design was not deployed |
 
 > [!NOTE]
 > **Gateway Design Choice**: The team pivoted from third-party oracle providers to a custom post-quantum relayer committee to ensure native signature compatibility and eliminate third-party oracle risks.
@@ -144,15 +143,15 @@ The gateway is designed for full 1:1 backing. Foundation mining rewards fund res
 
 ## Risk Disclosure
 
-### The Gateway May Never Activate
+### The Gateway Was Not Activated
 
-We are being explicit: **the 1:1 gateway activation is contingent on audit completion**. Reasons it might not activate:
+The design made activation contingent on audit completion. The reasons recorded at the time that it might not activate:
 
 1. **Audit findings:** Critical vulnerabilities that cannot be remediated
 2. **Regulatory uncertainty:** Legal advice indicating the gateway creates unacceptable risk
 3. **Technical blockers:** L1 script limitations or Solana runtime issues
 
-If the gateway does not activate, pSOQ remains an independent Solana token. This is a real risk that participants should price in.
+The design was not deployed. pSOQ is a token on Solana. The path from pSOQ to SOQ is in legal review and details will be published when it is complete.
 
 ### Relayer Compromise Scenarios
 
@@ -162,18 +161,18 @@ If the gateway does not activate, pSOQ remains an independent Solana token. This
 | Relayer keys compromised | Same as above | Key rotation, hardware security modules |
 | Relayer set goes offline | Gateway halts, no new mints or redeems | Fallback relayer set, emergency governance |
 
-We are designing for these threats, but no system is invulnerable. The gateway adds trust assumptions that native SOQ does not have.
+The design addressed these threats, but no system is invulnerable. A gateway adds trust assumptions that native SOQ does not have.
 
 ---
 
 ## For Miners: Practical Guidance
 
-If you are evaluating participation in Soqucoin, here is our honest recommendation:
+The recommendation recorded in June 2026 for anyone evaluating participation in Soqucoin:
 
 1. **pSOQ is for pre-mainnet exposure only.** It is a speculation vehicle, not the ultimate store of value.
 2. **Mining native SOQ post-mainnet gives you actual PQ protection.** That is the core thesis.
-3. **Do not over-allocate to pSOQ based on gateway assumptions.** Price in the possibility that it does not happen.
-4. **Watch for audit announcements.** We will publish results transparently.
+3. **Do not over-allocate to pSOQ based on gateway assumptions.** The design was not deployed.
+4. **Audit results are published when they are available.**
 
 ---
 

--- a/doc/bridge/SOLANA_BRIDGE_ARCHITECTURE.md
+++ b/doc/bridge/SOLANA_BRIDGE_ARCHITECTURE.md
@@ -8,7 +8,7 @@
 > redemption, of backing, or of a timeline; the specific dates and backing tables below
 > predate the current review and will be revised.
 
-> **Version**: 1.0 | **Status**: Shipped to Devnet/Stagenet
+> **Version**: 1.0 | **Status**: Design record. Demonstrated on devnet and stagenet in 2026; not deployed.
 > **Last Updated**: June 15, 2026
 > **Network**: Soqucoin ↔ Solana
 
@@ -21,17 +21,19 @@
 
 ## 1. Overview
 
-The Soqucoin-Solana Gateway enables bidirectional transfer of value between the Soqucoin mainnet and the Solana blockchain through a wrapped token mechanism.
+This document records the Soqucoin-Solana gateway design as of June 2026. The design described a bidirectional transfer of value between the Soqucoin mainnet and the Solana blockchain through a lock-and-mint / burn-and-release mechanism. The design was not deployed.
 
 | Component | Description |
 |-----------|-------------|
 | **SOQ** | Native Soqucoin token (L1, Dilithium signatures) |
-| **pSOQ** | Wrapped SOQ on Solana (SPL token inside XMSS vault) |
-| **Gateway** | Smart contract system managing lock/mint/burn/release |
+| **pSOQ** | SPL token on Solana; the design placed it inside an XMSS vault |
+| **Gateway** | Smart contract system that would manage lock/mint/burn/release |
 
 ---
 
 ## 2. Token Mechanics
+
+The flows below describe the design. They were not deployed.
 
 ### SOQ → pSOQ (Lock & Mint)
 
@@ -76,8 +78,8 @@ The Soqucoin-Solana Gateway enables bidirectional transfer of value between the 
 
 | Model | Description | Status |
 |-------|-------------|--------|
-| **1:1 Custody** | SOQ locked = pSOQ minted | ✅ Confirmed |
-| **Proof of Reserves** | Real-time on-chain dashboard | ✅ Active |
+| **1:1 Custody** | SOQ locked = pSOQ minted | Design; not deployed |
+| **Proof of Reserves** | On-chain dashboard | Design; not deployed |
 
 ---
 
@@ -128,7 +130,7 @@ The Soqucoin-Solana Gateway enables bidirectional transfer of value between the 
 | **Development** | Q2 2026 | Custom Dilithium relayer and XMSS Vault ✅ |
 | **Audit** | Q2-Q3 2026 | Halborn Phase 2 audit (in progress) |
 | **Testnet** | Q2-Q3 2026 | Integration testing on devnet and stagenet |
-| **Mainnet** | **Q3 2026** | Production gateway activation |
+| **Mainnet** | Planned for Q3 2026 at the time of writing | Not carried out; the design was not deployed |
 
 ---
 
@@ -149,17 +151,17 @@ The Soqucoin-Solana Gateway enables bidirectional transfer of value between the 
 
 ### The Core Economics
 
-pSOQ was launched on Pump.fun before Soqucoin mainnet was active. This creates a timing mismatch:
+pSOQ was launched on Solana before Soqucoin mainnet was active. This created a timing mismatch:
 
-| Asset | Supply | Current Backing |
+| Asset | Supply | Backing |
 |-------|--------|-----------------|
-| **pSOQ (Solana)** | 1 billion | ❌ Not backed (pre-gateway) |
+| **pSOQ (Solana)** | 1 billion | Not backed |
 | **SOQ (at block 100k)** | ~5 billion | N/A (native L1 token) |
 
-**"1:1" refers to the exchange rate, not supply parity:**
-- 1 SOQ locked in vault = 1 pSOQ redeemable
-- Gateway operates at 1:1 unit rate
-- Total pSOQ backing depends on SOQ locked in vault
+**In the design, "1:1" referred to the unit rate, not supply parity:**
+- 1 SOQ locked in the vault would back 1 pSOQ
+- The gateway would operate at a 1:1 unit rate
+- Total pSOQ backing would depend on SOQ locked in the vault
 
 ### pSOQ Distribution
 
@@ -170,12 +172,14 @@ pSOQ was launched on Pump.fun before Soqucoin mainnet was active. This creates a
 | **Foundation Total** | **~180M pSOQ** | **18%** | See subordination below |
 | **Public Float** | ~820M pSOQ | 82% | Trading on Solana DEXs |
 
-### Backing Model: Foundation Commitment + Open Market Redemption
+### Backing Model as Designed (June 2026): Foundation Subordination + Open Market Redemption
 
-#### Phase 1: Gateway Launch (Q3 2026)
+The model below was the design. No SOQ was locked and the design was not deployed.
+
+#### Phase 1: Gateway Launch
 
 ```
-Foundation commits: Lock 180M mined SOQ
+Foundation, per the design: lock 180M mined SOQ
 Vault balance: 180M SOQ
 pSOQ circulation: 1B
 Foundation pSOQ (subordinated): 180M
@@ -198,19 +202,19 @@ Month 6+: Approaching full backing
 ### Foundation Subordination Structure
 
 > [!NOTE]
-> The foundation's 180M pSOQ is subordinated to public holdings.
-> This means the team's pSOQ is redeemable only after public pSOQ is 100% backed.
+> The design subordinated the Foundation's 180M pSOQ to public holdings:
+> it would be redeemable only after public pSOQ was 100% backed.
 
-| Priority | Holder | Redemption Rights |
+| Priority | Holder | Redemption Rights (as designed) |
 |----------|--------|-------------------|
-| **Senior (1st)** | Public (820M pSOQ) | Can redeem immediately from vault |
-| **Junior (2nd)** | Foundation (180M pSOQ) | Can only redeem after vault ≥ 1B SOQ |
+| **Senior (1st)** | Public (820M pSOQ) | Would redeem first from the vault |
+| **Junior (2nd)** | Foundation (180M pSOQ) | Would redeem only after the vault held at least 1B SOQ |
 
-**Subordination Terms:**
-1. Foundation locks 180M mined SOQ at gateway launch.
-2. Foundation pSOQ redeems LAST, after all public pSOQ is 100% backed.
-3. Foundation cannot front-run public redemptions.
-4. Subordination is enforced by smart contract logic.
+**Subordination Terms (as designed):**
+1. The Foundation would lock 180M mined SOQ at gateway launch.
+2. Foundation pSOQ would redeem last, after all public pSOQ was 100% backed.
+3. The Foundation could not front-run public redemptions.
+4. Subordination would be enforced by smart contract logic.
 
 ### Illustrative Convergence Scenarios
 
@@ -221,9 +225,9 @@ Month 6+: Approaching full backing
 | Month 3 | ~580M SOQ | 70% | 0.65 - 0.85 |
 | Month 6+ | ~800M+ SOQ | 97%+ | 0.90 - 1.00 |
 
-*Illustrative only — not a projection or promise. Actual convergence depends on SOQ liquidity and independent market participation.*
+*Illustrative figures from the June 2026 design. Not a projection or promise; the design was not deployed.*
 
-### Why This Model Works
+### Why This Model Was Chosen
 
 | Stakeholder | Benefit |
 |-------------|---------|
@@ -232,13 +236,13 @@ Month 6+: Approaching full backing
 | **Community** | Founders cannot dump before the gateway is stable |
 | **Regulators** | Clear subordination = transparent risk hierarchy |
 
-### Required Disclosures
+### Disclosures
 
-**Pre-Gateway (Now):**
-> pSOQ is a speculation vehicle representing aspirational access to Soqucoin. 
-> It is NOT currently backed. Gateway activation is planned for Q3 2026.
+**Current (September 2026):**
+> pSOQ is a token on Solana. It is not backed by SOQ. The path from pSOQ to SOQ is in
+> legal review and details will be published when it is complete.
 
-**At Gateway Launch:**
+**Drafted in the design for a gateway launch (not used):**
 > pSOQ Gateway Economics:
 > - Total pSOQ: 1 billion
 > - Foundation holdings: 180M (18%), subordinated
@@ -322,9 +326,9 @@ Phase 3: Foundation guarantee expires, fully decentralized
 >
 > **Acceptable if properly executed.**
 
-### Recommended Approach
+### Approach Recommended at the Time
 
-Based on expert analysis, the recommended path is:
+Based on the analysis above, the path recommended in June 2026 was:
 
 | Phase | Timeline | Model | Notes |
 |-------|----------|-------|-------|
@@ -339,6 +343,8 @@ sacrificing long-term credibility.
 ---
 
 ## 10. Gateway Decisions
+
+The decisions below were recorded in June 2026 for the design. None was carried into a deployment.
 
 ### Decision 1: Relayer Provider (Custom Dilithium Committee)
 
@@ -433,10 +439,10 @@ sacrificing long-term credibility.
 | **Reduced support** | Months 18-24 | No new incentives, full function |
 | **Sunset** | Month 24+ | Gateway open, no guaranteed support |
 
-**Post-Sunset:**
-- pSOQ remains redeemable indefinitely (vault stays)
-- Minimum 3 validators maintain operations
-- Monthly community updates in final 6 months
+**Post-Sunset (as designed):**
+- pSOQ would remain redeemable indefinitely (the vault would stay)
+- At least 3 validators would maintain operations
+- Monthly community updates in the final 6 months
 
 ---
 
@@ -458,5 +464,5 @@ sacrificing long-term credibility.
 ---
 
 *Last Updated: June 15, 2026*
-*Gateway decisions pending board approval post-mainnet*
+*Gateway decisions were recorded for board review; the design was not deployed*
 *Soqucoin Core Development Team*

--- a/doc/guides/EXCHANGE_INTEGRATION_GUIDE.md
+++ b/doc/guides/EXCHANGE_INTEGRATION_GUIDE.md
@@ -10,7 +10,7 @@
 
 This guide provides comprehensive instructions for integrating Soqucoin (SOQ) into cryptocurrency exchanges. 
 
-Soqucoin is a **codebase fork** (not a hard fork) of Dogecoin Core — it uses Dogecoin's well-tested foundation while replacing the cryptographic engine with post-quantum primitives and adding high-performance feature engineering upgrades. Soqucoin begins with its own Genesis Block (Block 0) with **no shared transaction history** and **no airdrop to Dogecoin holders**. It is an entirely new and independent blockchain featuring Dilithium (ML-DSA-44) signatures and AuxPoW merged mining compatibility with Litecoin/Dogecoin.
+Soqucoin is **based on Dogecoin Core**. It uses Dogecoin's well-tested foundation while replacing the cryptographic engine with post-quantum primitives and adding high-performance feature engineering upgrades. Soqucoin begins with its own Genesis Block (Block 0) with **no shared transaction history** and **no airdrop to Dogecoin holders**. It is an entirely new and independent blockchain featuring Dilithium (ML-DSA-44) signatures and AuxPoW merged mining compatibility with Litecoin/Dogecoin.
 
 ### Key Properties
 

--- a/doc/guides/FAQ.md
+++ b/doc/guides/FAQ.md
@@ -44,7 +44,7 @@ Soqucoin is **post-quantum resistant from day one**. It uses:
 - **Dilithium (ML-DSA-44)**: NIST FIPS 204 standardized signatures replacing ECDSA
 - **Bulletproofs++**: Optional confidential transaction amounts
 - **PAT**: Practical Aggregation Technique for efficient batch verification
-- **LatticeFold+**: Lattice-based recursive SNARKs (activates at height 100,000)
+- **LatticeFold+**: deprecated batch verification (`OP_CHECKFOLDPROOF`, witness v3); the deployment does not activate on any network. Its successor for confidential assets and succinct proofs is SoquObscura, in research and not scheduled on any network
 
 ## Mining Information ⛏
 

--- a/doc/specifications/CONSENSUS_COST_SPEC.md
+++ b/doc/specifications/CONSENSUS_COST_SPEC.md
@@ -1,5 +1,7 @@
 # Soqucoin Protocol Parameters & Consensus Cost Specification
 
+> Status (2026-09-11): LatticeFold+ batch verification (`OP_CHECKFOLDPROOF`, witness v3) is deprecated and its deployment does not activate on any network; the ALWAYS_ACTIVE references to it below are historical. Its successor for confidential assets and succinct proofs is SoquObscura, in research and not scheduled on any network.
+
 > **Version**: 4.1 | **Status**: Pre-Mainnet
 > **Last Updated**: July 2, 2026
 > **Specification Tag**: Mainnet Candidate v1.0.0-rc4

--- a/doc/specifications/PAT-Architecture.md
+++ b/doc/specifications/PAT-Architecture.md
@@ -1,5 +1,7 @@
 # PAT (Practical Aggregation Technique) Architecture
 
+> Status (2026-09-11): LatticeFold+ batch verification (`OP_CHECKFOLDPROOF`, witness v3) is deprecated and its deployment does not activate on any network; the Stage 2 and block 100,000 references below are historical. Its successor for confidential assets and succinct proofs is SoquObscura, in research and not scheduled on any network. PAT is unchanged and ships.
+
 > **Version**: 1.0
 > **Last Updated**: January 20, 2026
 > **Audience**: Security auditors, developers, researchers

--- a/doc/specifications/STAGE_3_LATTICE_BP_ARCHITECTURE.md
+++ b/doc/specifications/STAGE_3_LATTICE_BP_ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # Soqucoin Lattice-BP++ Privacy Architecture
 
+> Status (2026-09-11): historical document. Lattice-BP++ is superseded by SoquObscura, a lattice-based confidential-asset system in research whose deployment is not scheduled on any network and which is subject to the second external audit phase before any activation. LatticeFold+ batch verification (`OP_CHECKFOLDPROOF`, witness v3) is deprecated and its deployment does not activate on any network; the ALWAYS_ACTIVE references below are historical.
+
 > **Version**: 2.0 | **Status**: Implementation Complete, Audit Pending
 > **Author**: Soqucoin Foundation R&D
 > **Updated**: April 27, 2026

--- a/doc/specifications/STAGE_5_L2_SPECIFICATION.md
+++ b/doc/specifications/STAGE_5_L2_SPECIFICATION.md
@@ -1,5 +1,7 @@
 # Stage 5: L2SOQ — Quantum-Safe Payment Channel Network
 
+> Status (2026-09-11): LatticeFold+ batch verification (`OP_CHECKFOLDPROOF`, witness v3) is deprecated and its deployment does not activate on any network; the Stage 2 and ALWAYS_ACTIVE references to it below are historical and batch settlement is not a shipped feature. Its successor for succinct proofs is SoquObscura, in research and not scheduled on any network.
+
 > **Version**: 0.5 (ELTOO Architecture)
 > **Status**: PROTOTYPE — Single-Hop ELTOO Channels Functional on Stagenet
 > **Classification**: PUBLIC - Research Specification  

--- a/doc/v0_22-design-note.md
+++ b/doc/v0_22-design-note.md
@@ -1,5 +1,7 @@
 # Soqucoin v0.22 Design Note
 
+> Status (2026-09-11): historical draft. LatticeFold+ batch verification (`OP_CHECKFOLDPROOF`, witness v3) is deprecated and its deployment does not activate on any network; its successor for confidential assets and succinct proofs is SoquObscura, in research and not scheduled on any network. The activation plan below was not carried out.
+
 ## Full Confidential Amounts and LatticeFold+ Activation
 
 Status: **Draft**  

--- a/doc/wallet/WALLET_THREAT_MODEL.md
+++ b/doc/wallet/WALLET_THREAT_MODEL.md
@@ -72,7 +72,7 @@ This document defines the threat model for the Soqucoin post-quantum wallet (`li
 | Timeframe | CRQC Availability | Soqucoin Mitigation |
 |-----------|-------------------|---------------------|
 | 2026-2030 | Unlikely | Dilithium provides future-proofing |
-| 2030-2035 | Possible | Dilithium + LatticeFold provide ~128-bit PQ security |
+| 2030-2035 | Possible | Dilithium (ML-DSA-44) provides ~128-bit PQ security; LatticeFold+ is deprecated and not part of the security argument |
 | 2035+ | Probable | Migration path to stronger parameters if needed |
 
 **Design Decision**: Soqucoin uses NIST Level 2 (Dilithium2/ML-DSA-44) which provides 128-bit security against both classical and quantum adversaries per NIST SP 800-208.


### PR DESCRIPTION
Documentation only. No source, test or consensus change.

The two gateway design records under doc/bridge keep their 2026-08-28 historical banner and now read as past-tense descriptions of a design that was not deployed. The exchange integration guide describes the project as based on Dogecoin Core. The reviewer guide's authority paragraph states that the project is not an issuer and holds no reserves.

LatticeFold+ is marked deprecated across README, GOVERNANCE, DEPLOYMENT_PRECONDITIONS, FOR_AI_REVIEWERS, PAT_BLOCK_ATTESTATION, the FAQ, SECURITY.md and the wallet threat model, with SoquObscura named as its successor in research and not scheduled on any network. Basis: src/chainparams.cpp sets DEPLOYMENT_LATTICEFOLD nStartTime 0 and nTimeout 0 on every tier (mainnet 286 to 287, test tier 654 to 655 marked retired). Dated design notes receive a one-line status header and are otherwise left as historical record.
