### PR TITLE
chainparams: arm the genesis-migration constants in every height tier, and show the armed state

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -119,6 +119,7 @@ BITCOIN_TESTS =\
   test/pat_tests.cpp \
   test/pat_script_tests.cpp \
   test/merkle_tests.cpp \
+  test/migration_arming_tests.cpp \
   test/migration_rule_tests.cpp \
   test/miner_tests.cpp \
   test/net_tests.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -138,25 +138,30 @@ static CBlock CreateGenesisBlockStagenet(uint32_t nTime, uint32_t nNonce, uint32
  * UTXO set regardless; this choice is about what decoders display.
  */
 /**
- * Writes the genesis-migration allocation constants into every height tier of a
- * params set (bead chainparams-migration-arming-tier-footgun-ldbr).
+ * Writes the genesis-migration allocation constants into every height tier that
+ * GetConsensus can return (bead chainparams-migration-arming-tier-footgun-ldbr).
  *
- * GetConsensus(nHeight) walks a height-indexed tree: on mainnet every height >= 1
- * resolves to auxpowConsensus, never to `consensus`. ConnectBlock reads the
- * migration fields through GetConsensus(pindex->nHeight), so a value assigned to
- * `consensus` alone after the tier copies is invisible at the armed height and
- * the rule stays silently inert. Every arming path, regtest or ceremony, goes
- * through this function so the three tiers can never disagree.
+ * GetConsensus(nHeight) walks a height-indexed tree of Consensus::Params rooted
+ * at pConsensusRoot: on mainnet every height >= 1 resolves to auxpowConsensus,
+ * never to `consensus`; stagenet has a fourth tier, maturityMirrorConsensus,
+ * from height 100000. ConnectBlock, the miner, init and getblockchaininfo read
+ * the migration fields through GetConsensus, so a value assigned to one struct
+ * is invisible at every height another tier covers and the rule stays silently
+ * inert there. This walks the tree from the root through pLeft and pRight, so
+ * every reachable tier is written and a tier added later is covered without a
+ * change here. Reachable tiers today: mainnet and testnet 2 (consensus and
+ * auxpowConsensus; their digishieldConsensus is assigned but not linked),
+ * regtest 3, stagenet 4. Call it only after the tree is wired.
  */
-static void ArmMigrationTiers(Consensus::Params& base, Consensus::Params& digishield,
-                              Consensus::Params& auxpow, const uint256& hashOutputs,
+static void ArmMigrationTiers(Consensus::Params* tier, const uint256& hashOutputs,
                               CAmount nTotal, int nHeight)
 {
-    for (Consensus::Params* tier : {&base, &digishield, &auxpow}) {
-        tier->hashMigrationOutputs = hashOutputs;
-        tier->nMigrationTotal = nTotal;
-        tier->nMigrationHeight = nHeight;
-    }
+    if (tier == nullptr) return;
+    tier->hashMigrationOutputs = hashOutputs;
+    tier->nMigrationTotal = nTotal;
+    tier->nMigrationHeight = nHeight;
+    ArmMigrationTiers(tier->pLeft, hashOutputs, nTotal, nHeight);
+    ArmMigrationTiers(tier->pRight, hashOutputs, nTotal, nHeight);
 }
 
 static CBlock CreateGenesisBlockMainnet(uint32_t nTime, uint32_t nNonce, uint32_t nBits, int32_t nVersion, const CAmount& genesisReward)
@@ -588,11 +593,12 @@ public:
 
 private:
     /** The only permitted way to arm the migration rule on mainnet (bead ldbr).
-     *  Writes all three height tiers through ArmMigrationTiers and refuses, at
-     *  construction time, a vector that does not hash to the published constant or
-     *  sum to the published total: a node built with mismatched constants must not
-     *  start, because at H it would reject every honest block. Unused while the
-     *  rule is inert; the ceremony adds the single call documented above. */
+     *  Writes every reachable height tier through ArmMigrationTiers and refuses,
+     *  at construction time, a vector that does not hash to the published constant
+     *  or sum to the published total: a node built with mismatched constants must
+     *  not start, because at H it would reject every honest block. Unused while
+     *  the rule is inert; the ceremony adds the single call documented above,
+     *  which sits after the tier tree is wired. */
     void ArmMigration(const uint256& hashOutputs, CAmount nTotal, int nHeight,
                       const std::vector<CTxOut>& vOutputs)
     {
@@ -604,7 +610,7 @@ private:
         CAmount sum = 0;
         for (const CTxOut& out : vOutputs) sum += out.nValue;
         assert(sum == nTotal);
-        ArmMigrationTiers(consensus, digishieldConsensus, auxpowConsensus, hashOutputs, nTotal, nHeight);
+        ArmMigrationTiers(pConsensusRoot, hashOutputs, nTotal, nHeight);
         vMigrationOutputs = vOutputs;
     }
 };
@@ -1157,12 +1163,12 @@ public:
     void UpdateMigrationParams(const uint256& hashOutputs, CAmount nTotal, int nHeight,
                                const std::vector<CTxOut>& vOutputs)
     {
-        // ALL THREE structs, for the same height-indexed-tree reason as
+        // Every tier in the tree, for the same height-indexed-tree reason as
         // UpdateActivationHeight above (bead tofg): a migration height above 19
         // resolves to auxpowConsensus, not `consensus`. Shared with the mainnet
         // ceremony path (bead ldbr). Hash, total and height are taken as given so
         // tests can arm deliberately inconsistent values (tamper case 10).
-        ArmMigrationTiers(consensus, digishieldConsensus, auxpowConsensus, hashOutputs, nTotal, nHeight);
+        ArmMigrationTiers(pConsensusRoot, hashOutputs, nTotal, nHeight);
         vMigrationOutputs = vOutputs;
     }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -536,7 +536,7 @@ public:
         // Genesis-migration allocation constants (DL-GENESIS-MIGRATION-IMPLEMENTATION §A1).
         // Deliberately NOT set here: hashMigrationOutputs stays null, nMigrationTotal 0,
         // nMigrationHeight 0, so the rule is inert. If a migration window is ever run,
-        // the ceremony arms the rule at a scheduled post-genesis height with ONE call:
+        // the ceremony arms the rule, at height 1 in the launch release, with ONE call:
         //
         //     ArmMigration(uint256S("<hash_migration_outputs>"), <n_migration_total>, <H>,
         //                  { CTxOut(...), ... });   // the published outputs.hex, in order

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -543,8 +543,10 @@ public:
         //
         // Never assign consensus.hashMigrationOutputs here directly: the tier copies ran
         // above, so a value written to `consensus` alone never reaches auxpowConsensus,
-        // the tier that validates every height >= 1 (bead ldbr; the helper writes all
-        // three and asserts the vector against the constants). Struct defaults propagate
+        // the tier that validates every height >= 1 (bead ldbr; the helper walks the
+        // tier tree from pConsensusRoot, so on mainnet it writes `consensus` and
+        // auxpowConsensus, and ArmMigration asserts the vector against the constants).
+        // Struct defaults propagate
         // into digishieldConsensus and auxpowConsensus via the copies above, which is why
         // the inert state needs no call. Procedure: doc/GENESIS_CEREMONY.md.
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -6,6 +6,7 @@
 
 #include "chainparams.h"
 #include "consensus/merkle.h"
+#include "hash.h"
 
 #include "tinyformat.h"
 #include "utilstrencodings.h"
@@ -136,6 +137,28 @@ static CBlock CreateGenesisBlockStagenet(uint32_t nTime, uint32_t nNonce, uint32
  * data, so nothing-up-my-sleeve. The genesis coinbase is excluded from the
  * UTXO set regardless; this choice is about what decoders display.
  */
+/**
+ * Writes the genesis-migration allocation constants into every height tier of a
+ * params set (bead chainparams-migration-arming-tier-footgun-ldbr).
+ *
+ * GetConsensus(nHeight) walks a height-indexed tree: on mainnet every height >= 1
+ * resolves to auxpowConsensus, never to `consensus`. ConnectBlock reads the
+ * migration fields through GetConsensus(pindex->nHeight), so a value assigned to
+ * `consensus` alone after the tier copies is invisible at the armed height and
+ * the rule stays silently inert. Every arming path, regtest or ceremony, goes
+ * through this function so the three tiers can never disagree.
+ */
+static void ArmMigrationTiers(Consensus::Params& base, Consensus::Params& digishield,
+                              Consensus::Params& auxpow, const uint256& hashOutputs,
+                              CAmount nTotal, int nHeight)
+{
+    for (Consensus::Params* tier : {&base, &digishield, &auxpow}) {
+        tier->hashMigrationOutputs = hashOutputs;
+        tier->nMigrationTotal = nTotal;
+        tier->nMigrationHeight = nHeight;
+    }
+}
+
 static CBlock CreateGenesisBlockMainnet(uint32_t nTime, uint32_t nNonce, uint32_t nBits, int32_t nVersion, const CAmount& genesisReward)
 {
     const char* pszTimestamp = "The Block 26/Aug/2026 First quantum-resistant Bitcoin transaction mined BTC 965186 d3b0f490";
@@ -508,10 +531,17 @@ public:
         // Genesis-migration allocation constants (DL-GENESIS-MIGRATION-IMPLEMENTATION §A1).
         // Deliberately NOT set here: hashMigrationOutputs stays null, nMigrationTotal 0,
         // nMigrationHeight 0, so the rule is inert. If a migration window is ever run,
-        // the ceremony sets all three beside these genesis pins (with vMigrationOutputs
-        // compiled in and asserted against the hash) at a scheduled post-genesis height,
-        // per doc/GENESIS_CEREMONY.md. Struct defaults propagate into digishieldConsensus
-        // and auxpowConsensus via the copies above.
+        // the ceremony arms the rule at a scheduled post-genesis height with ONE call:
+        //
+        //     ArmMigration(uint256S("<hash_migration_outputs>"), <n_migration_total>, <H>,
+        //                  { CTxOut(...), ... });   // the published outputs.hex, in order
+        //
+        // Never assign consensus.hashMigrationOutputs here directly: the tier copies ran
+        // above, so a value written to `consensus` alone never reaches auxpowConsensus,
+        // the tier that validates every height >= 1 (bead ldbr; the helper writes all
+        // three and asserts the vector against the constants). Struct defaults propagate
+        // into digishieldConsensus and auxpowConsensus via the copies above, which is why
+        // the inert state needs no call. Procedure: doc/GENESIS_CEREMONY.md.
 
         // SOQ-H3: Lattice-BP++ consensus seed — derived from genesis hash
         consensus.latticeBPSeed = ComputeSoquObscuraSeed(
@@ -554,6 +584,28 @@ public:
             0,    // No transactions yet
             0.0   // No estimated tx rate yet
         };
+    }
+
+private:
+    /** The only permitted way to arm the migration rule on mainnet (bead ldbr).
+     *  Writes all three height tiers through ArmMigrationTiers and refuses, at
+     *  construction time, a vector that does not hash to the published constant or
+     *  sum to the published total: a node built with mismatched constants must not
+     *  start, because at H it would reject every honest block. Unused while the
+     *  rule is inert; the ceremony adds the single call documented above. */
+    void ArmMigration(const uint256& hashOutputs, CAmount nTotal, int nHeight,
+                      const std::vector<CTxOut>& vOutputs)
+    {
+        assert(nHeight > 0);
+        assert(!vOutputs.empty());
+        CHashWriter hasher(SER_GETHASH, PROTOCOL_VERSION);
+        hasher << vOutputs;
+        assert(hasher.GetHash() == hashOutputs);
+        CAmount sum = 0;
+        for (const CTxOut& out : vOutputs) sum += out.nValue;
+        assert(sum == nTotal);
+        ArmMigrationTiers(consensus, digishieldConsensus, auxpowConsensus, hashOutputs, nTotal, nHeight);
+        vMigrationOutputs = vOutputs;
     }
 };
 static CMainParams mainParams;
@@ -1105,18 +1157,12 @@ public:
     void UpdateMigrationParams(const uint256& hashOutputs, CAmount nTotal, int nHeight,
                                const std::vector<CTxOut>& vOutputs)
     {
-        // ⚠️ ALL THREE structs, for the same height-indexed-tree reason as
+        // ALL THREE structs, for the same height-indexed-tree reason as
         // UpdateActivationHeight above (bead tofg): a migration height above 19
-        // resolves to auxpowConsensus, not `consensus`.
-        consensus.hashMigrationOutputs = hashOutputs;
-        consensus.nMigrationTotal = nTotal;
-        consensus.nMigrationHeight = nHeight;
-        digishieldConsensus.hashMigrationOutputs = hashOutputs;
-        digishieldConsensus.nMigrationTotal = nTotal;
-        digishieldConsensus.nMigrationHeight = nHeight;
-        auxpowConsensus.hashMigrationOutputs = hashOutputs;
-        auxpowConsensus.nMigrationTotal = nTotal;
-        auxpowConsensus.nMigrationHeight = nHeight;
+        // resolves to auxpowConsensus, not `consensus`. Shared with the mainnet
+        // ceremony path (bead ldbr). Hash, total and height are taken as given so
+        // tests can arm deliberately inconsistent values (tamper case 10).
+        ArmMigrationTiers(consensus, digishieldConsensus, auxpowConsensus, hashOutputs, nTotal, nHeight);
         vMigrationOutputs = vOutputs;
     }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -546,9 +546,9 @@ public:
         // the tier that validates every height >= 1 (bead ldbr; the helper walks the
         // tier tree from pConsensusRoot, so on mainnet it writes `consensus` and
         // auxpowConsensus, and ArmMigration asserts the vector against the constants).
-        // Struct defaults propagate
-        // into digishieldConsensus and auxpowConsensus via the copies above, which is why
-        // the inert state needs no call. Procedure: doc/GENESIS_CEREMONY.md.
+        // Struct defaults propagate into digishieldConsensus and auxpowConsensus via
+        // the copies above, which is why the inert state needs no call.
+        // Procedure: doc/GENESIS_CEREMONY.md.
 
         // SOQ-H3: Lattice-BP++ consensus seed — derived from genesis hash
         consensus.latticeBPSeed = ComputeSoquObscuraSeed(

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1253,8 +1253,9 @@ bool AppInitParameterInteraction()
                   (int)nMigrationHeight, nMigrationTotal, (unsigned)vOutputs.size(), hashOutputs.ToString());
     }
     // On every network, say at startup which genesis-migration constants this
-    // binary enforces. Arming is a hard fork, so the line is what an operator
-    // greps for before the activation height (bead ldbr; also getblockchaininfo).
+    // binary enforces. A node whose constants differ from the network's rejects
+    // the armed block, so this line is what an operator checks before the node
+    // reaches that height (bead ldbr; also getblockchaininfo).
     {
         const int nArmedHeight = chainparams.GetConsensus(0).nMigrationHeight;
         const Consensus::Params& tier = chainparams.GetConsensus(nArmedHeight > 0 ? nArmedHeight : 0);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1252,6 +1252,20 @@ bool AppInitParameterInteraction()
         LogPrintf("Arming regtest genesis-migration rule: height=%d total=%d outputs=%u hash=%s\n",
                   (int)nMigrationHeight, nMigrationTotal, (unsigned)vOutputs.size(), hashOutputs.ToString());
     }
+    // On every network, say at startup which genesis-migration constants this
+    // binary enforces. Arming is a hard fork, so the line is what an operator
+    // greps for before the activation height (bead ldbr; also getblockchaininfo).
+    {
+        const int nArmedHeight = chainparams.GetConsensus(0).nMigrationHeight;
+        const Consensus::Params& tier = chainparams.GetConsensus(nArmedHeight > 0 ? nArmedHeight : 0);
+        if (nArmedHeight != 0 && !tier.hashMigrationOutputs.IsNull()) {
+            LogPrintf("Genesis-migration allocation rule ARMED: height=%d total=%d outputs=%u hash=%s\n",
+                      tier.nMigrationHeight, tier.nMigrationTotal,
+                      (unsigned)chainparams.MigrationOutputs().size(), tier.hashMigrationOutputs.ToString());
+        } else {
+            LogPrintf("Genesis-migration allocation rule inert (height 0, null hash)\n");
+        }
+    }
     return true;
 }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1181,7 +1181,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
             "     }\n"
             "  },\n"
             "  \"genesis_migration\": {      (object) the one-shot allocation rule this node enforces\n"
-            "     \"armed\": xx,              (boolean) false on every network until a coordinated release arms it\n"
+            "     \"armed\": xx,              (boolean) true when this node carries the constants: compiled into a release, or set on regtest by -migrationheight and -migrationoutputs\n"
             "     \"height\": xx,             (numeric) the one height the rule applies at (0 = inert)\n"
             "     \"hash_migration_outputs\": \"xxxx\",  (string) the committed output vector hash (all zero = inert)\n"
             "     \"total_sats\": xx          (numeric) the committed total in sats\n"
@@ -1240,9 +1240,10 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     obj.pushKV("softforks", softforks);
     obj.pushKV("bip9_softforks", bip9_softforks);
     // Genesis-migration allocation rule (DL-GENESIS-MIGRATION-IMPLEMENTATION §A1).
-    // Arming it is a hard fork, so operators need to see which constants a node
-    // enforces BEFORE the activation height. Read through the tier that validates
-    // the armed height, which is the struct ConnectBlock consults (bead ldbr).
+    // A node whose constants differ from the network's rejects the armed block, so
+    // operators need to see which constants a node enforces before it reaches that
+    // height. Read through the tier that validates the armed height, which is the
+    // struct ConnectBlock consults (bead ldbr).
     {
         const int nMigrationHeight = consensusParams.nMigrationHeight;
         const Consensus::Params& armedTier = Params().GetConsensus(nMigrationHeight > 0 ? nMigrationHeight : 0);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1179,6 +1179,12 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
             "        \"timeout\": xx,         (numeric) the median time past of a block at which the deployment is considered failed if not yet locked in\n"
             "        \"since\": xx            (numeric) height of the first block to which the status applies\n"
             "     }\n"
+            "  },\n"
+            "  \"genesis_migration\": {      (object) the one-shot allocation rule this node enforces\n"
+            "     \"armed\": xx,              (boolean) false on every network until a coordinated release arms it\n"
+            "     \"height\": xx,             (numeric) the one height the rule applies at (0 = inert)\n"
+            "     \"hash_migration_outputs\": \"xxxx\",  (string) the committed output vector hash (all zero = inert)\n"
+            "     \"total_sats\": xx          (numeric) the committed total in sats\n"
             "  }\n"
             "}\n"
             "\nExamples:\n" +
@@ -1233,6 +1239,20 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     BIP9SoftForkDescPushBack(bip9_softforks, "csfs", consensusParams, Consensus::DEPLOYMENT_CSFS);
     obj.pushKV("softforks", softforks);
     obj.pushKV("bip9_softforks", bip9_softforks);
+    // Genesis-migration allocation rule (DL-GENESIS-MIGRATION-IMPLEMENTATION §A1).
+    // Arming it is a hard fork, so operators need to see which constants a node
+    // enforces BEFORE the activation height. Read through the tier that validates
+    // the armed height, which is the struct ConnectBlock consults (bead ldbr).
+    {
+        const int nMigrationHeight = consensusParams.nMigrationHeight;
+        const Consensus::Params& armedTier = Params().GetConsensus(nMigrationHeight > 0 ? nMigrationHeight : 0);
+        UniValue migration(UniValue::VOBJ);
+        migration.pushKV("armed", nMigrationHeight != 0 && !armedTier.hashMigrationOutputs.IsNull());
+        migration.pushKV("height", armedTier.nMigrationHeight);
+        migration.pushKV("hash_migration_outputs", armedTier.hashMigrationOutputs.GetHex());
+        migration.pushKV("total_sats", armedTier.nMigrationTotal);
+        obj.pushKV("genesis_migration", migration);
+    }
     obj.pushKV("warnings", GetWarnings("statusbar"));
     return obj;
 }

--- a/src/test/migration_arming_tests.cpp
+++ b/src/test/migration_arming_tests.cpp
@@ -28,6 +28,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <set>
+
 namespace {
 
 // Heights that land on every tier boundary any network has: genesis, the
@@ -117,6 +119,30 @@ BOOST_AUTO_TEST_CASE(every_network_every_tier_agrees)
     for (const std::string& net : networks) {
         CheckTiersAgree(Params(net), net);
     }
+}
+
+// Presence control for the agreement check above: the sampled heights must
+// reach a distinct tier struct for every tier GetConsensus can return, or the
+// check would compare one struct with itself. The counts are the reachable
+// tiers per network that ArmMigrationTiers documents; stagenet's fourth tier
+// (the maturity mirror at 100000) is the one a fixed-arity helper missed.
+BOOST_AUTO_TEST_CASE(sampled_heights_reach_every_reachable_tier)
+{
+    const struct { const char* net; size_t tiers; } expected[] = {
+        {CBaseChainParams::MAIN.c_str(), 2},
+        {CBaseChainParams::TESTNET.c_str(), 2},
+        {CBaseChainParams::REGTEST.c_str(), 3},
+        {CBaseChainParams::STAGENET.c_str(), 4},
+    };
+    for (const auto& e : expected) {
+        const CChainParams& params = Params(e.net);
+        std::set<const Consensus::Params*> seen;
+        for (int h : kSampleHeights) seen.insert(&params.GetConsensus(h));
+        BOOST_CHECK_MESSAGE(seen.size() == e.tiers,
+            e.net << ": sampled heights reach " << seen.size() << " tier structs, expected " << e.tiers);
+    }
+    const CChainParams& stagenet = Params(CBaseChainParams::STAGENET);
+    BOOST_CHECK(&stagenet.GetConsensus(99999) != &stagenet.GetConsensus(100000));
 }
 
 // The shared arming path puts the constants where ConnectBlock reads them,

--- a/src/test/migration_arming_tests.cpp
+++ b/src/test/migration_arming_tests.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Soqucoin Labs Inc.
+// Distributed under the MIT software license.
+//
+// migration_arming_tests.cpp — where the genesis-migration constants land
+// (bead chainparams-migration-arming-tier-footgun-ldbr).
+//
+// ConnectBlock reads hashMigrationOutputs / nMigrationTotal / nMigrationHeight
+// through chainparams.GetConsensus(pindex->nHeight), which resolves every
+// height >= 1 to a tier struct that was COPIED from `consensus` before the
+// migration comment block in CMainParams. A constant written to `consensus`
+// alone after those copies never reaches the tier that validates the armed
+// height, and the rule stays silently inert. migration_rule_tests proves the
+// rule fires when the constants are in the right tier; this suite proves the
+// constants are in every tier, on every network, armed or not.
+//
+// The invariant is written so it holds today (everything null/0/0) AND on the
+// day a ceremony arms mainnet: every sampled tier agrees, and if armed, the
+// tier at the armed height carries the constants and the compiled-in vector
+// hashes and sums to them.
+
+#include "chainparams.h"
+#include "consensus/params.h"
+#include "hash.h"
+#include "primitives/transaction.h"
+#include "script/script.h"
+#include "uint256.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+// Heights that land on every tier boundary any network has: genesis, the
+// regtest digishield (10) and auxpow (20) boundaries, the mainnet merged tier
+// at 1, the stagenet maturity mirror at 100000, and the planning-order
+// activation height from the design log (about 40000).
+static const int kSampleHeights[] = {0, 1, 2, 9, 10, 11, 19, 20, 21, 100, 1000,
+                                     40000, 99999, 100000, 100001, 1000000};
+
+struct Armed {
+    uint256 hash;
+    CAmount total;
+    int height;
+    bool operator==(const Armed& o) const { return hash == o.hash && total == o.total && height == o.height; }
+};
+
+static Armed At(const CChainParams& params, int nHeight)
+{
+    const Consensus::Params& c = params.GetConsensus(nHeight);
+    return Armed{c.hashMigrationOutputs, c.nMigrationTotal, c.nMigrationHeight};
+}
+
+static CScript V1Spk(unsigned char seed)
+{
+    return CScript() << OP_1 << std::vector<unsigned char>(32, seed);
+}
+
+static uint256 HashOutputs(const std::vector<CTxOut>& vOutputs)
+{
+    CHashWriter hasher(SER_GETHASH, PROTOCOL_VERSION);
+    hasher << vOutputs;
+    return hasher.GetHash();
+}
+
+//! Arms regtest for one scope and ALWAYS disarms on exit (same discipline as
+//! migration_rule_tests: a leaked arming would poison every later suite).
+struct RegtestArming {
+    RegtestArming(const uint256& h, CAmount t, int height, const std::vector<CTxOut>& v)
+    {
+        UpdateRegtestMigrationParams(h, t, height, v);
+    }
+    ~RegtestArming() { UpdateRegtestMigrationParams(uint256(), 0, 0, std::vector<CTxOut>()); }
+};
+
+//! The standing invariant, checked on one network: all sampled tiers agree,
+//! and an armed set is self-consistent with the compiled-in vector.
+static void CheckTiersAgree(const CChainParams& params, const std::string& name)
+{
+    const Armed base = At(params, 0);
+    for (int h : kSampleHeights) {
+        const Armed tier = At(params, h);
+        BOOST_CHECK_MESSAGE(tier == base,
+            name << ": migration constants differ between height 0 and height " << h
+                 << " (a tier was missed when arming)");
+    }
+    if (base.height == 0) {
+        BOOST_CHECK_MESSAGE(base.hash.IsNull() && base.total == 0,
+            name << ": nMigrationHeight is 0 but the hash or total is set");
+        BOOST_CHECK_MESSAGE(params.MigrationOutputs().empty(),
+            name << ": inert constants but a committed vector is compiled in");
+        return;
+    }
+    // Armed: the tier that validates H must carry it, and the vector must match.
+    const Armed atH = At(params, base.height);
+    BOOST_CHECK_MESSAGE(atH == base, name << ": GetConsensus(H) does not carry the armed constants");
+    BOOST_CHECK_MESSAGE(!base.hash.IsNull(), name << ": armed height with a null hash");
+    BOOST_CHECK_MESSAGE(!params.MigrationOutputs().empty(), name << ": armed without a committed vector");
+    BOOST_CHECK_EQUAL(HashOutputs(params.MigrationOutputs()).ToString(), base.hash.ToString());
+    CAmount sum = 0;
+    for (const CTxOut& out : params.MigrationOutputs()) sum += out.nValue;
+    BOOST_CHECK_EQUAL(sum, base.total);
+}
+
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(migration_arming_tests, BasicTestingSetup)
+
+// Today's state, on every network: inert on every tier, no vector compiled in.
+// This is also the test that fails the day someone arms mainnet by assigning
+// to `consensus` alone.
+BOOST_AUTO_TEST_CASE(every_network_every_tier_agrees)
+{
+    // Built here, not at static-init time: the chain-name constants live in
+    // another translation unit and may not exist yet when this file's statics run.
+    const std::string networks[] = {CBaseChainParams::MAIN, CBaseChainParams::TESTNET,
+                                    CBaseChainParams::STAGENET, CBaseChainParams::REGTEST};
+    for (const std::string& net : networks) {
+        CheckTiersAgree(Params(net), net);
+    }
+}
+
+// The shared arming path puts the constants where ConnectBlock reads them,
+// for heights on both sides of every regtest tier boundary.
+BOOST_AUTO_TEST_CASE(armed_height_tier_carries_constants)
+{
+    std::vector<CTxOut> vOutputs;
+    vOutputs.push_back(CTxOut(10 * COIN, V1Spk(0xA1)));
+    vOutputs.push_back(CTxOut(20 * COIN, V1Spk(0xA2)));
+    const uint256 hash = HashOutputs(vOutputs);
+    const CChainParams& regtest = Params(CBaseChainParams::REGTEST);
+
+    for (int H : {1, 5, 10, 19, 20, 21, 100, 40000}) {
+        RegtestArming arming(hash, 30 * COIN, H, vOutputs);
+        const Consensus::Params& c = regtest.GetConsensus(H);
+        BOOST_CHECK_EQUAL(c.nMigrationHeight, H);
+        BOOST_CHECK_EQUAL(c.hashMigrationOutputs.ToString(), hash.ToString());
+        BOOST_CHECK_EQUAL(c.nMigrationTotal, 30 * COIN);
+        // The rule must be visible from every tier, not only the one at H.
+        CheckTiersAgree(regtest, "regtest armed at " + std::to_string(H));
+    }
+    // Disarmed again on scope exit: inert on every tier.
+    CheckTiersAgree(regtest, "regtest after disarm");
+    BOOST_CHECK(regtest.GetConsensus(40000).hashMigrationOutputs.IsNull());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## What

`ArmMigrationTiers` writes the genesis-migration constants into the three consensus tiers; the regtest setter and a new private `CMainParams::ArmMigration` both go through it. The mainnet method asserts at startup that the compiled-in allocation vector hashes to the constant and sums to the total. `getblockchaininfo` gains a `genesis_migration` object and `init` logs the arming state on every network, both read through the tier that validates the armed height. `migration_arming_tests` checks that every sampled tier agrees on every network and that the regtest arming path lands the constants at the armed height.

## Why

Before this change the constants could be set on one tier and read from another, and a node's arming state was not observable without reading its parameters. With the migration ruled block 1 or never, the arming release is this branch plus constants; the startup assertion, the RPC field and the log line are what an operator and the ceremony checklist use to confirm the state of a running node.

## What it does not change

No rule changes while the constants are null. The allocation vector is empty in this branch. No serialization, policy or P2P change.

## Evidence

- `migration_arming_tests`, `migration_rule_tests`, `consensus_digest_tests` green on the rebuilt daemon.
- `qa/rpc-tests/genesis-migration.py` passing.
- `getblockchaininfo.genesis_migration` and the startup line observed inert and armed on regtest.

## Release

The next release candidate is cut so that the block 1 constants can ride a constants-only release on top of it. Bead `soqucoin-build-migration-arming-hard-fork-ujij` records the finding; `ldbr` the regtest arming path.
